### PR TITLE
docs/test: DataFrame.fillna(value, subset=[...]) (#290)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **#287 – DataFrame.agg(*exprs) for global aggregation (PySpark parity)** — `DataFrame.agg(expr)` and `DataFrame.agg([expr1, expr2, ...])` (or a tuple of expressions) now perform global aggregation over the whole DataFrame and return a single-row DataFrame (e.g. `df.agg([sum(col("x")), avg(col("y"))])`). Fixes #287.
 - **#288 – Window.partitionBy() / orderBy() accept column names (str) (PySpark parity)** — `Window.partitionBy("col1", "col2")` and `Window.orderBy("col")` now accept column names (strings) as well as Column expressions, so `Window.partitionBy("dept").orderBy("salary")` works without wrapping in `col()`. Fixes #288.
 - **#289 – DataFrame.na.drop() / na.fill() with subset, how, thresh (PySpark parity)** — `df.na().drop(subset=..., how=..., thresh=...)` and `df.na().fill(value, subset=...)` now match PySpark: `drop` accepts `subset` (columns to consider), `how` (`"any"` drop if any null, `"all"` drop only if all null), and `thresh` (keep row if at least that many non-null in subset). `fill` accepts scalar or Column as `value` and optional `subset` (columns to fill). Direct `df.dropna(subset=..., how=..., thresh=...)` and `df.fillna(value, subset=...)` updated accordingly. Fixes #289.
+- **#290 – DataFrame.fillna(value, subset=[...]) (PySpark parity)** — Direct `df.fillna(value, subset=[...])` is supported (same API as #289); fills only the listed columns. Fixes #290.
 
 ### Planned
 

--- a/tests/python/test_robin_sparkless.py
+++ b/tests/python/test_robin_sparkless.py
@@ -1831,6 +1831,24 @@ def test_na_drop_fill_subset_how_thresh_issue_289() -> None:
     assert out_thresh.count() == 1  # only (3, 3) has 2 non-null
 
 
+def test_fillna_subset_direct_issue_290() -> None:
+    """DataFrame.fillna(value, subset=[...]) accepts subset keyword (#290)."""
+    import robin_sparkless as rs
+
+    spark = rs.SparkSession.builder().app_name("test").get_or_create()
+    df = spark._create_dataframe_from_rows(
+        [{"a": 1, "b": None}, {"a": None, "b": 2}],
+        [("a", "int"), ("b", "int")],
+    )
+    out = df.fillna(0, subset=["b"])
+    rows = out.collect()
+    assert len(rows) == 2
+    # Only column b is filled; a is unchanged (1 and None)
+    by_a = {r.get("a") for r in rows}
+    assert by_a == {1, None}
+    assert [r["b"] for r in rows] == [0, 2]
+
+
 def test_window_partition_by_order_by_accept_str_issue_288() -> None:
     """Window.partitionBy and orderBy accept column names (str) not only Column (#288)."""
     import robin_sparkless as rs


### PR DESCRIPTION
## Summary
Fixes #290. The behavior was already implemented in #289: `df.fillna(value, subset=[...])` is supported. This PR adds an explicit test for the issue repro and documents #290 in the CHANGELOG.

## Changes
- **test_fillna_subset_direct_issue_290**: Exact repro from the issue — `df.fillna(0, subset=["b"])` on `[{"a": 1, "b": None}, {"a": None, "b": 2}]`; asserts only `b` is filled.
- **CHANGELOG**: Unreleased entry for #290 (fillna subset supported via #289).

No code changes; API was already correct.

Made with [Cursor](https://cursor.com)