### PR TITLE
SparkSession.builder() callable (fixes #410)

### DIFF
--- a/src/python/session.rs
+++ b/src/python/session.rs
@@ -1137,6 +1137,12 @@ impl PySparkSessionBuilder {
         slf
     }
 
+    /// Make builder callable so that SparkSession.builder() works (PySpark parity).
+    /// Returns self for chaining.
+    fn __call__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
     /// Build and return a SparkSession with the current builder configuration.
     ///
     /// The returned session is stored as the default session for df.create_or_replace_temp_view(name)

--- a/tests/python/test_issue_410_builder_callable.py
+++ b/tests/python/test_issue_410_builder_callable.py
@@ -1,0 +1,17 @@
+"""
+Tests for #410: SparkSession.builder() callable (PySpark parity).
+
+PySpark allows SparkSession.builder() (with parentheses); Robin should accept both.
+"""
+
+from __future__ import annotations
+
+import robin_sparkless as rs
+
+
+def test_builder_callable_returns_session() -> None:
+    """SparkSession.builder().app_name("x").get_or_create() works."""
+    spark = rs.SparkSession.builder().app_name("issue_410").get_or_create()
+    assert spark is not None
+    df = spark.createDataFrame([(1,)], ["a"])
+    assert len(df.collect()) == 1


### PR DESCRIPTION
Closes #410

- PySparkSessionBuilder.__call__ returns self so builder() works
- Test: test_issue_410_builder_callable.py

Made with [Cursor](https://cursor.com)