### PR TITLE
fix(#199): add string-to-boolean cast support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **#199 – String-to-boolean cast (partial)** — `cast` and `try_cast` now support string-to-boolean via custom parsing ("true"/"false"/"1"/"0" case-insensitive). Polars does not support Utf8→Boolean natively. Fixes test_column_astype string-to-boolean failures.
 - **#198 – map(), array(), nested struct/row values** — `create_dataframe_from_rows` and `execute_plan` now support `array<>`, `struct<>`, and nested types. Python row values accept `dict` (struct/map) and `list` (array); `collect()` returns struct columns as Python dicts. New test: `test_create_dataframe_from_rows_struct_and_array`.
 - **Type stubs and lint** — Added `Column.try_cast` to robin_sparkless.pyi for mypy; addressed clippy warnings in session.rs (is_none_or, needless_borrow).
 - **#208 – String arithmetic tests adapted for robin-sparkless API** — `test_string_arithmetic_robin.py` now uses `with_column` (snake_case) instead of `withColumn`, explicit `cast`/`try_cast` for string-to-numeric coercion (robin requires explicit cast; invalid strings become null via `try_cast`), and `print_schema()` instead of `schema()` for result type assertions.

--- a/tests/python/test_robin_sparkless.py
+++ b/tests/python/test_robin_sparkless.py
@@ -2066,6 +2066,32 @@ def test__create_dataframe_from_rows_schema_pyspark_parity() -> None:
     assert result == EXPECTED_CREATE_DATAFRAME_FROM_ROWS_PARITY
 
 
+def test_cast_string_to_boolean() -> None:
+    """cast/try_cast string to boolean (fixes #199)."""
+    import robin_sparkless as rs
+
+    spark = rs.SparkSession.builder().app_name("test").get_or_create()
+    df = spark._create_dataframe_from_rows(
+        [
+            {"s": "true"},
+            {"s": "false"},
+            {"s": "1"},
+            {"s": "0"},
+            {"s": "TRUE"},
+            {"s": "invalid"},
+        ],
+        [("s", "string")],
+    )
+    result = df.with_column("b", rs.col("s").try_cast("boolean"))
+    rows = result.collect()
+    assert rows[0]["b"] is True
+    assert rows[1]["b"] is False
+    assert rows[2]["b"] is True
+    assert rows[3]["b"] is False
+    assert rows[4]["b"] is True
+    assert rows[5]["b"] is None
+
+
 def test_create_dataframe_from_rows_struct_and_array() -> None:
     """_create_dataframe_from_rows supports struct and array columns (#198)."""
     import robin_sparkless as rs


### PR DESCRIPTION
## Summary

Fixes part of [GitHub issue #199](https://github.com/eddiethedean/robin-sparkless/issues/199) — [Sparkless parity] Other expression or result parity.

## Changes

- **String-to-boolean cast**: Polars does not support direct Utf8→Boolean casting. Added custom `apply_string_to_boolean` in udfs.rs that parses "true"/"false"/"1"/"0" (case-insensitive).
- **cast()** and **try_cast()**: When target type is Boolean, use the custom parser instead of Polars native cast.
- **New test**: `test_cast_string_to_boolean` verifies try_cast with various string values.

## Affected Sparkless tests

Addresses these failures from the issue:
- `test_astype_string_to_boolean`
- `test_astype_zero_and_negative`
- `test_astype_boolean`

## Verification

- `make check-full` passes (182 Python tests, 38 skipped)
- New test `test_cast_string_to_boolean` passes

Made with [Cursor](https://cursor.com)