### PR TITLE
Fix #399: cast numeric (int/float) to boolean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **#399 – Cast numeric (int/float) to boolean (PySpark parity)** — `cast` and `try_cast` now support casting numeric types (Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64, Float32, Float64) to boolean. Semantics: 0/0.0 → false, non-zero → true. Fixes #399.
 - **#366 – Comparison coercion string/numeric and date/string (column-to-column)** — `df.filter(col("id") == col("label"))` when `id` is numeric and `label` is string now coerces (string parsed via `try_to_number`) instead of raising "cannot compare string with numeric type". Column-to-column comparisons in filter now use `coerce_for_pyspark_comparison` when both sides are columns with differing types (string–numeric, date/datetime–string). Fixes #366.
 - **#365 – regexp_extract support lookahead/lookbehind (PySpark parity)** — Patterns with `(?=...)`, `(?!...)`, `(?<=...)`, `(?<!...)` are now supported via the `fancy-regex` crate. Polars’ built-in regex does not support lookaround; when detected, extraction uses a UDF. Enables `df.select(rs.regexp_extract(rs.col("s"), r"(?<=hello )\w+", 0))` → `"world"`. Fixes #365.
 - **#363 – struct() accept multiple Column arguments (PySpark parity)** — `struct(*cols)` now accepts variadic Column arguments like PySpark `F.struct(col1, col2, ...)`. Previously only a single list argument was accepted. Enables `df.select(rs.struct(rs.col("a"), rs.col("b")).alias("s")).collect()`. Fixes #363.

--- a/src/udfs.rs
+++ b/src/udfs.rs
@@ -4178,7 +4178,8 @@ fn parse_str_to_bool(s: &str, strict: bool) -> Option<bool> {
     }
 }
 
-/// Apply string-to-boolean cast. Handles string columns; passes through boolean; null for others (try_cast) or error (cast).
+/// Apply string-to-boolean cast. Handles string columns; passes through boolean; numeric types
+/// (0/0.0 -> false, non-zero -> true for PySpark parity #399); null for others (try_cast) or error (cast).
 pub fn apply_string_to_boolean(column: Column, strict: bool) -> PolarsResult<Option<Column>> {
     let name = column.field().into_owned().name;
     let series = column.take_materialized_series();
@@ -4211,6 +4212,96 @@ pub fn apply_string_to_boolean(column: Column, strict: bool) -> PolarsResult<Opt
                 .bool()
                 .map_err(|e| PolarsError::ComputeError(format!("boolean: {e}").into()))?;
             BooleanChunked::from_iter_options(name.as_str().into(), ca.into_iter())
+        }
+        DataType::Int8 => {
+            let ca = series
+                .i8()
+                .map_err(|e| PolarsError::ComputeError(format!("i8: {e}").into()))?;
+            BooleanChunked::from_iter_options(
+                name.as_str().into(),
+                ca.into_iter().map(|o| o.map(|v| v != 0)),
+            )
+        }
+        DataType::Int16 => {
+            let ca = series
+                .i16()
+                .map_err(|e| PolarsError::ComputeError(format!("i16: {e}").into()))?;
+            BooleanChunked::from_iter_options(
+                name.as_str().into(),
+                ca.into_iter().map(|o| o.map(|v| v != 0)),
+            )
+        }
+        DataType::Int32 => {
+            let ca = series
+                .i32()
+                .map_err(|e| PolarsError::ComputeError(format!("i32: {e}").into()))?;
+            BooleanChunked::from_iter_options(
+                name.as_str().into(),
+                ca.into_iter().map(|o| o.map(|v| v != 0)),
+            )
+        }
+        DataType::Int64 => {
+            let ca = series
+                .i64()
+                .map_err(|e| PolarsError::ComputeError(format!("i64: {e}").into()))?;
+            BooleanChunked::from_iter_options(
+                name.as_str().into(),
+                ca.into_iter().map(|o| o.map(|v| v != 0)),
+            )
+        }
+        DataType::UInt8 => {
+            let ca = series
+                .u8()
+                .map_err(|e| PolarsError::ComputeError(format!("u8: {e}").into()))?;
+            BooleanChunked::from_iter_options(
+                name.as_str().into(),
+                ca.into_iter().map(|o| o.map(|v| v != 0)),
+            )
+        }
+        DataType::UInt16 => {
+            let ca = series
+                .u16()
+                .map_err(|e| PolarsError::ComputeError(format!("u16: {e}").into()))?;
+            BooleanChunked::from_iter_options(
+                name.as_str().into(),
+                ca.into_iter().map(|o| o.map(|v| v != 0)),
+            )
+        }
+        DataType::UInt32 => {
+            let ca = series
+                .u32()
+                .map_err(|e| PolarsError::ComputeError(format!("u32: {e}").into()))?;
+            BooleanChunked::from_iter_options(
+                name.as_str().into(),
+                ca.into_iter().map(|o| o.map(|v| v != 0)),
+            )
+        }
+        DataType::UInt64 => {
+            let ca = series
+                .u64()
+                .map_err(|e| PolarsError::ComputeError(format!("u64: {e}").into()))?;
+            BooleanChunked::from_iter_options(
+                name.as_str().into(),
+                ca.into_iter().map(|o| o.map(|v| v != 0)),
+            )
+        }
+        DataType::Float32 => {
+            let ca = series
+                .f32()
+                .map_err(|e| PolarsError::ComputeError(format!("f32: {e}").into()))?;
+            BooleanChunked::from_iter_options(
+                name.as_str().into(),
+                ca.into_iter().map(|o| o.map(|v| v != 0.0)),
+            )
+        }
+        DataType::Float64 => {
+            let ca = series
+                .f64()
+                .map_err(|e| PolarsError::ComputeError(format!("f64: {e}").into()))?;
+            BooleanChunked::from_iter_options(
+                name.as_str().into(),
+                ca.into_iter().map(|o| o.map(|v| v != 0.0)),
+            )
         }
         _ => {
             if strict {

--- a/tests/python/test_issue_399_cast_i64_to_boolean.py
+++ b/tests/python/test_issue_399_cast_i64_to_boolean.py
@@ -1,0 +1,33 @@
+"""Tests for issue #399: cast integer to boolean (0 -> false, non-zero -> true)."""
+
+from __future__ import annotations
+
+import robin_sparkless as rs
+
+
+def test_cast_i64_to_boolean() -> None:
+    """cast i64 to boolean: 0 -> false, non-zero -> true (PySpark parity)."""
+    spark = rs.SparkSession.builder().app_name("issue_399").get_or_create()
+    df = spark.createDataFrame([(0,), (1,)], ["x"])
+    result = df.select(rs.col("x").cast("boolean")).collect()
+    assert result[0]["x"] is False
+    assert result[1]["x"] is True
+
+
+def test_try_cast_i64_to_boolean() -> None:
+    """try_cast i64 to boolean also works."""
+    spark = rs.SparkSession.builder().app_name("issue_399").get_or_create()
+    df = spark.createDataFrame([(0,), (1,), (-1,)], ["x"])
+    result = df.select(rs.col("x").try_cast("boolean").alias("b")).collect()
+    assert result[0]["b"] is False
+    assert result[1]["b"] is True
+    assert result[2]["b"] is True
+
+
+def test_cast_float_to_boolean() -> None:
+    """cast float to boolean: 0.0 -> false, non-zero -> true."""
+    spark = rs.SparkSession.builder().app_name("issue_399").get_or_create()
+    df = spark.createDataFrame([(0.0,), (1.5,)], ["x"])
+    result = df.select(rs.col("x").cast("boolean")).collect()
+    assert result[0]["x"] is False
+    assert result[1]["x"] is True


### PR DESCRIPTION
Fixes #399

Support casting numeric types (int/long/float) to boolean: 0/0.0 → false, non-zero → true, matching PySpark behavior.

- Extend `apply_string_to_boolean` to handle Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64, Float32, Float64
- Add `tests/python/test_issue_399_cast_i64_to_boolean.py`
- `make check-full` passes