### PR TITLE
Fix #519: Empty DataFrame with schema + parquet table append / catalog

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -852,6 +852,7 @@ impl SparkSession {
     /// `rows`: each inner vec is one row; length must match schema length. Values are JSON-like (i64, f64, string, bool, null, object, array).
     /// `schema`: list of (column_name, dtype_string), e.g. `[("id", "bigint"), ("name", "string")]`.
     /// Supported dtype strings: bigint, int, long, double, float, string, str, varchar, boolean, bool, date, timestamp, datetime, list, array, array<element_type>, struct<field:type,...>.
+    /// When `rows` is empty and `schema` is non-empty, returns an empty DataFrame with that schema (issue #519). Use with `write.format("parquet").saveAsTable(...)` then append; PySpark would fail with "can not infer schema from empty dataset".
     pub fn create_dataframe_from_rows(
         &self,
         rows: Vec<Vec<JsonValue>>,


### PR DESCRIPTION
Documents that create_dataframe_from_rows with empty rows and non-empty schema returns an empty DataFrame with that schema, which can be used with write.format('parquet').saveAsTable(...) and append (PySpark fails with 'can not infer schema from empty dataset'). Behavior already supported; existing tests cover it. make check-full passes.