### PR TITLE
Allow create_map() with zero arguments (fixes #512)

### DIFF
--- a/src/plan/expr.rs
+++ b/src/plan/expr.rs
@@ -2129,7 +2129,7 @@ fn expr_from_fn_rest(name: &str, args: &[Value]) -> Result<Expr, PlanExprError> 
         }
         // --- Map / struct ---
         "create_map" => {
-            require_args_min(name, args, 1)?;
+            // PySpark F.create_map() with no args: empty map {} per row (#512).
             let exprs: Result<Vec<Expr>, _> = args.iter().map(expr_from_value).collect();
             let cols: Vec<Column> = exprs?.into_iter().map(expr_to_column).collect();
             let refs: Vec<&Column> = cols.iter().collect();
@@ -2317,6 +2317,13 @@ mod tests {
             "op": "create_map",
             "args": [{"lit": "k"}, {"col": "a"}]
         });
+        let _ = expr_from_value(&v).unwrap();
+    }
+
+    #[test]
+    fn test_create_map_fn_empty() {
+        // PySpark F.create_map() with no args: empty map {} per row (#512).
+        let v = json!({"fn": "create_map", "args": []});
         let _ = expr_from_value(&v).unwrap();
     }
 

--- a/tests/fixtures/plans/create_map_empty_issue512.json
+++ b/tests/fixtures/plans/create_map_empty_issue512.json
@@ -1,0 +1,26 @@
+{
+  "name": "create_map_empty_issue512",
+  "input": {
+    "schema": [{"name": "id", "type": "bigint"}],
+    "rows": [[1], [2]]
+  },
+  "plan": [
+    {
+      "op": "withColumn",
+      "payload": {
+        "name": "m",
+        "expr": {"fn": "create_map", "args": []}
+      }
+    }
+  ],
+  "expected": {
+    "schema": [
+      {"name": "id", "type": "bigint"},
+      {"name": "m", "type": "map"}
+    ],
+    "rows": [
+      [1, {}],
+      [2, {}]
+    ]
+  }
+}


### PR DESCRIPTION
Fixes #512. PySpark F.create_map() with no args returns empty map {} per row. Remove require_args_min for create_map in plan fn handler. Add test and plan fixture.