### PR TITLE
Fix #265: date/datetime vs string comparison (PySpark parity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **#262 – F.round() on string column (PySpark parity)** — `round()` now accepts string columns that contain numeric values; values are implicitly cast to double then rounded (PySpark behavior). Previously raised `RuntimeError: round can only be used on numeric types`. Fixes #262.
 - **#263 – F.array() with no args (PySpark parity)** — `array()` with no arguments now returns a column of empty arrays (one `[]` per row). Previously raised `RuntimeError: array requires at least one column`. Fixes #263.
 - **#264 – F.posexplode() and F.explode() in Python module (PySpark parity)** — Module-level `posexplode(column)` and `explode(column)` are now exposed; previously `F.posexplode` raised `AttributeError`. `posexplode` returns `(pos_column, value_column)`. Fixes #264.
+- **#265 – date/datetime vs string comparison (PySpark parity)** — Comparing a date or datetime column to a string literal in `filter` (e.g. `df.filter(col("dt") == "2025-01-01")`) now implicitly casts the string to the column type instead of raising `RuntimeError: cannot compare 'date/datetime/time' to a string value`. Uses `try_cast` so invalid strings become null (non-matching). Fixes #265.
 
 ### Planned
 

--- a/tests/issue_235_filter_coercion.rs
+++ b/tests/issue_235_filter_coercion.rs
@@ -1,11 +1,15 @@
 //! Integration tests for issue #235: string–numeric comparison coercion in filter.
+//! And issue #265: date/datetime vs string comparison (PySpark implicit cast).
 //!
 //! These tests ensure that `df.filter(col("str_col") == lit(123))` (and symmetric form)
 //! is coerced so that the string column is compared numerically (PySpark parity), and
 //! that the filter runs without "cannot compare string with numeric type".
+//! Issue #265: `df.filter(col("dt") == "2025-01-01")` on a date column is coerced so
+//! the string literal is cast to date (PySpark parity).
 
-use polars::prelude::{NamedFrom, Series};
-use robin_sparkless::{col, lit_i64, DataFrame};
+use chrono::NaiveDate;
+use polars::prelude::{DataType, NamedFrom, Series};
+use robin_sparkless::{col, lit_i64, lit_str, DataFrame};
 
 fn df_with_string_column() -> DataFrame {
     let s = Series::new("str_col".into(), &["123", "456"]);
@@ -60,5 +64,39 @@ fn issue_235_string_eq_numeric_with_invalid_string_non_matching() {
         out.count().unwrap(),
         1,
         "invalid numeric string should not match"
+    );
+}
+
+fn df_with_date_column() -> DataFrame {
+    let d1 = NaiveDate::from_ymd_opt(2025, 1, 1).unwrap();
+    let d2 = NaiveDate::from_ymd_opt(2025, 1, 2).unwrap();
+    let s = Series::new("dt".into(), [d1, d2])
+        .cast(&DataType::Date)
+        .unwrap();
+    let pl_df = polars::prelude::DataFrame::new(vec![s.into()]).unwrap();
+    DataFrame::from_polars(pl_df)
+}
+
+#[test]
+fn issue_265_date_column_eq_string_literal() {
+    let df = df_with_date_column();
+    let expr = col("dt").eq(lit_str("2025-01-01").into_expr()).into_expr();
+    let out = df.filter(expr).unwrap();
+    assert_eq!(
+        out.count().unwrap(),
+        1,
+        "filter(dt == '2025-01-01') on date column should return one row"
+    );
+}
+
+#[test]
+fn issue_265_date_column_ne_string_literal() {
+    let df = df_with_date_column();
+    let expr = col("dt").neq(lit_str("2025-01-01").into_expr()).into_expr();
+    let out = df.filter(expr).unwrap();
+    assert_eq!(
+        out.count().unwrap(),
+        1,
+        "filter(dt != '2025-01-01') on date column should return one row"
     );
 }

--- a/tests/python/test_issue_265_date_string_comparison.py
+++ b/tests/python/test_issue_265_date_string_comparison.py
@@ -1,0 +1,43 @@
+"""
+Tests for issue #265: date/datetime vs string comparison (PySpark parity).
+
+PySpark supports comparing date/datetime columns to string literals (implicit cast).
+Robin previously raised RuntimeError: cannot compare 'date/datetime/time' to a string value.
+"""
+
+from __future__ import annotations
+
+import robin_sparkless as rs
+
+F = rs
+
+
+def test_filter_date_column_equals_string_literal() -> None:
+    """filter(F.col('dt') == '2025-01-01') on date column returns matching row."""
+    spark = F.SparkSession.builder().app_name("test_265").get_or_create()
+    create_df = getattr(spark, "create_dataframe_from_rows", None) or getattr(
+        spark, "_create_dataframe_from_rows"
+    )
+    df = create_df(
+        [{"dt": "2025-01-01"}, {"dt": "2025-01-02"}],
+        [("dt", "date")],
+    )
+    out = df.filter(F.col("dt") == "2025-01-01").collect()
+    assert len(out) == 1
+    # Row may have dt as date or ISO string depending on binding
+    assert out[0]["dt"] == "2025-01-01" or str(out[0]["dt"]).startswith("2025-01-01")
+
+
+def test_filter_date_column_not_equals_string_literal() -> None:
+    """filter(F.col('dt') != '2025-01-01') on date column returns non-matching rows."""
+    spark = F.SparkSession.builder().app_name("test_265").get_or_create()
+    create_df = getattr(spark, "create_dataframe_from_rows", None) or getattr(
+        spark, "_create_dataframe_from_rows"
+    )
+    df = create_df(
+        [{"dt": "2025-01-01"}, {"dt": "2025-01-02"}],
+        [("dt", "date")],
+    )
+    out = df.filter(F.col("dt") != "2025-01-01").collect()
+    assert len(out) == 1
+    assert out[0]["dt"] == "2025-01-02" or str(out[0]["dt"]).startswith("2025-01-02")


### PR DESCRIPTION
## Summary
Fixes https://github.com/eddiethedean/robin-sparkless/issues/265

PySpark allows comparing date/datetime columns to string literals (implicit cast). Robin previously raised `RuntimeError: cannot compare 'date/datetime/time' to a string value`.

## Changes
- **type_coercion**: Add date/datetime vs string branch in `coerce_for_pyspark_comparison`; cast string side via `try_cast` to date or timestamp.
- **dataframe**: Add column-vs-string-literal handling in `coerce_string_numeric_comparisons`; resolve column dtype from schema and coerce when column is Date/Datetime. Add `get_column_dtype()` on DataFrame.
- **Tests**: Rust (issue_265_date_column_eq/ne_string_literal) and Python (`test_issue_265_date_string_comparison.py`).
- CHANGELOG: unreleased entry for #265.

`df.filter(col("dt") == "2025-01-01")` on a date column now returns the matching row(s) instead of raising.

Made with [Cursor](https://cursor.com)