### PR TITLE
Fix #276: between() with string column and numeric bounds (PySpark parity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **#273 – to_timestamp() on string column (PySpark parity)** — `to_timestamp(col("ts_str"))` without format now parses common string timestamps (e.g. `"2024-01-01 10:00:00"`) using default format `%Y-%m-%d %H:%M:%S` instead of raising `RuntimeError`. With format, PySpark-style patterns with single-quoted literals (e.g. `"yyyy-MM-dd'T'HH:mm:ss"`) are supported: quoted segments like `'T'` are unquoted before conversion to strftime, so `"2024-01-01T10:00:00"` parses correctly. String values are trimmed before parsing. Fixes #273.
 - **#274 – join key type coercion (PySpark parity)** — Join on columns with different types (e.g. str on left, int on right) now coerces both sides to a common type (via `find_common_type`) instead of raising `RuntimeError: datatypes of join keys don't match`. Fixes #274.
 - **#275 – create_map() with no arguments (PySpark parity)** — `create_map()` and `create_map([])` now return a column of empty maps (one `{}` per row) instead of raising `TypeError: py_create_map() missing 1 required positional argument: 'cols'`. Python binding accepts `*cols` so zero arguments is valid. Fixes #275.
+- **#276 – between() with string column and numeric bounds (PySpark parity)** — `col("col").between(1, 20)` when `col` is string now coerces (string parsed to number for comparison) instead of raising `RuntimeError: cannot compare string with numeric type`. Coercion is applied in `with_column` as well as in `filter`. Fixes #276.
 
 ### Planned
 

--- a/src/dataframe/transformations.rs
+++ b/src/dataframe/transformations.rs
@@ -128,6 +128,7 @@ pub fn with_column(
         }
     }
     let expr = df.resolve_expr_column_names(column.expr().clone())?;
+    let expr = df.coerce_string_numeric_comparisons(expr)?;
     let lf = df.df.as_ref().clone().lazy();
     let lf_with_col = lf.with_column(expr.alias(column_name));
     let pl_df = lf_with_col.collect()?;

--- a/tests/python/test_issue_276_between_string_numeric.py
+++ b/tests/python/test_issue_276_between_string_numeric.py
@@ -1,0 +1,42 @@
+"""
+Tests for issue #276: between() with string column and numeric bounds (PySpark parity).
+
+PySpark col("col").between(1, 20) when col is string coerces for comparison.
+Robin previously raised: RuntimeError: cannot compare string with numeric type (i32).
+"""
+
+from __future__ import annotations
+
+import robin_sparkless as rs
+
+F = rs
+
+
+def test_between_string_column_numeric_bounds_with_column() -> None:
+    """df.with_column("between", col("col").between(1, 20)) when col is string coerces."""
+    spark = F.SparkSession.builder().app_name("test_276").get_or_create()
+    create_df = getattr(spark, "create_dataframe_from_rows", None) or getattr(
+        spark, "_create_dataframe_from_rows"
+    )
+    data = [{"col": "5"}, {"col": "10"}, {"col": "15"}]
+    df = create_df(data, [("col", "str")])
+    df = df.with_column("between", F.col("col").between(1, 20))
+    rows = df.collect()
+    assert len(rows) == 3
+    # All "5", "10", "15" are in [1, 20] when coerced to number
+    assert rows[0]["between"] is True
+    assert rows[1]["between"] is True
+    assert rows[2]["between"] is True
+
+
+def test_between_string_column_numeric_bounds_filter() -> None:
+    """df.filter(col("col").between(1, 20)) when col is string also coerces."""
+    spark = F.SparkSession.builder().app_name("test_276").get_or_create()
+    create_df = getattr(spark, "create_dataframe_from_rows", None) or getattr(
+        spark, "_create_dataframe_from_rows"
+    )
+    data = [{"col": "5"}, {"col": "10"}, {"col": "25"}]
+    df = create_df(data, [("col", "str")])
+    out = df.filter(F.col("col").between(1, 20)).collect()
+    assert len(out) == 2  # "5" and "10" in range, "25" not
+    assert {r["col"] for r in out} == {"5", "10"}


### PR DESCRIPTION
Fixes https://github.com/eddiethedean/robin-sparkless/issues/276

**Summary**
- `col("col").between(1, 20)` when `col` is string was failing with `RuntimeError: cannot compare string with numeric type (i32)` when used in `with_column` (filter already applied coercion).
- **Fix:** Call `coerce_string_numeric_comparisons` on the expression in `with_column` (in `transformations.rs`) before adding the column, so nested comparisons (e.g. the two legs of `between`) get string→numeric coercion (try_to_number) like in filter.
- Added Python tests: `test_between_string_column_numeric_bounds_with_column` and `test_between_string_column_numeric_bounds_filter`.
- CHANGELOG entry under Added.

Made with [Cursor](https://cursor.com)