### PR TITLE
Fix #266: eq_null_safe type coercion (PySpark parity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **#263 – F.array() with no args (PySpark parity)** — `array()` with no arguments now returns a column of empty arrays (one `[]` per row). Previously raised `RuntimeError: array requires at least one column`. Fixes #263.
 - **#264 – F.posexplode() and F.explode() in Python module (PySpark parity)** — Module-level `posexplode(column)` and `explode(column)` are now exposed; previously `F.posexplode` raised `AttributeError`. `posexplode` returns `(pos_column, value_column)`. Fixes #264.
 - **#265 – date/datetime vs string comparison (PySpark parity)** — Comparing a date or datetime column to a string literal in `filter` (e.g. `df.filter(col("dt") == "2025-01-01")`) now implicitly casts the string to the column type instead of raising `RuntimeError: cannot compare 'date/datetime/time' to a string value`. Uses `try_cast` so invalid strings become null (non-matching). Fixes #265.
+- **#266 – eq_null_safe type coercion (PySpark parity)** — `eq_null_safe` (eqNullSafe) now applies the same string–numeric coercion as regular comparisons: string column vs int literal is coerced via `try_to_number` so that e.g. `df.select(col("str_col").eq_null_safe(lit(123)))` returns True/False per row instead of raising `RuntimeError: cannot compare string with numeric type (i32)`. Fixes #266.
 
 ### Planned
 

--- a/tests/python/test_issue_266_eqnullsafe_type_coercion.py
+++ b/tests/python/test_issue_266_eqnullsafe_type_coercion.py
@@ -1,0 +1,49 @@
+"""
+Tests for issue #266: eq_null_safe type coercion (PySpark parity).
+
+PySpark supports eqNullSafe with type coercion (e.g. string column vs int literal).
+Robin previously raised RuntimeError: cannot compare string with numeric type (i32).
+"""
+
+from __future__ import annotations
+
+import robin_sparkless as rs
+
+F = rs
+
+
+def test_eqnullsafe_string_column_eq_int_literal() -> None:
+    """select(col('str_col').eq_null_safe(lit(123))) with string column returns True/False per row."""
+    spark = F.SparkSession.builder().app_name("test_266").get_or_create()
+    create_df = getattr(spark, "create_dataframe_from_rows", None) or getattr(
+        spark, "_create_dataframe_from_rows"
+    )
+    df = create_df(
+        [
+            {"str_col": "123", "other": 1},
+            {"str_col": "456", "other": 2},
+        ],
+        [("str_col", "string"), ("other", "int")],
+    )
+    out = df.select(F.col("str_col").eq_null_safe(F.lit(123)).alias("eq")).collect()
+    assert len(out) == 2
+    # "123" == 123 -> True; "456" != 123 -> False (PySpark coerces string to number)
+    assert out[0]["eq"] is True
+    assert out[1]["eq"] is False
+
+
+def test_eqnullsafe_string_column_eq_int_literal_no_match() -> None:
+    """eq_null_safe with non-numeric string yields False (coerced to null, not equal)."""
+    spark = F.SparkSession.builder().app_name("test_266").get_or_create()
+    create_df = getattr(spark, "create_dataframe_from_rows", None) or getattr(
+        spark, "_create_dataframe_from_rows"
+    )
+    df = create_df(
+        [{"str_col": "abc"}, {"str_col": "123"}],
+        [("str_col", "string")],
+    )
+    out = df.select(F.col("str_col").eq_null_safe(F.lit(123)).alias("eq")).collect()
+    assert len(out) == 2
+    # "abc" -> null when parsed as number, null eq 123 is False (eq_null_safe: one null -> False)
+    assert out[0]["eq"] is False
+    assert out[1]["eq"] is True


### PR DESCRIPTION
## Summary
Fixes https://github.com/eddiethedean/robin-sparkless/issues/266

PySpark supports `eqNullSafe` with type coercion (e.g. string column vs int literal). Robin previously raised `RuntimeError: cannot compare string with numeric type (i32)`.

## Changes
- **type_coercion**: Add `infer_type_from_expr` and `coerce_for_pyspark_eq_null_safe`; infer types from literals, assume String for column, then coerce via `coerce_for_pyspark_comparison` (try_to_number on string side).
- **plan/expr.rs**: `eq_null_safe_expr` coerces left/right before building when/then/eq. Returns `Result<Expr, PlanExprError>`.
- **column.rs**: `eq_null_safe` uses coerced exprs for the equality branch.
- **Python tests**: `test_issue_266_eqnullsafe_type_coercion.py` (string column eq_null_safe int literal).
- CHANGELOG: unreleased entry for #266.

`df.select(col("str_col").eq_null_safe(lit(123)))` now returns True/False per row (e.g. True for "123", False for "456") instead of raising.

Made with [Cursor](https://cursor.com)