### PR TITLE
Fix #524: Case sensitivity - Column not found when names differ by case

### DIFF
--- a/src/dataframe/mod.rs
+++ b/src/dataframe/mod.rs
@@ -90,6 +90,16 @@ impl DataFrame {
         }
     }
 
+    /// Return a new DataFrame with the same data but case-insensitive column resolution.
+    /// Used by plan execution so that Sparkless plans (e.g. col("ID") with schema "id") resolve (issue #524).
+    pub(crate) fn with_case_insensitive_column_resolution(self) -> Self {
+        DataFrame {
+            inner: self.inner,
+            case_sensitive: false,
+            alias: self.alias,
+        }
+    }
+
     /// Create an empty DataFrame
     pub fn empty() -> Self {
         DataFrame {

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -27,7 +27,8 @@ pub fn execute_plan(
     set_thread_udf_session(session.clone());
     let mut df = session
         .create_dataframe_from_rows(data, schema)
-        .map_err(PlanError::Session)?;
+        .map_err(PlanError::Session)?
+        .with_case_insensitive_column_resolution();
 
     for op_value in plan {
         let op_obj = op_value


### PR DESCRIPTION
Plan execution now always uses case-insensitive column resolution so that when schema has e.g. `id` and the plan uses `ID`, the column is found. Added `DataFrame::with_case_insensitive_column_resolution()` and call it in `execute_plan` on the initial DataFrame. make check-full passes.