### PR TITLE
Fix #262: F.round() on string column (PySpark parity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **#262 – F.round() on string column (PySpark parity)** — `round()` now accepts string columns that contain numeric values; values are implicitly cast to double then rounded (PySpark behavior). Previously raised `RuntimeError: round can only be used on numeric types`. Fixes #262.
+
 ### Planned
 
 - **Phase 26 – Publish crate**: Prepare and publish robin-sparkless to crates.io (and optionally PyPI via maturin). See [ROADMAP.md](docs/ROADMAP.md) for details.

--- a/src/column.rs
+++ b/src/column.rs
@@ -1226,9 +1226,14 @@ impl Column {
         Self::from_expr(self.expr().clone().floor(), None)
     }
 
-    /// Round to given decimal places (PySpark round)
+    /// Round to given decimal places (PySpark round). Supports string columns containing
+    /// numeric values (implicit cast to double then round; parity with PySpark).
     pub fn round(&self, decimals: u32) -> Column {
-        Self::from_expr(self.expr().clone().round(decimals), None)
+        let expr = self.expr().clone().map(
+            move |s| crate::udfs::apply_round(s, decimals),
+            GetOutput::from_type(DataType::Float64),
+        );
+        Self::from_expr(expr, None)
     }
 
     /// Banker's rounding - round half to even (PySpark bround).

--- a/tests/python/test_issue_262_round_string_column.py
+++ b/tests/python/test_issue_262_round_string_column.py
@@ -1,0 +1,48 @@
+"""
+Tests for issue #262: F.round() on string column (PySpark parity).
+
+PySpark supports F.round() on string columns that contain numeric values (implicit cast).
+Robin previously raised RuntimeError: round can only be used on numeric types.
+"""
+
+from __future__ import annotations
+
+import robin_sparkless as rs
+
+F = rs
+
+
+def test_round_string_column_implicit_cast() -> None:
+    """with_column with F.round(F.col('val')) on string column succeeds; matches PySpark [10.0, 10.0]."""
+    spark = F.SparkSession.builder().app_name("test_262").get_or_create()
+    create_df = getattr(spark, "create_dataframe_from_rows", None) or getattr(
+        spark, "_create_dataframe_from_rows"
+    )
+    df = create_df(
+        [{"val": "10.4"}, {"val": "9.6"}],
+        [("val", "string")],
+    )
+    df = df.with_column("rounded", F.round(F.col("val")))
+    out = df.collect()
+    assert len(out) == 2
+    assert out[0]["val"] == "10.4"
+    assert out[0]["rounded"] == 10.0
+    assert out[1]["val"] == "9.6"
+    assert out[1]["rounded"] == 10.0
+
+
+def test_round_string_column_with_scale() -> None:
+    """round on string column with scale=1 yields one decimal place."""
+    spark = F.SparkSession.builder().app_name("test_262").get_or_create()
+    create_df = getattr(spark, "create_dataframe_from_rows", None) or getattr(
+        spark, "_create_dataframe_from_rows"
+    )
+    df = create_df(
+        [{"val": "10.44"}, {"val": "9.66"}],
+        [("val", "string")],
+    )
+    df = df.with_column("rounded", F.round(F.col("val"), 1))
+    out = df.collect()
+    assert len(out) == 2
+    assert out[0]["rounded"] == 10.4
+    assert out[1]["rounded"] == 9.7


### PR DESCRIPTION
## Summary
PySpark supports `F.round()` on string columns that contain numeric values (implicit cast). Robin previously raised `RuntimeError: round can only be used on numeric types`.

## Changes
- **`src/udfs.rs`**: Added `apply_round(column, decimals)` — casts input to Float64 via `float_series_to_f64` (handles string and numeric), then rounds to the given scale.
- **`src/column.rs`**: `Column::round(decimals)` now uses `map(apply_round)` instead of `expr.round(decimals)`, so string columns are supported.
- **`tests/python/test_issue_262_round_string_column.py`**: Tests for implicit cast (`["10.4", "9.6"]` → `[10.0, 10.0]`) and `round(col, 1)` on string column.
- **`CHANGELOG.md`**: Unreleased entry for #262.

## Verification
- `cargo test` (Rust)
- `pytest tests/python/` (Python, 237 tests)

Fixes #262

Made with [Cursor](https://cursor.com)