### PR TITLE
Fix #368: Duplicate column names in agg result (PySpark parity)

### DIFF
--- a/src/dataframe/aggregations.rs
+++ b/src/dataframe/aggregations.rs
@@ -794,7 +794,7 @@ impl CubeRollupData {
         for subset in subsets {
             if subset.is_empty() {
                 // Single row: no grouping keys, one row of aggregates over full table
-                let lf = self.df.clone().lazy().select(aggregations.to_vec());
+                let lf = self.df.clone().lazy().select(&aggregations);
                 let mut part = lf.collect()?;
                 let n = part.height();
                 for gc in &self.grouping_cols {
@@ -817,7 +817,7 @@ impl CubeRollupData {
                     .clone()
                     .lazy()
                     .group_by(subset.iter().map(|s| col(s.as_str())).collect::<Vec<_>>());
-                let mut part = grouped.agg(aggregations.to_vec()).collect()?;
+                let mut part = grouped.agg(aggregations.clone()).collect()?;
                 part = reorder_groupby_columns(&mut part, &subset)?;
                 let n = part.height();
                 for gc in &self.grouping_cols {

--- a/src/dataframe/mod.rs
+++ b/src/dataframe/mod.rs
@@ -617,7 +617,13 @@ impl DataFrame {
             .map(|e| self.resolve_expr_column_names(e))
             .collect::<Result<Vec<_>, _>>()?;
         let disambiguated = aggregations::disambiguate_agg_output_names(resolved);
-        let pl_df = self.df.as_ref().clone().lazy().select(disambiguated).collect()?;
+        let pl_df = self
+            .df
+            .as_ref()
+            .clone()
+            .lazy()
+            .select(disambiguated)
+            .collect()?;
         Ok(Self::from_polars_with_options(pl_df, self.case_sensitive))
     }
 

--- a/tests/python/test_issue_368_duplicate_agg_column_names.py
+++ b/tests/python/test_issue_368_duplicate_agg_column_names.py
@@ -11,10 +11,16 @@ def test_group_by_agg_sum_avg_same_column_no_duplicate_error() -> None:
         [("a", 10), ("a", 20)],
         ["g", "value"],
     )
-    result = df.group_by("g").agg([
-        rs.sum(rs.col("value")),
-        rs.avg(rs.col("value")),
-    ]).collect()
+    result = (
+        df.group_by("g")
+        .agg(
+            [
+                rs.sum(rs.col("value")),
+                rs.avg(rs.col("value")),
+            ]
+        )
+        .collect()
+    )
     assert len(result) == 1
     row = result[0]
     assert row["g"] == "a"


### PR DESCRIPTION
## Summary

When multiple aggregations produce the same output column name (e.g. `groupBy("g").agg(sum("value"), avg("value"))` where both sum and avg use the column "value"), Polars raises `duplicate: column with name 'value' has more than one occurrence`. PySpark allows this and typically produces distinct names (e.g. `sum(value)`, `avg(value)`) or disambiguates.

## Solution

Disambiguate duplicate agg output names by suffixing with `_1`, `_2`, … (same approach as #213 for `select`):

- **`disambiguate_agg_output_names(aggregations)`** — Uses `polars_plan::utils::expr_output_name` to get each expression’s output name; when a name is seen more than once, later occurrences get `_1`, `_2`, etc. via `.alias()`.
- **GroupedData::agg()** — Runs aggregations through `disambiguate_agg_output_names` before `lazy_grouped.agg(...)`.
- **DataFrame::agg()** (global agg) — Same disambiguation before `lazy().select(...)`.
- **CubeRollupData::agg()** — Same disambiguation at the start so all uses of the agg list have unique names.

## Testing

- `tests/python/test_issue_368_duplicate_agg_column_names.py` — `group_by("g").agg([sum(col("value")), avg(col("value"))])` and global `df.agg([sum(col("x")), avg(col("x"))])` no longer raise; result columns are disambiguated (e.g. `value`, `value_1`).
- Existing Rust tests and parity tests pass.

Closes #368.

Made with [Cursor](https://cursor.com)