### PR TITLE
docs: string/binary parity batch 2 (Sparkless #100-#116)

### DIFF
--- a/docs/SPARKLESS_PARITY_STATUS.md
+++ b/docs/SPARKLESS_PARITY_STATUS.md
@@ -49,6 +49,10 @@ Datetime and cast/alias behaviour are implemented and covered by hand-written pa
 
 String and binary functions in this batch are implemented and covered by hand-written parity fixtures: ascii, base64/unbase64, concat_ws (string_concat), crc32 (string_crc32), hex, initcap, levenshtein (string_levenshtein), repeat, reverse, soundex, and related tests. Fixtures include `string_crc32`, `string_levenshtein`, `string_concat`, `string_upper_lower`, `string_left_right_replace`, `string_length_trim`, `string_substring_index`, `string_lpad_rpad`, `string_translate`, `string_xxhash64`, etc. When running Sparkless tests with robin backend, ensure the adapter uses these APIs.
 
+## String / binary parity batch 2 (Sparkless issues #100–#116)
+
+String and binary functions in this batch are implemented and covered by hand-written parity fixtures: string_length/length, like/rlike (with escape), lower/upper, lpad/rpad, regexp_extract, rtrim/trim, substring/substr, translate, substring_index, xxhash64. Fixtures include `string_length_trim`, `string_upper_lower`, `string_lpad_rpad`, `string_substring`, `string_substring_index`, `string_translate`, `string_xxhash64`, `like_escape_char`, `ilike_escape_char`, etc. When running Sparkless tests with robin backend, ensure the adapter uses these APIs.
+
 ## Failure reasons (converted fixtures)
 
 When a converted fixture fails, classify and document here:


### PR DESCRIPTION
Documents string/binary parity batch 2 in SPARKLESS_PARITY_STATUS.md.

Fixes #100.
Fixes #101.
Fixes #102.
Fixes #103.
Fixes #104.
Fixes #105.
Fixes #106.
Fixes #107.
Fixes #108.
Fixes #109.
Fixes #110.
Fixes #111.
Fixes #112.
Fixes #113.
Fixes #114.
Fixes #115.
Fixes #116.

Made with [Cursor](https://cursor.com)