### PR TITLE
fix(#386): unionByName column name case matching

### DIFF
--- a/src/dataframe/transformations.rs
+++ b/src/dataframe/transformations.rs
@@ -266,10 +266,12 @@ pub fn union_by_name(
     } else {
         left_names.clone()
     };
+    // Alias every expression to the canonical name `c` so that when left has "ID" and right has "id"
+    // (case-insensitive match), both sides produce the same column name in the result (#386).
     let left_exprs: Vec<Expr> = all_columns
         .iter()
         .map(|c| match resolve(&left_names, c.as_str()) {
-            Some(r) => col(r.as_str()),
+            Some(r) => col(r.as_str()).alias(c.as_str()),
             None => {
                 let dtype = resolve(&right_names, c.as_str())
                     .and_then(|r| right_df.column(r.as_str()).ok())
@@ -284,7 +286,7 @@ pub fn union_by_name(
     let mut right_exprs: Vec<Expr> = Vec::with_capacity(all_columns.len());
     for c in &all_columns {
         let expr = match resolve(&right_names, c.as_str()) {
-            Some(r) => col(r.as_str()),
+            Some(r) => col(r.as_str()).alias(c.as_str()),
             None if allow_missing_columns => {
                 let dtype = resolve(&left_names, c.as_str())
                     .and_then(|r| left_df.column(r.as_str()).ok())

--- a/tests/python/test_issue_386_union_by_name_case.py
+++ b/tests/python/test_issue_386_union_by_name_case.py
@@ -1,0 +1,33 @@
+"""Tests for issue #386: unionByName column name case matching."""
+
+from __future__ import annotations
+
+import robin_sparkless as rs
+
+
+def test_union_by_name_case_insensitive_matching() -> None:
+    """When session is case-insensitive, union_by_name matches 'ID' with 'id' and produces one column."""
+    spark = rs.SparkSession.builder().app_name("issue_386").get_or_create()
+    # Default is case-insensitive; left has "ID", right has "id"
+    left = spark.createDataFrame([(1,)], ["ID"])
+    right = spark.createDataFrame([(2,)], ["id"])
+    out = left.union_by_name(right, allow_missing_columns=True)
+    rows = out.collect()
+    assert len(rows) == 2
+    # Result should have one column (name from left, "ID")
+    assert len(rows[0]) == 1
+    names = list(rows[0].keys())
+    assert names == ["ID"] or names == ["id"]
+    assert rows[0][names[0]] == 1 and rows[1][names[0]] == 2
+
+
+def test_union_by_name_same_case() -> None:
+    """union_by_name with same column names works as before."""
+    spark = rs.SparkSession.builder().app_name("issue_386").get_or_create()
+    left = spark.createDataFrame([(1, "a")], ["id", "label"])
+    right = spark.createDataFrame([(2, "b")], ["id", "label"])
+    out = left.union_by_name(right)
+    rows = out.collect()
+    assert len(rows) == 2
+    assert rows[0]["id"] == 1 and rows[0]["label"] == "a"
+    assert rows[1]["id"] == 2 and rows[1]["label"] == "b"


### PR DESCRIPTION
Closes #386

- Alias both left and right expressions to the canonical column name from all_columns so that when left has "ID" and right has "id" (case-insensitive match), concat produces one column instead of two.
- transformations.rs: col(r).alias(c.as_str()) for both left_exprs and right_exprs when resolving by name.
- Tests: test_issue_386_union_by_name_case.py (case-insensitive ID/id, same-case sanity).