### PR TITLE
fix(#383): WhenThen chained .when() and .otherwise()

### DIFF
--- a/robin_sparkless.pyi
+++ b/robin_sparkless.pyi
@@ -388,12 +388,20 @@ class WhenThen:
     def otherwise(self, value: Column) -> Column: ...
 
 class WhenBuilder:
-    """Result of when(condition). Chain .then(value).otherwise(default)."""
+    """Result of when(condition). Chain .then(value).otherwise(default) or .then(value).when(cond).then(val)…"""
 
     def then(self, value: Column) -> ThenBuilder: ...
 
 class ThenBuilder:
+    """Result of when(cond).then(val). Chain .when(cond).then(val) for more branches or .otherwise(default)."""
+
+    def when(self, condition: Column) -> ChainedWhenBuilder: ...
     def otherwise(self, value: Column) -> Column: ...
+
+class ChainedWhenBuilder:
+    """Result of ThenBuilder.when(condition). Call .then(value) to add the branch (returns ThenBuilder)."""
+
+    def then(self, value: Column) -> ThenBuilder: ...
 
 class GroupedData:
     def count(self) -> DataFrame: ...

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -72,7 +72,8 @@ pub(crate) use dataframe::{
     PyGroupedData, PyPivotedGroupedData,
 };
 pub(crate) use order::{
-    PyDenseRank, PyRowNumber, PySortOrder, PyThenBuilder, PyWhenBuilder, PyWhenThen, PyWindow,
+    PyChainedWhenBuilder, PyDenseRank, PyRowNumber, PySortOrder, PyThenBuilder, PyWhenBuilder,
+    PyWhenThen, PyWindow,
 };
 use session::parse_return_type;
 pub(crate) use session::{
@@ -411,6 +412,7 @@ fn robin_sparkless(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyWhenThen>()?;
     m.add_class::<PyWhenBuilder>()?;
     m.add_class::<PyThenBuilder>()?;
+    m.add_class::<PyChainedWhenBuilder>()?;
     m.add_class::<PyGroupedData>()?;
     m.add_class::<PyPivotedGroupedData>()?;
     m.add_class::<PyCubeRollupData>()?;

--- a/tests/python/test_issue_383_when_then_chained.py
+++ b/tests/python/test_issue_383_when_then_chained.py
@@ -1,0 +1,63 @@
+"""Tests for issue #383: WhenThen chained .when() and .otherwise()."""
+
+from __future__ import annotations
+
+import robin_sparkless as rs
+
+
+def test_when_then_when_then_otherwise() -> None:
+    """when(a).then(x).when(b).then(y).otherwise(z) evaluates first match."""
+    spark = rs.SparkSession.builder().app_name("issue_383").get_or_create()
+    df = spark.createDataFrame(
+        [(1, "a"), (2, "b"), (3, "c"), (4, "d")], ["id", "label"]
+    )
+    out = df.with_column(
+        "tier",
+        rs.when(rs.col("id").eq(rs.lit(1)))
+        .then(rs.lit("first"))
+        .when(rs.col("id").eq(rs.lit(2)))
+        .then(rs.lit("second"))
+        .when(rs.col("id").eq(rs.lit(3)))
+        .then(rs.lit("third"))
+        .otherwise(rs.lit("other")),
+    )
+    rows = out.collect()
+    assert len(rows) == 4
+    by_id = {r["id"]: r["tier"] for r in rows}
+    assert by_id[1] == "first"
+    assert by_id[2] == "second"
+    assert by_id[3] == "third"
+    assert by_id[4] == "other"
+
+
+def test_when_then_otherwise_single_branch_unchanged() -> None:
+    """Single when().then().otherwise() still works as before."""
+    spark = rs.SparkSession.builder().app_name("issue_383").get_or_create()
+    df = spark.createDataFrame([(10,), (25,)], ["age"])
+    out = df.with_column(
+        "group",
+        rs.when(rs.col("age").gt(rs.lit(18)))
+        .then(rs.lit("adult"))
+        .otherwise(rs.lit("minor")),
+    )
+    rows = out.collect()
+    assert len(rows) == 2
+    assert rows[0]["group"] == "minor"
+    assert rows[1]["group"] == "adult"
+
+
+def test_chained_when_in_select() -> None:
+    """Chained when/then in select()."""
+    spark = rs.SparkSession.builder().app_name("issue_383").get_or_create()
+    df = spark.createDataFrame([(1,), (2,), (3,)], ["x"])
+    out = df.select(
+        rs.col("x"),
+        rs.when(rs.col("x").eq(rs.lit(1)))
+        .then(rs.lit("one"))
+        .when(rs.col("x").eq(rs.lit(2)))
+        .then(rs.lit("two"))
+        .otherwise(rs.lit("many"))
+        .alias("word"),
+    )
+    rows = out.collect()
+    assert [r["word"] for r in rows] == ["one", "two", "many"]


### PR DESCRIPTION
Closes #383

- ThenBuilder.when(condition).then(value) chains multiple when-then clauses (PySpark parity).
- Rust: ChainedWhenBuilder, WhenThenState (Single/Chained), boxed enum for clippy.
- Python: PyChainedWhenBuilder, PyThenBuilder.when() returns it, .then() returns PyThenBuilder.
- pyi: ChainedWhenBuilder, ThenBuilder.when(), docstrings.
- Tests: test_issue_383_when_then_chained.py (chained branches, single branch unchanged, select).