### PR TITLE
fix: #316 array_remove(col, element) at module level (PySpark parity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **#315 – last_day(col) (PySpark parity)** — Module-level `last_day(column)` returns the last day of the month for a date/timestamp column. Fixes #315.
 - **#322 – to_date(col [, format]) (PySpark parity)** — Module-level `to_date(column, format=None)` casts or parses to date; with `format` parses string column using PySpark-style format. Fixes #322.
 - **#317 – element_at(col, index) (PySpark parity)** — Module-level `element_at(column, index)` (1-based index) for array/map columns. Fixes #317.
+- **#316 – array_remove(col, element) (PySpark parity)** — Module-level `array_remove(column, value)` removes all elements equal to value from the array. Fixes #316.
 
 ### Planned
 

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -5,15 +5,15 @@
 use crate::column::Column as RsColumn;
 use crate::functions::{
     abs, acos, acosh, add_months, array, array_append, array_compact, array_distinct, array_except,
-    array_insert, array_intersect, array_prepend, array_union, ascii, asin, asinh, atan, atan2,
-    atanh, base64, cast as rs_cast, cbrt, ceiling, char_length, character_length, chr, contains,
-    convert_timezone, cos, cosh, curdate, current_date, current_timestamp, current_timezone,
-    date_add, date_diff, date_format, date_from_unix_date, date_part, date_sub, date_trunc,
-    dateadd, datepart, day, dayname, dayofmonth, dayofweek, dayofyear, days, degrees, endswith,
-    expm1, extract, factorial, find_in_set, format_number, format_string, from_csv, from_unixtime,
-    from_utc_timestamp, get_json_object, greatest as rs_greatest, hour, hours, hypot, ifnull,
-    ilike, initcap, isnan as rs_isnan, isnotnull, isnull, json_tuple, last_day, lcase,
-    least as rs_least, left, length, like, ln, localtimestamp, log, log10, log1p, log2,
+    array_insert, array_intersect, array_prepend, array_remove, array_union, ascii, asin, asinh,
+    atan, atan2, atanh, base64, cast as rs_cast, cbrt, ceiling, char_length, character_length, chr,
+    contains, convert_timezone, cos, cosh, curdate, current_date, current_timestamp,
+    current_timezone, date_add, date_diff, date_format, date_from_unix_date, date_part, date_sub,
+    date_trunc, dateadd, datepart, day, dayname, dayofmonth, dayofweek, dayofyear, days, degrees,
+    endswith, expm1, extract, factorial, find_in_set, format_number, format_string, from_csv,
+    from_unixtime, from_utc_timestamp, get_json_object, greatest as rs_greatest, hour, hours,
+    hypot, ifnull, ilike, initcap, isnan as rs_isnan, isnotnull, isnull, json_tuple, last_day,
+    lcase, least as rs_least, left, length, like, ln, localtimestamp, log, log10, log1p, log2,
     log_with_base, ltrim, make_date, make_interval, make_timestamp, make_timestamp_ntz, md5,
     minutes, month, months, months_between, next_day, now, nullif, nvl, nvl2, overlay, pmod, power,
     quarter, radians, regexp_count, regexp_extract, regexp_extract_all, regexp_instr,
@@ -619,6 +619,7 @@ fn robin_sparkless(m: &Bound<'_, PyModule>) -> PyResult<()> {
         wrap_pyfunction!(py_map_zip_with_coalesce, m)?,
     )?;
     m.add("create_map", wrap_pyfunction!(py_create_map, m)?)?;
+    m.add("array_remove", wrap_pyfunction!(py_array_remove, m)?)?;
     m.add("element_at", wrap_pyfunction!(py_element_at, m)?)?;
     m.add("get", wrap_pyfunction!(py_get, m)?)?;
     m.add("try_divide", wrap_pyfunction!(py_try_divide, m)?)?;
@@ -2937,6 +2938,13 @@ fn py_create_map(cols: &Bound<'_, pyo3::types::PyTuple>) -> PyResult<PyColumn> {
     let inner =
         create_map(&refs).map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
     Ok(PyColumn { inner })
+}
+
+#[pyfunction]
+fn py_array_remove(col: &PyColumn, value: &PyColumn) -> PyColumn {
+    PyColumn {
+        inner: array_remove(&col.inner, &value.inner),
+    }
 }
 
 #[pyfunction]

--- a/tests/python/test_robin_sparkless.py
+++ b/tests/python/test_robin_sparkless.py
@@ -1979,6 +1979,22 @@ def test_to_date_module_issue_322() -> None:
     assert r["d"] is not None and "2024-01-15" in str(r["d"])
 
 
+def test_array_remove_module_issue_316() -> None:
+    """Module-level array_remove(column, value) (#316)."""
+    import robin_sparkless as rs
+
+    spark = rs.SparkSession.builder().app_name("test").get_or_create()
+    df = spark._create_dataframe_from_rows(
+        [{"arr": [1, 2, 2, 3]}, {"arr": [2, 2]}],
+        [("arr", "array<bigint>")],
+    )
+    out = df.with_column("removed", rs.array_remove(rs.col("arr"), rs.lit(2)))
+    rows = out.collect()
+    assert len(rows) == 2
+    assert rows[0]["removed"] == [1, 3]
+    assert rows[1]["removed"] == []
+
+
 def test_element_at_module_issue_317() -> None:
     """Module-level element_at(column, index) 1-based for array (#317)."""
     import robin_sparkless as rs


### PR DESCRIPTION
Expose `array_remove(column, value)` at module level. Fixes #316.

Made with [Cursor](https://cursor.com)