### PR TITLE
Fix #344: greatest() / least() accept multiple arguments (variadic)

### DIFF
--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -2366,15 +2366,39 @@ fn py_isnan(col: &PyColumn) -> PyColumn {
     }
 }
 #[pyfunction]
-fn py_greatest(cols: Vec<PyRef<PyColumn>>) -> PyResult<PyColumn> {
-    let refs: Vec<&RsColumn> = cols.iter().map(|c| &c.inner).collect();
+#[pyo3(signature = (*cols))]
+fn py_greatest(cols: &Bound<'_, pyo3::types::PyTuple>) -> PyResult<PyColumn> {
+    let columns: Vec<PyRef<PyColumn>> = (0..cols.len())
+        .map(|i| cols.get_item(i).and_then(|ob| ob.extract()))
+        .collect::<PyResult<Vec<_>>>()
+        .map_err(|e| {
+            pyo3::exceptions::PyTypeError::new_err(format!("greatest() args must be Column: {e}"))
+        })?;
+    if columns.is_empty() {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "greatest() requires at least one column",
+        ));
+    }
+    let refs: Vec<&RsColumn> = columns.iter().map(|c| &c.inner).collect();
     rs_greatest(&refs)
         .map(|inner| PyColumn { inner })
         .map_err(|e| pyo3::exceptions::PyValueError::new_err(e))
 }
 #[pyfunction]
-fn py_least(cols: Vec<PyRef<PyColumn>>) -> PyResult<PyColumn> {
-    let refs: Vec<&RsColumn> = cols.iter().map(|c| &c.inner).collect();
+#[pyo3(signature = (*cols))]
+fn py_least(cols: &Bound<'_, pyo3::types::PyTuple>) -> PyResult<PyColumn> {
+    let columns: Vec<PyRef<PyColumn>> = (0..cols.len())
+        .map(|i| cols.get_item(i).and_then(|ob| ob.extract()))
+        .collect::<PyResult<Vec<_>>>()
+        .map_err(|e| {
+            pyo3::exceptions::PyTypeError::new_err(format!("least() args must be Column: {e}"))
+        })?;
+    if columns.is_empty() {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "least() requires at least one column",
+        ));
+    }
+    let refs: Vec<&RsColumn> = columns.iter().map(|c| &c.inner).collect();
     rs_least(&refs)
         .map(|inner| PyColumn { inner })
         .map_err(|e| pyo3::exceptions::PyValueError::new_err(e))

--- a/tests/python/test_pyspark_port_extracted.py
+++ b/tests/python/test_pyspark_port_extracted.py
@@ -394,7 +394,7 @@ def test_when() -> None:
 
 
 def test_greatest() -> None:
-    """Ported from PySpark: greatest returns max of columns."""
+    """Ported from PySpark: greatest returns max of columns (variadic, issue #344)."""
     import robin_sparkless as rs
 
     spark = rs.SparkSession.builder().app_name("test").get_or_create()
@@ -404,7 +404,7 @@ def test_greatest() -> None:
     )
     out = df.with_column(
         "max_val",
-        rs.greatest([rs.col("a"), rs.col("b"), rs.col("c")]),  # type: ignore[arg-type]
+        rs.greatest(rs.col("a"), rs.col("b"), rs.col("c")),
     )
     rows = out.collect()
     assert rows[0]["max_val"] == 3
@@ -412,7 +412,7 @@ def test_greatest() -> None:
 
 
 def test_least() -> None:
-    """Ported from PySpark: least returns min of columns."""
+    """Ported from PySpark: least returns min of columns (variadic, issue #344)."""
     import robin_sparkless as rs
 
     spark = rs.SparkSession.builder().app_name("test").get_or_create()
@@ -420,7 +420,10 @@ def test_least() -> None:
         [[1, 2, 3], [4, 2, 1]],
         [("a", "bigint"), ("b", "bigint"), ("c", "bigint")],
     )
-    out = df.with_column("min_val", rs.least([rs.col("a"), rs.col("b"), rs.col("c")]))  # type: ignore[arg-type]
+    out = df.with_column(
+        "min_val",
+        rs.least(rs.col("a"), rs.col("b"), rs.col("c")),
+    )
     rows = out.collect()
     assert rows[0]["min_val"] == 1
     assert rows[1]["min_val"] == 1


### PR DESCRIPTION
## Summary
Fixes [#344](https://github.com/eddiethedean/robin-sparkless/issues/344): `greatest()` and `least()` now accept multiple column arguments (variadic), matching PySpark.

## Changes
- **Python bindings** (`src/python/mod.rs`): Use `#[pyo3(signature = (*cols))]` and `PyTuple` so `F.greatest(col("a"), col("b"), col("c"))` and `F.least(...)` work instead of raising `TypeError: py_greatest() takes 1 positional arguments but 3 were given`.
- **Tests**: `test_greatest` and `test_least` in `test_pyspark_port_extracted.py` updated to use the variadic form (no list wrapper).

## Verification
- `pytest tests/python/test_pyspark_port_extracted.py::test_greatest tests/python/test_pyspark_port_extracted.py::test_least` passes.
- Rust `greatest`/`least` in `src/functions.rs` already supported multiple columns; only the Python API needed to accept `*args`.

Made with [Cursor](https://cursor.com)