### PR TITLE
feat: collect_list and collect_set module-level aggregates (#309, #310)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **#300 – approx_percentile(col, percentage [, accuracy]) (PySpark parity)** — Module-level `approx_percentile(column, percentage, accuracy=None)` for use in `groupBy.agg()` (maps to quantile; accuracy reserved for API). Fixes #300.
 - **#303 – max_by(value_col, ord_col) / min_by(value_col, ord_col) (PySpark parity)** — Module-level `max_by(value_column, ord_column)` and `min_by(value_column, ord_column)` for use in `groupBy.agg()` (value at row where ord is max/min). Fixes #303.
 - **#304 – try_sum(column) / try_avg(column) (PySpark parity)** — Module-level `try_sum(column)` and `try_avg(column)` for use in `groupBy.agg()` (maps to sum/mean; null-on-overflow reserved for API). Fixes #304.
+- **#309 – collect_list(column) (PySpark parity)** — Module-level `collect_list(column)` for use in `groupBy.agg()` (collect values into list per group). Fixes #309.
+- **#310 – collect_set(column) (PySpark parity)** — Module-level `collect_set(column)` for use in `groupBy.agg()` (collect distinct values into list per group). Fixes #310.
 
 ### Planned
 

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -224,6 +224,22 @@ pub fn min_by(value_col: &Column, ord_col: &Column) -> Column {
     Column::from_expr(e, None)
 }
 
+/// Collect column values into list per group (PySpark collect_list). Use in groupBy.agg().
+pub fn collect_list(col: &Column) -> Column {
+    Column::from_expr(
+        col.expr().clone().implode(),
+        Some("collect_list".to_string()),
+    )
+}
+
+/// Collect distinct column values into list per group (PySpark collect_set). Use in groupBy.agg().
+pub fn collect_set(col: &Column) -> Column {
+    Column::from_expr(
+        col.expr().clone().unique().implode(),
+        Some("collect_set".to_string()),
+    )
+}
+
 /// Standard deviation (sample) aggregation (PySpark stddev / stddev_samp)
 pub fn stddev(col: &Column) -> Column {
     Column::from_expr(col.expr().clone().std(1), Some("stddev".to_string()))

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -44,8 +44,9 @@ use crate::functions::{
     xxhash64, zip_with_coalesce,
 };
 use crate::functions::{
-    any_value, approx_count_distinct, approx_percentile, avg, coalesce, col as rs_col, count,
-    count_if, first, max, max_by, min, min_by, sum as rs_sum, try_avg, try_sum,
+    any_value, approx_count_distinct, approx_percentile, avg, coalesce, col as rs_col,
+    collect_list, collect_set, count, count_if, first, max, max_by, min, min_by, sum as rs_sum,
+    try_avg, try_sum,
 };
 use crate::functions::{
     asc, asc_nulls_first, asc_nulls_last, bround, cot, csc, desc, desc_nulls_first,
@@ -437,6 +438,8 @@ fn robin_sparkless(m: &Bound<'_, PyModule>) -> PyResult<()> {
         "approx_percentile",
         wrap_pyfunction!(py_approx_percentile, m)?,
     )?;
+    m.add("collect_list", wrap_pyfunction!(py_collect_list, m)?)?;
+    m.add("collect_set", wrap_pyfunction!(py_collect_set, m)?)?;
     m.add("count", wrap_pyfunction!(py_count, m)?)?;
     m.add("count_if", wrap_pyfunction!(py_count_if, m)?)?;
     m.add("first", wrap_pyfunction!(py_first, m)?)?;
@@ -1200,6 +1203,20 @@ fn py_approx_count_distinct(col: &PyColumn, rsd: Option<f64>) -> PyColumn {
 fn py_approx_percentile(col: &PyColumn, percentage: f64, accuracy: Option<i32>) -> PyColumn {
     PyColumn {
         inner: approx_percentile(&col.inner, percentage, accuracy),
+    }
+}
+
+#[pyfunction]
+fn py_collect_list(col: &PyColumn) -> PyColumn {
+    PyColumn {
+        inner: collect_list(&col.inner),
+    }
+}
+
+#[pyfunction]
+fn py_collect_set(col: &PyColumn) -> PyColumn {
+    PyColumn {
+        inner: collect_set(&col.inner),
     }
 }
 


### PR DESCRIPTION
## Summary
- **#309** Module-level `collect_list(column)` for `groupBy.agg()`.
- **#310** Module-level `collect_set(column)` for `groupBy.agg()` (distinct values as list).

## Changes
- `src/functions.rs`: collect_list (implode), collect_set (unique+implode).
- `src/python/mod.rs`: bindings (pyi had stubs).
- Test and CHANGELOG.

`make check-full` passes.

Made with [Cursor](https://cursor.com)