### PR TITLE
fix(#397): struct field dot notation for select and col

### DIFF
--- a/src/python/dataframe.rs
+++ b/src/python/dataframe.rs
@@ -522,11 +522,9 @@ impl PyDataFrame {
                         exprs.push(col(c.as_str()));
                     }
                 } else {
-                    let resolved = self
-                        .inner
-                        .resolve_column_name(&name)
-                        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
-                    exprs.push(col(resolved.as_str()));
+                    // Push col(name); resolve_expr_column_names in select_exprs handles
+                    // case resolution and struct field dot notation (e.g. "StructValue.E1").
+                    exprs.push(col(name.as_str()));
                 }
             } else {
                 return Err(pyo3::exceptions::PyTypeError::new_err(

--- a/tests/python/test_issue_397_struct_field_dot_notation.py
+++ b/tests/python/test_issue_397_struct_field_dot_notation.py
@@ -1,0 +1,56 @@
+"""
+Tests for #397: struct field dot notation (PySpark parity).
+
+PySpark supports col("struct_col.field") and select("struct_col.field") when
+struct_col is a struct column with that field. createDataFrame lowercases
+struct field names in the schema, so we use lowercase field names in tests.
+"""
+
+from __future__ import annotations
+
+import robin_sparkless as rs
+
+
+def _spark() -> rs.SparkSession:
+    return rs.SparkSession.builder().app_name("issue_397").get_or_create()
+
+
+def test_select_struct_field_dot_notation_string() -> None:
+    """select("StructValue.e1") selects struct field (issue repro)."""
+    spark = _spark()
+    df = spark.createDataFrame(
+        [
+            {"StructValue": {"e1": 42, "e2": "a"}},
+            {"StructValue": {"e1": 10, "e2": "b"}},
+        ],
+        [("StructValue", "struct<e1:int,e2:string>")],
+    )
+    out = df.select("StructValue.e1").collect()
+    assert len(out) == 2
+    assert out[0]["e1"] == 42
+    assert out[1]["e1"] == 10
+
+
+def test_select_struct_field_dot_notation_col() -> None:
+    """select(col("StructValue.e1")) works like string form."""
+    spark = _spark()
+    df = spark.createDataFrame(
+        [{"StructValue": {"e1": 100, "e2": "x"}}],
+        [("StructValue", "struct<e1:int,e2:string>")],
+    )
+    out = df.select(rs.col("StructValue.e1")).collect()
+    assert len(out) == 1
+    assert out[0]["e1"] == 100
+
+
+def test_select_struct_field_multiple_dots() -> None:
+    """select("outer.inner.leaf") for nested struct."""
+    spark = _spark()
+    # Nested struct: outer has field inner which is struct<leaf:int>
+    df = spark.createDataFrame(
+        [{"outer": {"inner": {"leaf": 7}}}],
+        [("outer", "struct<inner:struct<leaf:int>>")],
+    )
+    out = df.select("outer.inner.leaf").collect()
+    assert len(out) == 1
+    assert out[0]["leaf"] == 7


### PR DESCRIPTION
Closes #397.

- **resolve_expr_column_names**: For column names containing `.`, treat as struct field path: resolve the first segment as the column name, then chain `struct_().field_by_name()` for each remaining segment (supports nested structs).
- **Python select()**: For string items, push `col(name)` so dotted names are resolved by `resolve_expr_column_names` (e.g. `select("StructValue.e1")`).
- **Tests**: `test_issue_397_struct_field_dot_notation.py` for `select("struct_col.field")`, `select(col("struct_col.field"))`, and nested `outer.inner.leaf`.

`make check-full` passes.