### PR TITLE
fix(#396): selectExpr and expr() SQL string

### DIFF
--- a/robin_sparkless.pyi
+++ b/robin_sparkless.pyi
@@ -154,9 +154,15 @@ class DataFrame:
     ) -> DataFrame: ...  # func(row_dict) -> iterable of dicts; flattens
     def flatMap(self, func: Any) -> DataFrame: ...  # alias for flat_map
     def select(
-        self, *cols: str | Column | list[str] | list[Column] | tuple[Column, Column]
+        self,
+        *cols: str
+        | Column
+        | ExprStr
+        | list[str]
+        | list[Column]
+        | tuple[Column, Column],
     ) -> DataFrame: ...
-    def select_expr(self, exprs: list[str]) -> DataFrame: ...
+    def selectExpr(self, *exprs: str) -> DataFrame: ...
     def with_column(self, column_name: str, expr: _ColumnOperand) -> DataFrame: ...
     def with_columns(
         self, mapping: dict[str, Column] | list[tuple[str, Column]]
@@ -404,6 +410,12 @@ class Column:
         self, n: int, partition_by: list[str], descending: bool = False
     ) -> Column: ...
 
+class ExprStr:
+    """SQL expression string (from expr()). Use in select() or selectExpr(); requires sql feature."""
+
+    @property
+    def expr_sql(self) -> str: ...
+
 class SortOrder: ...
 
 class WhenThen:
@@ -500,6 +512,9 @@ class DataFrameWriter:
 # --- Module-level functions (expression builders return Column) ---
 
 def col(name: str) -> Column: ...
+def expr(
+    sql_string: str,
+) -> ExprStr: ...  # SQL expression for select(); requires sql feature
 def lit(value: None | int | float | bool | str | date | datetime) -> Column: ...
 def call_udf(name: str, *cols: Column | str) -> Column: ...
 def pandas_udf(

--- a/src/python/column.rs
+++ b/src/python/column.rs
@@ -79,6 +79,13 @@ pub struct PyColumn {
     pub inner: RsColumn,
 }
 
+/// Wrapper for SQL expression string returned by expr(). Resolved to Expr when used in select()/withColumn().
+#[cfg(feature = "sql")]
+#[pyclass(name = "ExprStr")]
+pub struct PyExprStr {
+    pub expr_sql: String,
+}
+
 #[pymethods]
 impl PyColumn {
     /// Return the column name for simple column references (e.g. ``col("x").name`` → ``"x"``).
@@ -1528,5 +1535,15 @@ impl PyColumn {
         PyColumn {
             inner: factorial(&self.inner),
         }
+    }
+}
+
+#[cfg(feature = "sql")]
+#[pymethods]
+impl PyExprStr {
+    /// The SQL expression string (e.g. "upper(Name)").
+    #[getter]
+    fn expr_sql(&self) -> &str {
+        &self.expr_sql
     }
 }

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -67,6 +67,8 @@ mod order;
 mod session;
 mod udf;
 pub(crate) use column::PyColumn;
+#[cfg(feature = "sql")]
+pub(crate) use column::PyExprStr;
 pub(crate) use dataframe::{
     PyCubeRollupData, PyDataFrame, PyDataFrameNa, PyDataFrameStat, PyDataFrameWriter,
     PyGroupedData, PyPivotedGroupedData,
@@ -404,6 +406,8 @@ fn robin_sparkless(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyDataFrameStat>()?;
     m.add_class::<PyDataFrameNa>()?;
     m.add_class::<PyColumn>()?;
+    #[cfg(feature = "sql")]
+    m.add_class::<PyExprStr>()?;
     m.add_class::<PyPosexplodeResult>()?;
     m.add_class::<PySortOrder>()?;
     m.add_class::<PyWindow>()?;
@@ -418,6 +422,8 @@ fn robin_sparkless(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyCubeRollupData>()?;
     m.add_class::<PyDataFrameWriter>()?;
     m.add("col", wrap_pyfunction!(py_col, m)?)?;
+    #[cfg(feature = "sql")]
+    m.add("expr", wrap_pyfunction!(py_expr, m)?)?;
     m.add("concat", wrap_pyfunction!(py_concat, m)?)?;
     m.add("concat_ws", wrap_pyfunction!(py_concat_ws, m)?)?;
     m.add("row_number", wrap_pyfunction!(py_row_number, m)?)?;
@@ -835,6 +841,15 @@ fn robin_sparkless(m: &Bound<'_, PyModule>) -> PyResult<()> {
 #[pyfunction]
 fn py_col(col: &str) -> PyColumn {
     PyColumn { inner: rs_col(col) }
+}
+
+/// SQL expression string for use in select()/withColumn(). PySpark expr(). Resolved at evaluation with DataFrame context.
+#[cfg(feature = "sql")]
+#[pyfunction]
+fn py_expr(expr_sql: &str) -> PyExprStr {
+    PyExprStr {
+        expr_sql: expr_sql.to_string(),
+    }
 }
 
 /// Call a registered UDF by name. PySpark: F.call_udf(udfName, *cols).

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -17,7 +17,7 @@ pub fn execute_sql(session: &SparkSession, query: &str) -> Result<DataFrame, Pol
 }
 
 pub use parser::parse_sql;
-pub use translator::translate;
+pub use translator::{expr_string_to_polars, translate};
 
 #[cfg(test)]
 mod tests {

--- a/tests/python/test_issue_396_select_expr_expr.py
+++ b/tests/python/test_issue_396_select_expr_expr.py
@@ -1,0 +1,38 @@
+"""Tests for issue #396: selectExpr and expr() SQL string."""
+
+from __future__ import annotations
+
+import robin_sparkless as rs
+
+
+def test_select_expr_sql_expressions() -> None:
+    """selectExpr accepts SQL expressions (e.g. 'Name', 'upper(Name) as u')."""
+    spark = rs.SparkSession.builder().app_name("issue_396").get_or_create()
+    df = spark.createDataFrame([("Alice",), ("Bob",)], ["Name"])
+    out = df.selectExpr("Name", "upper(Name) as u")
+    rows = out.collect()
+    assert len(rows) == 2
+    assert "Name" in rows[0] and "u" in rows[0]
+    assert rows[0]["u"] == "ALICE"
+    assert rows[1]["u"] == "BOB"
+
+
+def test_expr_in_select() -> None:
+    """expr(sql_string) returns ExprStr that resolves in select()."""
+    spark = rs.SparkSession.builder().app_name("issue_396").get_or_create()
+    df = spark.createDataFrame([("a",), ("b",)], ["x"])
+    out = df.select(rs.expr("upper(x) as up"))
+    rows = out.collect()
+    assert len(rows) == 2
+    assert rows[0]["up"] == "A"
+    assert rows[1]["up"] == "B"
+
+
+def test_select_expr_column_name_and_alias() -> None:
+    """selectExpr with simple column and 'col as alias'."""
+    spark = rs.SparkSession.builder().app_name("issue_396").get_or_create()
+    df = spark.createDataFrame([(1, 2)], ["a", "b"])
+    out = df.selectExpr("a", "b as b_col")
+    row = out.collect()[0]
+    assert row["a"] == 1
+    assert row["b_col"] == 2


### PR DESCRIPTION
Closes #396.

- **selectExpr(*exprs)**: When sql feature is on, parses and evaluates SQL expressions (e.g. `df.selectExpr("Name", "upper(Name) as u")`) by registering the DataFrame as a temp view and running `SELECT expr1, expr2, ... FROM view`. Exposed as `selectExpr` (PySpark name). Signature `(*exprs)` for variadic strings.
- **expr(sql_string)**: Returns `ExprStr`; when used in `select()`, resolves via `expr_string_to_polars` (parse `SELECT expr FROM __t`, convert first select item to Polars Expr with alias preserved). Requires sql feature and active session.
- **SQL**: `expr_string_to_polars` in sql/translator; exported from sql/mod. Preserves `AS alias` for `ExprWithAlias`.
- **pyi**: `expr()`, `ExprStr`, `selectExpr(*exprs)`, `select(..., ExprStr)`.
- Tests: `test_issue_396_select_expr_expr.py`.