### PR TITLE
[Parity] struct() accept multiple Column arguments (fixes #363)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **#363 – struct() accept multiple Column arguments (PySpark parity)** — `struct(*cols)` now accepts variadic Column arguments like PySpark `F.struct(col1, col2, ...)`. Previously only a single list argument was accepted. Enables `df.select(rs.struct(rs.col("a"), rs.col("b")).alias("s")).collect()`. Fixes #363.
 - **#364 – Row/result use column alias as key (PySpark parity)** — `collect()` Row objects use the column alias as the key when present (e.g. `df.select(rs.lit(42).alias("map_col")).collect()` → `rows[0]["map_col"] == 42`). Regression test added. Fixes #364.
 - **#362 – SQL: support DROP TABLE / DROP VIEW (PySpark parity)** — `spark.sql("DROP TABLE IF EXISTS my_schema.my_table")` and `DROP TABLE name` / `DROP VIEW name` are now supported. Removes the table/view from the session catalog (temp views and saved tables). Qualified name `global_temp.xyz` drops from the global temp view catalog. Returns empty DataFrame. Fixes #362.
 - **#361 – dropDuplicates(subset=[...]) (PySpark parity)** — `DataFrame.drop_duplicates(subset=None)` and `dropDuplicates(subset=None)` are now supported; both delegate to `distinct(subset=...)`. When subset is provided, one row per distinct key in those columns is kept. Fixes #361.

--- a/tests/python/test_issue_363_struct_variadic.py
+++ b/tests/python/test_issue_363_struct_variadic.py
@@ -1,0 +1,41 @@
+"""
+Tests for #363: struct() accept multiple Column arguments (PySpark parity).
+
+PySpark F.struct(col1, col2, ...) accepts variadic Column arguments.
+Robin-sparkless struct() now accepts the same: struct(col1, col2, ...).
+"""
+
+from __future__ import annotations
+
+
+def test_struct_multiple_columns_issue_repro() -> None:
+    """struct(col("a"), col("b")) works (issue repro)."""
+    import robin_sparkless as rs
+
+    spark = rs.SparkSession.builder().app_name("issue_363").get_or_create()
+    df = spark.createDataFrame([{"a": 1, "b": 2}], [("a", "int"), ("b", "int")])
+    rows = df.select(rs.struct(rs.col("a"), rs.col("b")).alias("s")).collect()
+    assert list(rows[0].keys()) == ["s"]
+    assert rows[0]["s"] == {"a": 1, "b": 2}
+
+
+def test_struct_single_column() -> None:
+    """struct(col("x")) produces struct with one field."""
+    import robin_sparkless as rs
+
+    spark = rs.SparkSession.builder().app_name("issue_363").get_or_create()
+    df = spark.createDataFrame([{"x": 10}], [("x", "int")])
+    rows = df.select(rs.struct(rs.col("x")).alias("s")).collect()
+    assert rows[0]["s"] == {"x": 10}
+
+
+def test_struct_three_columns() -> None:
+    """struct(col1, col2, col3) produces struct with three fields."""
+    import robin_sparkless as rs
+
+    spark = rs.SparkSession.builder().app_name("issue_363").get_or_create()
+    df = spark.createDataFrame([(1, "a", 3.0)], ["i", "s", "f"])
+    rows = df.select(
+        rs.struct(rs.col("i"), rs.col("s"), rs.col("f")).alias("s")
+    ).collect()
+    assert rows[0]["s"] == {"i": 1, "s": "a", "f": 3.0}


### PR DESCRIPTION
## Summary
PySpark `F.struct(col1, col2, ...)` accepts variadic Column arguments. Robin-sparkless `struct()` previously accepted only a single list argument, causing `TypeError: py_struct() takes 1 positional arguments but 2 were given` when calling `rs.struct(rs.col("a"), rs.col("b"))`.

## Changes
- **src/python/mod.rs** — `py_struct`: use `#[pyo3(signature = (*cols))]` and accept `&Bound<'_, PyTuple>`, extracting Column refs like `py_coalesce`. `struct(col1, col2, ...)` now works from Python.
- **tests/python/test_issue_363_struct_variadic.py** — Tests for single column, two columns (issue repro), and three columns.
- **CHANGELOG.md** — Document #363 under Unreleased.

## Verification
`df.select(rs.struct(rs.col("a"), rs.col("b")).alias("s")).collect()` → `rows[0]["s"] == {"a": 1, "b": 2}`.

Closes #363.

Made with [Cursor](https://cursor.com)