### PR TITLE
fix: #313 hour(col) at module level (PySpark parity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **#292 – union_by_name(allow_missing_columns=True) (PySpark parity)** — `df.union_by_name(other, allow_missing_columns=True)` (default True) fills columns missing in the other DataFrame with null. When False, errors if the other DataFrame is missing any column from this one. Fixes #292.
 - **#319 – lag(col, offset) / lead(col, offset) as module-level (PySpark parity)** — `lag(column, offset=1)` and `lead(column, offset=1)` are now exposed at module level; use with `.over(partition_by)` (e.g. `rs.lag(rs.col("v"), 1).over(["dept"])`). Fixes #319.
 - **#320 – dense_rank() window function (PySpark parity)** — `dense_rank(descending=False)` returns a window function; use with `.over(window)` (e.g. `rs.dense_rank().over(win)`). Fixes #320.
+- **#313 – hour(col) (PySpark parity)** — Module-level `hour(column)` extracts the hour (0–23) from a date or timestamp column. Fixes #313.
 
 ### Planned
 

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -11,16 +11,16 @@ use crate::functions::{
     date_add, date_diff, date_format, date_from_unix_date, date_part, date_sub, date_trunc,
     dateadd, datepart, day, dayname, dayofmonth, dayofweek, dayofyear, days, degrees, endswith,
     expm1, extract, factorial, find_in_set, format_number, format_string, from_csv, from_unixtime,
-    from_utc_timestamp, get_json_object, greatest as rs_greatest, hours, hypot, ifnull, ilike,
-    initcap, isnan as rs_isnan, isnotnull, isnull, json_tuple, lcase, least as rs_least, left,
-    length, like, ln, localtimestamp, log, log10, log1p, log2, log_with_base, ltrim, make_date,
-    make_interval, make_timestamp, make_timestamp_ntz, md5, minutes, month, months, months_between,
-    next_day, now, nullif, nvl, nvl2, overlay, pmod, power, quarter, radians, regexp_count,
-    regexp_extract, regexp_extract_all, regexp_instr, regexp_replace, regexp_substr, repeat,
-    replace as rs_replace, reverse, right, rint, rlike, rtrim, schema_of_csv, schema_of_json, sha1,
-    sha2, signum, sin, sinh, soundex, split, split_part, startswith, substr, tan, tanh,
-    timestamp_micros, timestamp_millis, timestamp_seconds, timestampadd, timestampdiff, to_csv,
-    to_degrees, to_radians, to_timestamp, to_unix_timestamp, to_utc_timestamp, trim,
+    from_utc_timestamp, get_json_object, greatest as rs_greatest, hour, hours, hypot, ifnull,
+    ilike, initcap, isnan as rs_isnan, isnotnull, isnull, json_tuple, lcase, least as rs_least,
+    left, length, like, ln, localtimestamp, log, log10, log1p, log2, log_with_base, ltrim,
+    make_date, make_interval, make_timestamp, make_timestamp_ntz, md5, minutes, month, months,
+    months_between, next_day, now, nullif, nvl, nvl2, overlay, pmod, power, quarter, radians,
+    regexp_count, regexp_extract, regexp_extract_all, regexp_instr, regexp_replace, regexp_substr,
+    repeat, replace as rs_replace, reverse, right, rint, rlike, rtrim, schema_of_csv,
+    schema_of_json, sha1, sha2, signum, sin, sinh, soundex, split, split_part, startswith, substr,
+    tan, tanh, timestamp_micros, timestamp_millis, timestamp_seconds, timestampadd, timestampdiff,
+    to_csv, to_degrees, to_radians, to_timestamp, to_unix_timestamp, to_utc_timestamp, trim,
     try_cast as rs_try_cast, ucase, unbase64, unix_date, unix_micros, unix_millis, unix_seconds,
     unix_timestamp, unix_timestamp_now, weekday, weekofyear, year, years,
 };
@@ -504,6 +504,7 @@ fn robin_sparkless(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("dayofmonth", wrap_pyfunction!(py_dayofmonth, m)?)?;
     m.add("year", wrap_pyfunction!(py_year, m)?)?;
     m.add("month", wrap_pyfunction!(py_month, m)?)?;
+    m.add("hour", wrap_pyfunction!(py_hour, m)?)?;
     m.add("to_degrees", wrap_pyfunction!(py_to_degrees, m)?)?;
     m.add("to_radians", wrap_pyfunction!(py_to_radians, m)?)?;
     m.add("isnull", wrap_pyfunction!(py_isnull, m)?)?;
@@ -2451,6 +2452,12 @@ fn py_year(col: &PyColumn) -> PyColumn {
 fn py_month(col: &PyColumn) -> PyColumn {
     PyColumn {
         inner: month(&col.inner),
+    }
+}
+#[pyfunction]
+fn py_hour(col: &PyColumn) -> PyColumn {
+    PyColumn {
+        inner: hour(&col.inner),
     }
 }
 #[pyfunction]

--- a/tests/python/test_robin_sparkless.py
+++ b/tests/python/test_robin_sparkless.py
@@ -1907,6 +1907,27 @@ def test_lag_lead_dense_rank_module_issue_319_320() -> None:
     assert rks == [1, 2, 2]  # dense_rank: no gap after tie
 
 
+def test_hour_module_issue_313() -> None:
+    """Module-level hour(column) extracts hour from timestamp (#313)."""
+    import robin_sparkless as rs
+
+    spark = rs.SparkSession.builder().app_name("test").get_or_create()
+    df = spark._create_dataframe_from_rows(
+        [
+            {"ts_str": "2024-01-15 09:30:00"},
+            {"ts_str": "2024-06-01 14:00:00"},
+            {"ts_str": "2023-12-31 23:59:00"},
+        ],
+        [("ts_str", "string")],
+    )
+    df = df.with_column("ts", rs.to_timestamp(rs.col("ts_str")))
+    out = df.with_column("h", rs.hour(rs.col("ts")))
+    rows = out.collect()
+    assert len(rows) == 3
+    hours = [r["h"] for r in rows]
+    assert hours == [9, 14, 23]
+
+
 def test_window_partition_by_order_by_accept_str_issue_288() -> None:
     """Window.partitionBy and orderBy accept column names (str) not only Column (#288)."""
     import robin_sparkless as rs


### PR DESCRIPTION
Expose `hour(column)` at module level; extracts hour (0–23) from date/timestamp column. Rust `hour()` already existed in `functions.rs`; added Python binding and test. Fixes #313.

Made with [Cursor](https://cursor.com)