### PR TITLE
Fix #284: Always expose SparkSession.sql() and table() in Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **#284 – SparkSession.sql() and SparkSession.table() always exposed (PySpark parity)** — `spark.sql(query)` and `spark.table(name)` are now always present on the Python SparkSession. When built with the `sql` feature they work as before. When built without it they raise a clear `RuntimeError` instead of `AttributeError`, so Sparkless and PySpark-migrating code can call these methods without attribute checks. Fixes #284.
+
 ### Planned
 
 - **Phase 26 – Publish crate**: Prepare and publish robin-sparkless to crates.io (and optionally PyPI via maturin). See [ROADMAP.md](docs/ROADMAP.md) for details.


### PR DESCRIPTION
## Summary
Fixes #284.

`spark.sql(query)` and `spark.table(name)` are now **always** present on the Python `SparkSession`. When built with the `sql` feature they work as before. When built without it they raise a clear `RuntimeError` instead of `AttributeError`, so Sparkless and PySpark-migrating code can call these methods without attribute checks.

## Changes
- **Python session** (`src/python/session.rs`): Added `#[cfg(not(feature = "sql"))]` stubs for `sql()`, `table()`, and `create_or_replace_temp_view()` that raise a `RuntimeError` with instructions to build with `--features sql`. The `sql`-enabled `create_or_replace_temp_view` now returns `PyResult<()>` so both branches have the same signature.
- **Tests**: New `test_spark_sql_and_table_exist_issue_284` asserts `hasattr(spark, "sql")` and `hasattr(spark, "table")` and runs the issue repro (`spark.sql("SELECT 1 as one")`, `spark.table("my_table")`) when the sql feature is built; skips on `RuntimeError` when not. Updated `test_sql_select_where_returns_rows` to catch `RuntimeError` (in addition to `AttributeError`) when sql is not built.
- **CHANGELOG**: Documented #284 under Unreleased.

## Testing
- `cargo check --no-default-features --features pyo3` (no sql) ✅
- `pytest tests/python/test_robin_sparkless.py -v -k "sql_and_table_exist or sql_select_where"` (with `maturin develop --features 'pyo3,sql'`) — run after installing with sql feature.

Made with [Cursor](https://cursor.com)