### PR TITLE
docs/test: explode_outer (#305) test and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **#311 – corr(col1, col2) (PySpark parity)** — Module-level `corr(column1, column2)` for use in `groupBy.agg()` (Pearson correlation). Fixes #311.
 - **#312 – covar_pop(col1, col2) (PySpark parity)** — Module-level `covar_pop(column1, column2)` for use in `groupBy.agg()` (population covariance). Fixes #312.
 - **#321 – skewness(col) / kurtosis(col) (PySpark parity)** — Module-level `skewness(column)` and `kurtosis(column)` for use in `groupBy.agg()`. Fixes #321.
+- **#305 – explode_outer(column) (PySpark parity)** — Module-level `explode_outer(column)` for list/map columns; null/empty list yields one row with null in the exploded column (Polars default behavior). Fixes #305.
 
 ### Planned
 


### PR DESCRIPTION
## Summary
- **#305** explode_outer already implemented; add test and CHANGELOG.

## Changes
- Test that explode_outer expands list and keeps null as one row.
- CHANGELOG entry.

`make check-full` passes.

Made with [Cursor](https://cursor.com)