### PR TITLE
[Parity] Comparison coercion string/numeric and date/string (column-to-column) (fixes #366)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **#366 – Comparison coercion string/numeric and date/string (column-to-column)** — `df.filter(col("id") == col("label"))` when `id` is numeric and `label` is string now coerces (string parsed via `try_to_number`) instead of raising "cannot compare string with numeric type". Column-to-column comparisons in filter now use `coerce_for_pyspark_comparison` when both sides are columns with differing types (string–numeric, date/datetime–string). Fixes #366.
 - **#365 – regexp_extract support lookahead/lookbehind (PySpark parity)** — Patterns with `(?=...)`, `(?!...)`, `(?<=...)`, `(?<!...)` are now supported via the `fancy-regex` crate. Polars’ built-in regex does not support lookaround; when detected, extraction uses a UDF. Enables `df.select(rs.regexp_extract(rs.col("s"), r"(?<=hello )\w+", 0))` → `"world"`. Fixes #365.
 - **#363 – struct() accept multiple Column arguments (PySpark parity)** — `struct(*cols)` now accepts variadic Column arguments like PySpark `F.struct(col1, col2, ...)`. Previously only a single list argument was accepted. Enables `df.select(rs.struct(rs.col("a"), rs.col("b")).alias("s")).collect()`. Fixes #363.
 - **#364 – Row/result use column alias as key (PySpark parity)** — `collect()` Row objects use the column alias as the key when present (e.g. `df.select(rs.lit(42).alias("map_col")).collect()` → `rows[0]["map_col"] == 42`). Regression test added. Fixes #364.

--- a/tests/python/test_issue_366_comparison_coercion_col_col.py
+++ b/tests/python/test_issue_366_comparison_coercion_col_col.py
@@ -1,0 +1,53 @@
+"""
+Tests for #366: Comparison coercion string/numeric and date/string (column-to-column).
+
+PySpark allows col("id") == col("label") when id is int and label is string;
+it coerces (string parsed to number). Robin-sparkless previously raised
+"cannot compare string with numeric type". Now column-to-column comparisons
+in filter use coerce_for_pyspark_comparison when types differ.
+"""
+
+from __future__ import annotations
+
+
+def test_col_col_string_numeric_issue_repro() -> None:
+    """col('id') == col('label') where id is int, label is string (issue repro)."""
+    import robin_sparkless as rs
+
+    spark = rs.SparkSession.builder().app_name("issue_366").get_or_create()
+    df = spark.createDataFrame(
+        [{"id": 1, "label": "1"}],
+        [("id", "int"), ("label", "string")],
+    )
+    rows = df.filter(rs.col("id") == rs.col("label")).collect()
+    assert len(rows) == 1
+    assert rows[0]["id"] == 1
+    assert rows[0]["label"] == "1"
+
+
+def test_col_col_string_numeric_no_match() -> None:
+    """col('n') == col('s') when s is non-numeric string: no match."""
+    import robin_sparkless as rs
+
+    spark = rs.SparkSession.builder().app_name("issue_366").get_or_create()
+    df = spark.createDataFrame(
+        [{"n": 42, "s": "abc"}, {"n": 1, "s": "1"}],
+        [("n", "int"), ("s", "string")],
+    )
+    rows = df.filter(rs.col("n") == rs.col("s")).collect()
+    assert len(rows) == 1
+    assert rows[0]["n"] == 1
+    assert rows[0]["s"] == "1"
+
+
+def test_col_col_numeric_string_reversed() -> None:
+    """col('label') == col('id') (string col first) also coerces."""
+    import robin_sparkless as rs
+
+    spark = rs.SparkSession.builder().app_name("issue_366").get_or_create()
+    df = spark.createDataFrame(
+        [{"id": 99, "label": "99"}],
+        [("id", "int"), ("label", "string")],
+    )
+    rows = df.filter(rs.col("label") == rs.col("id")).collect()
+    assert len(rows) == 1


### PR DESCRIPTION
## Summary
PySpark allows `df.filter(col("id") == col("label"))` when `id` is numeric and `label` is string—it coerces (string parsed to number). Robin-sparkless previously raised "cannot compare string with numeric type".

## Changes
- **src/dataframe/mod.rs** — In `coerce_string_numeric_comparisons`, add a root-level branch for **column-to-column** comparisons: when both sides are `Expr::Column` and types differ, look up column dtypes from the schema and call `coerce_for_pyspark_comparison`. This covers string–numeric and date/datetime–string (same logic as col-vs-literal).
- **tests/python/test_issue_366_comparison_coercion_col_col.py** — Repro, no-match, and reversed-order tests.
- **CHANGELOG.md** — Document #366 under Unreleased.

## Verification
`df.filter(rs.col("id") == rs.col("label"))` with id=int, label=string → returns matching row (e.g. id=1, label="1").

Closes #366.

Made with [Cursor](https://cursor.com)