### PR TITLE
Fix #518: isin with empty list semantics

### DIFF
--- a/src/plan/expr.rs
+++ b/src/plan/expr.rs
@@ -513,7 +513,8 @@ fn lit_as_usize(v: &Value) -> Result<usize, PlanExprError> {
 }
 
 /// Extract values for isin from JSON array. Each element: {"lit": v} or plain v. Returns Expr for is_in.
-/// When arr is empty or parses to no values, returns Ok(None) — caller should use lit(false) (issue #518).
+/// When arr is empty or parses to no values (e.g. all nulls), returns Ok(None) — caller uses lit(false)
+/// so that col.isin([]) is false for all rows (PySpark parity; issue #518).
 fn try_values_for_isin(arr: &[Value]) -> Result<Option<Expr>, PlanExprError> {
     if arr.is_empty() {
         return Ok(None);


### PR DESCRIPTION
PySpark parity: `col.isin([])` is false for all rows.

- Documented in `try_values_for_isin` that empty or all-null value lists yield `lit(false)` (caller already uses this).
- Existing tests: `plan::expr::tests::test_isin_op_empty`, `test_isin_fn_empty`, `parity::plan_filter_isin_empty`.

`make check-full` passes.