### PR TITLE
Support Decimal type in schema (fixes #371)

### DIFF
--- a/src/functions.rs
+++ b/src/functions.rs
@@ -76,8 +76,12 @@ pub fn desc_nulls_last(column: &Column) -> SortOrder {
 // -----------------------------------------------------------------------------
 
 /// Parse PySpark-like type name to Polars DataType.
+/// Decimal(precision, scale) is mapped to Float64 for schema parity (Polars dtype-decimal not enabled).
 pub fn parse_type_name(name: &str) -> Result<DataType, String> {
     let s = name.trim().to_lowercase();
+    if s.starts_with("decimal(") && s.contains(')') {
+        return Ok(DataType::Float64);
+    }
     Ok(match s.as_str() {
         "int" | "integer" => DataType::Int32,
         "long" | "bigint" => DataType::Int64,

--- a/tests/python/test_issue_371_decimal_type.py
+++ b/tests/python/test_issue_371_decimal_type.py
@@ -1,0 +1,46 @@
+"""
+Tests for #371: Decimal type support (PySpark parity).
+
+PySpark supports DecimalType (e.g. Decimal(10,0), Decimal(10,2)) in schema.
+Robin-sparkless now accepts Decimal(p,s) in schema and maps to Float64 for storage.
+"""
+
+from __future__ import annotations
+
+import robin_sparkless as rs
+
+
+def _spark() -> rs.SparkSession:
+    return rs.SparkSession.builder().app_name("issue_371").get_or_create()
+
+
+def test_decimal_schema_create_dataframe() -> None:
+    """createDataFrame with Decimal(10,2) schema works (issue repro)."""
+    spark = _spark()
+    create_df = getattr(spark, "create_dataframe_from_rows", spark.createDataFrame)
+    df = create_df([{"d": 1.5}], [("d", "Decimal(10,2)")])
+    out = df.collect()
+    assert len(out) == 1
+    assert out[0]["d"] == 1.5
+
+
+def test_decimal_schema_lowercase() -> None:
+    """decimal(10,0) (lowercase) is accepted."""
+    spark = _spark()
+    df = spark.createDataFrame([{"x": 42.0}], [("x", "decimal(10,0)")])
+    rows = df.collect()
+    assert rows[0]["x"] == 42.0
+
+
+def test_decimal_multiple_rows() -> None:
+    """Decimal column with multiple rows."""
+    spark = _spark()
+    df = spark.createDataFrame(
+        [{"d": 1.5}, {"d": 2.25}, {"d": None}],
+        [("d", "Decimal(10,2)")],
+    )
+    out = df.collect()
+    assert len(out) == 3
+    assert out[0]["d"] == 1.5
+    assert out[1]["d"] == 2.25
+    assert out[2]["d"] is None


### PR DESCRIPTION
Closes #371

**Summary**
- Accept `Decimal(precision, scale)` in schema (e.g. `Decimal(10,2)`, `decimal(10,0)`) and map to **Float64** for storage (Polars `dtype-decimal` feature not enabled).
- **functions.rs**: `parse_type_name` recognizes `decimal(p,s)` and returns `DataType::Float64`.
- **session.rs**: `is_decimal_type_str()`, `json_type_str_to_polars`, `create_dataframe_from_rows`, and `json_value_to_series_single` handle Decimal type strings.
- **Tests**: `tests/python/test_issue_371_decimal_type.py` — createDataFrame with Decimal(10,2), lowercase decimal(10,0), and multiple rows including null.

**Issue repro (now passes)**
```python
import robin_sparkless as rs
spark = rs.SparkSession.builder().app_name("repro").get_or_create()
create_df = getattr(spark, "create_dataframe_from_rows", spark.createDataFrame)
df = create_df([{"d": 1.5}], [("d", "Decimal(10,2)")])
df.collect()  # no longer "unknown type name"
```

Made with [Cursor](https://cursor.com)