### PR TITLE
fix: create_dataframe_from_rows accept schema 'list' and 'array' (Fixes #256)

### DIFF
--- a/src/python/session.rs
+++ b/src/python/session.rs
@@ -112,8 +112,9 @@ impl PySparkSession {
     /// Args:
     ///     data: List of rows. Each row is a dict (keyed by column name) or a list of
     ///         values in the same order as ``schema``. Supported value types: None, int,
-    ///         float, bool, str.
+    ///         float, bool, str, dict (struct), list (array).
     ///     schema: List of (name, dtype_str), e.g. [("id", "bigint"), ("name", "string")].
+    ///         Column types may include "list" or "array" for list columns (element type bigint; PySpark parity #256).
     ///
     /// Returns:
     ///     DataFrame (lazy).

--- a/tests/python/test_issue_256_create_dataframe_array_column.py
+++ b/tests/python/test_issue_256_create_dataframe_array_column.py
@@ -1,0 +1,61 @@
+"""
+Tests for issue #256: create_dataframe_from_rows accepts schema ("col", "list") and ("col", "array").
+
+PySpark accepts DataFrame creation with list/array column data, e.g.:
+  spark.createDataFrame([{"name": "a", "vals": [1,2,3]}])
+Robin's create_dataframe_from_rows now accepts schema dtype "list" or "array" for parity.
+"""
+
+from __future__ import annotations
+
+import robin_sparkless as rs
+
+
+def test_create_dataframe_from_rows_schema_list() -> None:
+    """create_dataframe_from_rows with ("vals", "list") succeeds and vals is list column."""
+    spark = rs.SparkSession.builder().app_name("test_256").get_or_create()
+    create_df = getattr(spark, "create_dataframe_from_rows", None) or getattr(
+        spark, "_create_dataframe_from_rows"
+    )
+    data = [{"name": "a", "vals": [1, 2, 3]}]
+    schema = [("name", "string"), ("vals", "list")]
+    df = create_df(data, schema)
+    out = df.collect()
+    assert len(out) == 1
+    assert out[0]["name"] == "a"
+    assert out[0]["vals"] == [1, 2, 3]
+
+
+def test_create_dataframe_from_rows_schema_array() -> None:
+    """create_dataframe_from_rows with ("vals", "array") succeeds and vals is list column."""
+    spark = rs.SparkSession.builder().app_name("test_256").get_or_create()
+    create_df = getattr(spark, "create_dataframe_from_rows", None) or getattr(
+        spark, "_create_dataframe_from_rows"
+    )
+    data = [{"name": "b", "vals": [10, 20]}]
+    schema = [("name", "string"), ("vals", "array")]
+    df = create_df(data, schema)
+    out = df.collect()
+    assert len(out) == 1
+    assert out[0]["name"] == "b"
+    assert out[0]["vals"] == [10, 20]
+
+
+def test_create_dataframe_from_rows_list_null_and_multiple_rows() -> None:
+    """list/array column supports null and multiple rows."""
+    spark = rs.SparkSession.builder().app_name("test_256").get_or_create()
+    create_df = getattr(spark, "create_dataframe_from_rows", None) or getattr(
+        spark, "_create_dataframe_from_rows"
+    )
+    data = [
+        {"id": 1, "vals": [1, 2]},
+        {"id": 2, "vals": None},
+        {"id": 3, "vals": []},
+    ]
+    schema = [("id", "bigint"), ("vals", "list")]
+    df = create_df(data, schema)
+    out = df.collect()
+    assert len(out) == 3
+    assert out[0]["vals"] == [1, 2]
+    assert out[1]["vals"] is None
+    assert out[2]["vals"] == []


### PR DESCRIPTION
## Summary
PySpark accepts `createDataFrame` with list/array column data (e.g. `spark.createDataFrame([{"name": "a", "vals": [1,2,3]}]`). Robin's `create_dataframe_from_rows` previously raised `RuntimeError: unsupported type 'list'/'array' for column`. This PR adds support for schema dtype `"list"` and `"array"` with default element type bigint.

## Changes
- **src/session.rs**: New match arm for `"list" | "array"` in `create_dataframe_from_rows`, building a list column (element type bigint) using the same logic as `array<element_type>`.
- **src/python/session.rs**: Docstring updated to mention list/array and PySpark parity #256.
- **tests/python/test_issue_256_create_dataframe_array_column.py**: Tests for `("vals", "list")`, `("vals", "array")`, and null/empty list / multiple rows.

## Testing
`pytest tests/python/test_issue_256_create_dataframe_array_column.py -v` — all 3 tests pass.

Fixes #256

Made with [Cursor](https://cursor.com)