### PR TITLE
fix(#195): Column/expression resolution in plan interpreter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **#195 – Column/expression resolution in plan interpreter** — `execute_plan` now resolves column names (case-insensitive) for `select`, `orderBy`, `drop`, `withColumnRenamed`, `groupBy`, and `join` so plans using column names that differ in case from the schema, or that reference computed columns by alias after a select-with-expressions step, work correctly. Select supports both a list of column name strings (resolved) and a list of `{name, expr}` objects (expressions resolved via `resolve_expr_column_names`). Aggregation columns in `groupBy`/`agg` are resolved. New test: `plan_column_resolution`.
+
 ### Planned
 
 - **Phase 26 – Publish crate**: Prepare and publish robin-sparkless to crates.io (and optionally PyPI via maturin). See [ROADMAP.md](docs/ROADMAP.md) for details.


### PR DESCRIPTION
## Summary
Resolves column/expression resolution in `execute_plan` so Sparkless tests that fail with "unable to find column …" (e.g. case mismatches, or references after computed columns) work when the plan uses the existing case-insensitive resolution.

Closes #195

## Changes
- **select**: Resolve column name strings via `resolve_column_name`. For `{name, expr}` payloads, resolve each expression with `resolve_expr_column_names` and alias with `name`.
- **orderBy**: Resolve each entry in `columns` with `resolve_column_name`.
- **drop**: Resolve each column name in the drop list, then `df.drop(refs)`.
- **withColumnRenamed**: Resolve `old` with `resolve_column_name` before renaming.
- **groupBy**: Resolve each `group_by` name; pass `&df` into `parse_aggs`.
- **join**: Resolve each `on` key with `resolve_column_name`.
- **parse_aggs**: For each agg with a `column` name, resolve with `df.resolve_column_name` and use that for `Column::new(resolved)`.

## Testing
- New test `plan_column_resolution`: schema `Id, Name, Value`, plan uses lowercase `id`, `name`, `value` in orderBy, select, and drop; asserts result has correct columns and dropped `Value`.
- `make check-full` (Rust + Python) passes.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core plan interpretation for several ops (select/orderBy/drop/groupBy/join), which can change query semantics and error behavior if resolution differs from prior behavior. Scope is contained to plan execution and is covered by a new regression test.
> 
> **Overview**
> Fixes `execute_plan` to **resolve column references against the current schema** (case-insensitive) for `select`, `orderBy`, `drop`, `withColumnRenamed`, `groupBy`/`agg`, and `join`.
> 
> `select` now supports either a list of column-name strings (resolved via `resolve_column_name`) or a list of `{name, expr}` items where expressions are first run through `resolve_expr_column_names` before aliasing.
> 
> Adds a regression test `plan_column_resolution` and documents the fix in `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 884de64f2592500f185627bcd91adb12d28124e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->