### PR TITLE
[Parity] Row/result use column alias as key (fixes #364)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **#364 – Row/result use column alias as key (PySpark parity)** — `collect()` Row objects use the column alias as the key when present (e.g. `df.select(rs.lit(42).alias("map_col")).collect()` → `rows[0]["map_col"] == 42`). Regression test added. Fixes #364.
 - **#362 – SQL: support DROP TABLE / DROP VIEW (PySpark parity)** — `spark.sql("DROP TABLE IF EXISTS my_schema.my_table")` and `DROP TABLE name` / `DROP VIEW name` are now supported. Removes the table/view from the session catalog (temp views and saved tables). Qualified name `global_temp.xyz` drops from the global temp view catalog. Returns empty DataFrame. Fixes #362.
 - **#361 – dropDuplicates(subset=[...]) (PySpark parity)** — `DataFrame.drop_duplicates(subset=None)` and `dropDuplicates(subset=None)` are now supported; both delegate to `distinct(subset=...)`. When subset is provided, one row per distinct key in those columns is kept. Fixes #361.
 - **#360 – DataFrame.na.replace() (PySpark parity)** — `df.na.replace(to_replace, value, subset=None)` replaces values in columns. Supports scalar to_replace and value (None, int, float, bool, str). When subset is provided, only those columns are updated; otherwise all columns. Fixes #360.

--- a/tests/python/test_issue_364_row_alias_key.py
+++ b/tests/python/test_issue_364_row_alias_key.py
@@ -1,0 +1,34 @@
+"""
+Tests for #364: Row/result use column alias as key (PySpark parity).
+
+After df.select(expr.alias("map_col")), collect() Row objects must use the alias
+as the key so row["map_col"] works. PySpark uses output column names (aliases) as keys.
+"""
+
+from __future__ import annotations
+
+
+def test_row_uses_alias_as_key_issue_repro() -> None:
+    """rows[0]['map_col'] works when select(lit(42).alias('map_col')) (issue repro)."""
+    import robin_sparkless as rs
+
+    spark = rs.SparkSession.builder().app_name("issue_364").get_or_create()
+    df = spark.createDataFrame([{"x": 1}], [("x", "int")])
+    rows = df.select(rs.lit(42).alias("map_col")).collect()
+    assert list(rows[0].keys()) == ["map_col"]
+    assert rows[0]["map_col"] == 42
+
+
+def test_row_keys_match_select_aliases() -> None:
+    """Multiple aliased columns: row keys are the aliases."""
+    import robin_sparkless as rs
+
+    spark = rs.SparkSession.builder().app_name("issue_364").get_or_create()
+    df = spark.createDataFrame([(1, "a")], ["id", "name"])
+    rows = df.select(
+        rs.col("id").alias("k"),
+        rs.col("name").alias("v"),
+    ).collect()
+    assert list(rows[0].keys()) == ["k", "v"]
+    assert rows[0]["k"] == 1
+    assert rows[0]["v"] == "a"


### PR DESCRIPTION
## Summary
Ensures `collect()` Row objects use the column **alias** as the key when one is set, for PySpark parity.

After `df.select(expr.alias("map_col"))`, PySpark uses `row["map_col"]`. This PR adds a regression test so we never use a different key (e.g. expression string or literal name).

## Changes
- **tests/python/test_issue_364_row_alias_key.py** — Asserts `rows[0]["map_col"] == 42` for `df.select(rs.lit(42).alias("map_col")).collect()` and that multiple aliased columns yield row keys `["k", "v"]`.
- **CHANGELOG.md** — Document #364 under Unreleased.

## Verification
Current behavior already uses the alias as the key (Polars `select` with `Expr::Alias` preserves the name). The new tests lock this in.

Closes #364.

Made with [Cursor](https://cursor.com)