### PR TITLE
Fix #353: join on accept Column expression(s) (PySpark parity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **#352 – group_by and order_by accept Column expressions (PySpark parity)** — `DataFrame.group_by(cols)` now accepts a single column name (str), a single Column (e.g. `group_by(col("dept"))`), or a list/tuple of str or Column. `DataFrame.order_by(cols)` now accepts a single Column or list of Column (treated as ascending), in addition to existing str, SortOrder, and list of SortOrder. Enables PySpark-style `df.groupBy(F.col("dept")).agg(F.sum(F.col("salary")))` and `df.orderBy(col("x"))`. Fixes #352.
+- **#353 – join on accept Column expression(s) (PySpark parity)** — `DataFrame.join(other, on=...)` now accepts `on` as a single Column (e.g. `join(right, col("id"))`) or list/tuple of str or Column, in addition to existing str or list/tuple of str. Enables PySpark-style `left.join(right, F.col("id"))`. Fixes #353.
 
 ### Planned
 

--- a/robin_sparkless.pyi
+++ b/robin_sparkless.pyi
@@ -164,7 +164,7 @@ class DataFrame:
     def join(
         self,
         other: DataFrame,
-        on: str | list[str] | tuple[str, ...],
+        on: str | list[str] | tuple[str, ...] | Column | list[Column],
         how: str = "inner",
     ) -> DataFrame: ...
     def drop(self, cols: list[str]) -> DataFrame: ...

--- a/tests/python/test_issue_353_join_on_accept_column.py
+++ b/tests/python/test_issue_353_join_on_accept_column.py
@@ -1,0 +1,47 @@
+"""
+Tests for #353: join on accept Column expression(s) (PySpark parity).
+
+PySpark's DataFrame.join(other, on=...) accepts on as a Column or list of column names.
+"""
+
+from __future__ import annotations
+
+import robin_sparkless as rs
+
+
+def _spark() -> rs.SparkSession:
+    return rs.SparkSession.builder().app_name("issue_353").get_or_create()
+
+
+def test_join_on_column() -> None:
+    """left.join(right, col("id")) works (PySpark parity)."""
+    spark = _spark()
+    left = spark.createDataFrame([{"id": 1, "v": 10}], [("id", "int"), ("v", "int")])
+    right = spark.createDataFrame([{"id": 1, "w": 20}], [("id", "int"), ("w", "int")])
+    result = left.join(right, rs.col("id")).collect()
+    assert result == [{"id": 1, "v": 10, "w": 20}]
+
+
+def test_join_on_list_of_columns() -> None:
+    """left.join(right, [col("a"), col("b")]) works."""
+    spark = _spark()
+    left = spark.createDataFrame(
+        [{"a": 1, "b": 2, "v": 10}],
+        [("a", "int"), ("b", "int"), ("v", "int")],
+    )
+    right = spark.createDataFrame(
+        [{"a": 1, "b": 2, "w": 20}],
+        [("a", "int"), ("b", "int"), ("w", "int")],
+    )
+    result = left.join(right, [rs.col("a"), rs.col("b")]).collect()
+    assert result == [{"a": 1, "b": 2, "v": 10, "w": 20}]
+
+
+def test_join_on_str_still_works() -> None:
+    """join(right, "id") and join(right, ["id"]) still work."""
+    spark = _spark()
+    left = spark.createDataFrame([{"id": 1, "v": 10}], [("id", "int"), ("v", "int")])
+    right = spark.createDataFrame([{"id": 1, "w": 20}], [("id", "int"), ("w", "int")])
+    r1 = left.join(right, "id").collect()
+    r2 = left.join(right, ["id"]).collect()
+    assert r1 == r2 == [{"id": 1, "v": 10, "w": 20}]

--- a/tests/python/test_robin_sparkless.py
+++ b/tests/python/test_robin_sparkless.py
@@ -1093,9 +1093,7 @@ def test_join_on_invalid_type_raises() -> None:
     df1 = spark.createDataFrame([{"id": 1}], [("id", "bigint")])
     df2 = spark.createDataFrame([{"id": 1}], [("id", "bigint")])
     for invalid in (42, None, 3.14):
-        with pytest.raises(
-            TypeError, match="join 'on' must be str or list/tuple of str"
-        ):
+        with pytest.raises(TypeError, match="join 'on' must be str"):
             df1.join(df2, on=invalid, how="inner")  # type: ignore[arg-type]
 
 


### PR DESCRIPTION
Closes #353.

**Summary**
PySpark's `DataFrame.join(other, on=...)` accepts `on` as a Column expression or list of column names. Robin-sparkless previously required `on` to be str or list/tuple of str only, causing `TypeError` when Column was passed.

**Changes**
- **join(other, on=...)** now accepts `on` as:
  - Single `str` (e.g. `join(right, "id")`) — unchanged
  - Single `Column` (e.g. `join(right, rs.col("id"))`) — column name is taken from `Column.name()` for equi-join
  - List or tuple of `str` or `Column` (e.g. `join(right, [rs.col("a"), rs.col("b")])`)
- **Implementation:** `py_join_on_to_column_names()` parses `on` into `Vec<String>`; `JoinOn` `FromPyObject` uses it.
- **Stubs:** `robin_sparkless.pyi` updated for `on: str | list[str] | tuple[str, ...] | Column | list[Column]`.
- **Tests:** `test_issue_353_join_on_accept_column.py` — join with `col("id")`, list of Columns, and str still works. `test_join_on_invalid_type_raises` match updated for new error message.
- **CHANGELOG:** #353 entry under Unreleased.

`make check-full` passes.

Made with [Cursor](https://cursor.com)