### PR TITLE
fix: #317 element_at(col, index) at module level (PySpark parity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **#313 – hour(col) (PySpark parity)** — Module-level `hour(column)` extracts the hour (0–23) from a date or timestamp column. Fixes #313.
 - **#315 – last_day(col) (PySpark parity)** — Module-level `last_day(column)` returns the last day of the month for a date/timestamp column. Fixes #315.
 - **#322 – to_date(col [, format]) (PySpark parity)** — Module-level `to_date(column, format=None)` casts or parses to date; with `format` parses string column using PySpark-style format. Fixes #322.
+- **#317 – element_at(col, index) (PySpark parity)** — Module-level `element_at(column, index)` (1-based index) for array/map columns. Fixes #317.
 
 ### Planned
 

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -31,10 +31,11 @@ use crate::functions::{
     bit_count, bit_length, bit_or, bit_xor, bitwise_not, broadcast as rs_broadcast, cardinality,
     concat as rs_concat, concat_ws as rs_concat_ws, create_map,
     current_catalog as rs_current_catalog, current_database as rs_current_database,
-    current_schema as rs_current_schema, current_user as rs_current_user, equal_null, exp, explode,
-    explode_outer, floor, get, hash, inline as rs_inline, inline_outer as rs_inline_outer,
-    input_file_name as rs_input_file_name, isin, isin_i64, isin_str, json_array_length, map_concat,
-    map_contains_key, map_filter_value_gt, map_from_entries, map_zip_with_coalesce,
+    current_schema as rs_current_schema, current_user as rs_current_user, element_at, equal_null,
+    exp, explode, explode_outer, floor, get, hash, inline as rs_inline,
+    inline_outer as rs_inline_outer, input_file_name as rs_input_file_name, isin, isin_i64,
+    isin_str, json_array_length, map_concat, map_contains_key, map_filter_value_gt,
+    map_from_entries, map_zip_with_coalesce,
     monotonically_increasing_id as rs_monotonically_increasing_id, named_struct, parse_url,
     posexplode, rand as rs_rand, randn as rs_randn, round, sequence, shift_left, shift_right,
     shuffle, size, spark_partition_id as rs_spark_partition_id, stddev, str_to_map, struct_,
@@ -618,6 +619,7 @@ fn robin_sparkless(m: &Bound<'_, PyModule>) -> PyResult<()> {
         wrap_pyfunction!(py_map_zip_with_coalesce, m)?,
     )?;
     m.add("create_map", wrap_pyfunction!(py_create_map, m)?)?;
+    m.add("element_at", wrap_pyfunction!(py_element_at, m)?)?;
     m.add("get", wrap_pyfunction!(py_get, m)?)?;
     m.add("try_divide", wrap_pyfunction!(py_try_divide, m)?)?;
     m.add("try_add", wrap_pyfunction!(py_try_add, m)?)?;
@@ -2935,6 +2937,13 @@ fn py_create_map(cols: &Bound<'_, pyo3::types::PyTuple>) -> PyResult<PyColumn> {
     let inner =
         create_map(&refs).map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
     Ok(PyColumn { inner })
+}
+
+#[pyfunction]
+fn py_element_at(col: &PyColumn, index: i64) -> PyColumn {
+    PyColumn {
+        inner: element_at(&col.inner, index),
+    }
 }
 
 #[pyfunction]

--- a/tests/python/test_robin_sparkless.py
+++ b/tests/python/test_robin_sparkless.py
@@ -1979,6 +1979,24 @@ def test_to_date_module_issue_322() -> None:
     assert r["d"] is not None and "2024-01-15" in str(r["d"])
 
 
+def test_element_at_module_issue_317() -> None:
+    """Module-level element_at(column, index) 1-based for array (#317)."""
+    import robin_sparkless as rs
+
+    spark = rs.SparkSession.builder().app_name("test").get_or_create()
+    df = spark._create_dataframe_from_rows(
+        [{"arr": [10, 20, 30]}, {"arr": [100, 200]}],
+        [("arr", "array<bigint>")],
+    )
+    out = df.with_column("first", rs.element_at(rs.col("arr"), 1)).with_column(
+        "third", rs.element_at(rs.col("arr"), 3)
+    )
+    rows = out.collect()
+    assert len(rows) == 2
+    assert rows[0]["first"] == 10 and rows[0]["third"] == 30
+    assert rows[1]["first"] == 100 and rows[1]["third"] is None  # out of bounds
+
+
 def test_window_partition_by_order_by_accept_str_issue_288() -> None:
     import robin_sparkless as rs
 


### PR DESCRIPTION
Expose `element_at(column, index)` at module level; 1-based index for array/map. Fixes #317.

Made with [Cursor](https://cursor.com)