### PR TITLE
Fix #526: SQL DROP SCHEMA / DROP DATABASE not supported

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -620,6 +620,18 @@ impl SparkSession {
             .unwrap_or(false)
     }
 
+    /// Drop a database/schema by name (from DROP SCHEMA / DROP DATABASE). Removes from registered databases only.
+    /// Does not drop "default" or "global_temp". No-op if not present (or if_exists). Returns true if removed.
+    pub fn drop_database(&self, name: &str) -> bool {
+        if name.eq_ignore_ascii_case("default") || name.eq_ignore_ascii_case("global_temp") {
+            return false;
+        }
+        self.databases
+            .lock()
+            .map(|mut s| s.remove(name))
+            .unwrap_or(false)
+    }
+
     /// Parse "global_temp.xyz" into ("global_temp", "xyz"). Returns None for plain names.
     fn parse_global_temp_name(name: &str) -> Option<(&str, &str)> {
         if let Some(dot) = name.find('.') {

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -220,6 +220,20 @@ mod tests {
     }
 
     #[test]
+    fn test_sql_drop_schema() {
+        let spark = SparkSession::builder().app_name("test").get_or_create();
+        // CREATE then DROP SCHEMA (issue #526; sqlparser 0.45 has no DROP DATABASE token)
+        spark
+            .sql("CREATE SCHEMA IF NOT EXISTS test_schema_to_drop")
+            .unwrap();
+        assert!(spark.database_exists("test_schema_to_drop"));
+        spark
+            .sql("DROP SCHEMA IF EXISTS test_schema_to_drop CASCADE")
+            .unwrap();
+        assert!(!spark.database_exists("test_schema_to_drop"));
+    }
+
+    #[test]
     fn test_sql_case_insensitive_columns() {
         let spark = SparkSession::builder().app_name("test").get_or_create();
         let df = spark

--- a/src/sql/parser.rs
+++ b/src/sql/parser.rs
@@ -11,7 +11,7 @@ pub fn parse_sql(query: &str) -> Result<Statement, PolarsError> {
     let stmts = Parser::parse_sql(&dialect, query).map_err(|e| {
         PolarsError::InvalidOperation(
             format!(
-                "SQL parse error: {}. Hint: only SELECT and CREATE SCHEMA/DATABASE/DROP TABLE are supported.",
+                "SQL parse error: {}. Hint: only SELECT and CREATE SCHEMA/DATABASE/DROP TABLE/VIEW/SCHEMA are supported.",
                 e
             )
             .into(),
@@ -31,13 +31,16 @@ pub fn parse_sql(query: &str) -> Result<Statement, PolarsError> {
         Statement::Query(_) => {}
         Statement::CreateSchema { .. } | Statement::CreateDatabase { .. } => {}
         Statement::Drop {
-            object_type: sqlparser::ast::ObjectType::Table | sqlparser::ast::ObjectType::View,
+            object_type:
+                sqlparser::ast::ObjectType::Table
+                | sqlparser::ast::ObjectType::View
+                | sqlparser::ast::ObjectType::Schema,
             ..
         } => {}
         _ => {
             return Err(PolarsError::InvalidOperation(
                 format!(
-                    "SQL: only SELECT, CREATE SCHEMA/DATABASE, and DROP TABLE/VIEW are supported, got {:?}.",
+                    "SQL: only SELECT, CREATE SCHEMA/DATABASE, and DROP TABLE/VIEW/SCHEMA are supported, got {:?}.",
                     stmt
                 )
                 .into(),

--- a/src/sql/translator.rs
+++ b/src/sql/translator.rs
@@ -104,8 +104,22 @@ pub fn translate(
                 session.is_case_sensitive(),
             ))
         }
+        Statement::Drop {
+            object_type: ObjectType::Schema,
+            names,
+            ..
+        } => {
+            for obj_name in names {
+                session.drop_database(&obj_name.to_string());
+            }
+            Ok(DataFrame::from_polars_with_options(
+                PlDataFrame::empty(),
+                session.is_case_sensitive(),
+            ))
+        }
         _ => Err(PolarsError::InvalidOperation(
-            "SQL: only SELECT, CREATE SCHEMA/DATABASE, and DROP TABLE/VIEW are supported.".into(),
+            "SQL: only SELECT, CREATE SCHEMA/DATABASE, and DROP TABLE/VIEW/SCHEMA are supported."
+                .into(),
         )),
     }
 }


### PR DESCRIPTION
Support DROP SCHEMA (and equivalent teardown). sqlparser 0.45 has no DROP DATABASE token; DROP SCHEMA is supported and removes from registered databases.

- Parser/translator: accept ObjectType::Schema in Drop.
- Session.drop_database() for removing registered schema/database names.
- test_sql_drop_schema (run with --features sql).

make check-full passes.