### PR TITLE
fix(#196): concat/concat_ws with literal separator or mixed literals in plan select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **#196 – concat/concat_ws with literal separator or mixed literals in plan select** — When the plan `select` payload contains a string that looks like `concat(...)` or `concat_ws(...)` (e.g. `concat(first_name, , last_name)` with empty literal between columns), the plan interpreter now parses it as an expression and evaluates it instead of resolving it as a column name. Supports literal separators and mixed column/literal args. `concat` in the expression layer now accepts a single argument (PySpark parity). New test: `plan_select_concat_string`.
 - **#195 – Column/expression resolution in plan interpreter** — `execute_plan` now resolves column names (case-insensitive) for `select`, `orderBy`, `drop`, `withColumnRenamed`, `groupBy`, and `join` so plans using column names that differ in case from the schema, or that reference computed columns by alias after a select-with-expressions step, work correctly. Select supports both a list of column name strings (resolved) and a list of `{name, expr}` objects (expressions resolved via `resolve_expr_column_names`). Aggregation columns in `groupBy`/`agg` are resolved. New test: `plan_column_resolution`.
 
 ### Planned


### PR DESCRIPTION
## Summary
When Sparkless sends a select list containing a string like `concat(first_name, , last_name)` (with literal separator or empty between columns), the plan interpreter previously tried to resolve it as a column name and failed with "not found". This PR parses such strings as expressions and evaluates them.

Closes #196

## Changes
- **plan/expr.rs**: `try_parse_concat_expr_from_string(s)` — parses `concat(...)` and `concat_ws(...)` from select-item strings; supports literal separators and mixed column/literal args (e.g. empty between commas → `lit("")`). `concat` in the expression layer now accepts a single argument (PySpark parity).
- **plan/mod.rs**: In the select branch (list of strings), when an item matches concat/concat_ws, parse to `Expr`, resolve with `resolve_expr_column_names`, and add as computed column; otherwise resolve as column name. Mixed lists use `select_exprs`.
- **Tests**: `plan_select_concat_string` — select with `["first_name", "last_name", "concat(first_name, , last_name)"]` yields a computed column `AliceSmith` / `BobJones`.
- **CHANGELOG**: #196 under Unreleased → Fixed.

## Testing
`make check-full` (Rust + Python) passes.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes select-plan interpretation to sometimes treat string items as parsed expressions instead of column names, which can affect query results/schema when inputs resemble `concat(...)`/`concat_ws(...)`. The new parser is string-based and may have edge cases around quoting/parentheses or ambiguous column names.
> 
> **Overview**
> Fixes issue **#196** by teaching plan `select` (when given a list of strings) to recognize `concat(...)` / `concat_ws(...)` *expression-like strings* and evaluate them as computed columns rather than resolving them as column names.
> 
> Adds a small string parser in `plan/expr.rs` (including support for empty/mixed literal args) and updates `concat` expression handling to allow a single argument; includes a new parity test `plan_select_concat_string` and a CHANGELOG entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17cc6f255867e59779d2eb6a0e02a1738e9a54c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->