### PR TITLE
Fix inner join returning 0 rows for Sparkless plan formats (fixes #513)

### DIFF
--- a/tests/fixtures/plans/join_on_string_issue513.json
+++ b/tests/fixtures/plans/join_on_string_issue513.json
@@ -1,0 +1,43 @@
+{
+  "name": "join_on_string_issue513",
+  "input": {
+    "schema": [
+      {"name": "Name", "type": "string"},
+      {"name": "Id", "type": "int"},
+      {"name": "Dept", "type": "string"}
+    ],
+    "rows": [
+      ["Alice", 1, "IT"],
+      ["Bob", 2, "HR"]
+    ]
+  },
+  "plan": [
+    {
+      "op": "join",
+      "payload": {
+        "other_data": [
+          ["IT", "Engineering"],
+          ["HR", "Human Resources"]
+        ],
+        "other_schema": [
+          {"name": "Dept", "type": "string"},
+          {"name": "Name", "type": "string"}
+        ],
+        "on": "Dept",
+        "how": "inner"
+      }
+    }
+  ],
+  "expected": {
+    "schema": [
+      {"name": "Name", "type": "string"},
+      {"name": "Id", "type": "int"},
+      {"name": "Dept", "type": "string"},
+      {"name": "Name_right", "type": "string"}
+    ],
+    "rows": [
+      ["Alice", 1, "IT", "Engineering"],
+      ["Bob", 2, "HR", "Human Resources"]
+    ]
+  }
+}

--- a/tests/fixtures/plans/join_other_data_dict_rows_issue513.json
+++ b/tests/fixtures/plans/join_other_data_dict_rows_issue513.json
@@ -1,0 +1,41 @@
+{
+  "name": "join_other_data_dict_rows_issue513",
+  "input": {
+    "schema": [
+      {"name": "a", "type": "int"},
+      {"name": "b", "type": "string"}
+    ],
+    "rows": [
+      [1, "x"],
+      [2, "y"]
+    ]
+  },
+  "plan": [
+    {
+      "op": "join",
+      "payload": {
+        "other_data": [
+          {"a": 1, "c": "p"},
+          {"a": 2, "c": "q"}
+        ],
+        "other_schema": [
+          {"name": "a", "type": "int"},
+          {"name": "c", "type": "string"}
+        ],
+        "on": ["a"],
+        "how": "inner"
+      }
+    }
+  ],
+  "expected": {
+    "schema": [
+      {"name": "a", "type": "int"},
+      {"name": "b", "type": "string"},
+      {"name": "c", "type": "string"}
+    ],
+    "rows": [
+      [1, "x", "p"],
+      [2, "y", "q"]
+    ]
+  }
+}


### PR DESCRIPTION
Fixes #513. Support join 'on' as string, schema fieldName/dataType, other_data as dict rows. Add plan fixtures.