### PR TITLE
Fix #263: F.array() with no args (PySpark parity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **#262 – F.round() on string column (PySpark parity)** — `round()` now accepts string columns that contain numeric values; values are implicitly cast to double then rounded (PySpark behavior). Previously raised `RuntimeError: round can only be used on numeric types`. Fixes #262.
+- **#263 – F.array() with no args (PySpark parity)** — `array()` with no arguments now returns a column of empty arrays (one `[]` per row). Previously raised `RuntimeError: array requires at least one column`. Fixes #263.
 
 ### Planned
 

--- a/src/plan/expr.rs
+++ b/src/plan/expr.rs
@@ -1668,11 +1668,6 @@ fn expr_from_fn_rest(name: &str, args: &[Value]) -> Result<Expr, PlanExprError> 
         }
         // --- Array / list ---
         "array" => {
-            if args.is_empty() {
-                return Err(PlanExprError(
-                    "fn 'array' requires at least one argument".to_string(),
-                ));
-            }
             let exprs: Result<Vec<Expr>, _> = args.iter().map(expr_from_value).collect();
             let cols: Vec<Column> = exprs?.into_iter().map(expr_to_column).collect();
             let refs: Vec<&Column> = cols.iter().collect();

--- a/tests/python/test_issue_263_array_empty.py
+++ b/tests/python/test_issue_263_array_empty.py
@@ -1,0 +1,44 @@
+"""
+Tests for issue #263: F.array() with no args (PySpark parity).
+
+PySpark supports F.array() with no arguments, returning an empty array column (one [] per row).
+Robin previously raised RuntimeError: array requires at least one column.
+"""
+
+from __future__ import annotations
+
+import robin_sparkless as rs
+
+F = rs
+
+
+def test_array_empty_returns_empty_array_column() -> None:
+    """with_column with F.array() (no args) succeeds and yields empty list per row."""
+    spark = F.SparkSession.builder().app_name("test_263").get_or_create()
+    create_df = getattr(spark, "create_dataframe_from_rows", None) or getattr(
+        spark, "_create_dataframe_from_rows"
+    )
+    df = create_df(
+        [{"Name": "Alice"}, {"Name": "Bob"}],
+        [("Name", "string")],
+    )
+    df = df.with_column("NewArray", F.array())
+    out = df.collect()
+    assert len(out) == 2
+    assert out[0]["Name"] == "Alice"
+    assert out[0]["NewArray"] == []
+    assert out[1]["Name"] == "Bob"
+    assert out[1]["NewArray"] == []
+
+
+def test_array_empty_with_other_columns() -> None:
+    """F.array() with no args works alongside other with_column expressions."""
+    spark = F.SparkSession.builder().app_name("test_263").get_or_create()
+    create_df = getattr(spark, "create_dataframe_from_rows", None) or getattr(
+        spark, "_create_dataframe_from_rows"
+    )
+    df = create_df([{"x": 1}, {"x": 2}], [("x", "int")])
+    df = df.with_column("empty_arr", F.array()).with_column("double", F.col("x") * 2)
+    out = df.collect()
+    assert [r["empty_arr"] for r in out] == [[], []]
+    assert [r["double"] for r in out] == [2, 4]


### PR DESCRIPTION
## Summary
PySpark supports `F.array()` with no arguments, returning an empty array column (one `[]` per row). Robin previously raised `RuntimeError: array requires at least one column`.

## Changes
- **`src/functions.rs`**: When `array(columns)` is called with no columns, create a literal empty list (one row) and use `.first()` so it broadcasts to the frame height; return that as the new column.
- **`src/plan/expr.rs`**: Remove the empty-args check for `array` so `array()` is allowed in plan/SQL and delegates to `functions::array(&[])`.
- **`tests/python/test_issue_263_array_empty.py`**: Tests for `with_column("NewArray", F.array())` (empty list per row) and with other columns.
- **`CHANGELOG.md`**: Unreleased entry for #263.

## Verification
- `cargo test` (Rust)
- `pytest tests/python/test_issue_263_array_empty.py` (Python)

Fixes #263

Made with [Cursor](https://cursor.com)