### PR TITLE
Fix #540: orderBy does not support nulls_first / nulls_last

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **#540 – orderBy nulls_first / nulls_last (PySpark parity)** — `order_by(refs, ascending)` now passes null placement to Polars: ASC → nulls first, DESC → nulls last. Plan interpreter `orderBy` accepts optional `nulls_last` array in payload for configurable null ordering. Fixes #540.
 - **GroupedData / PivotedGroupedData column resolution** — Aggregation methods (`sum`, `avg`, `min`, `max`, `first`, `last`, etc.) and pivot operations now resolve column names against the schema with case sensitivity. When `case_sensitive` is false, `grouped.sum("V")` works when the schema has `"v"`.
 - **subtract / intersect with different column casing** — `subtract` and `intersect` now align right-side column names to left when casing differs (case-sensitive or -insensitive), so set operations work when DataFrames have different column casing.
 - **#492 – case-insensitive orderBy on mixed-case column names (PySpark parity)** — Clarify and regression-test that when `spark.sql.caseSensitive` is false (default), `DataFrame::order_by` / `orderBy` resolve column names case-insensitively so `"value"` and `"VALUE"` work for schema column `"Value"`. Fixes #492.

--- a/src/dataframe/transformations.rs
+++ b/src/dataframe/transformations.rs
@@ -134,9 +134,13 @@ pub fn order_by(
         .collect::<Result<Vec<_>, _>>()?;
     let exprs: Vec<Expr> = resolved.iter().map(|s| col(s.as_str())).collect();
     let descending: Vec<bool> = asc.iter().map(|&a| !a).collect();
+    // PySpark default: ASC nulls first (nulls_last=false), DESC nulls last (nulls_last=true).
+    let nulls_last: Vec<bool> = descending.clone();
     let lf = df.lazy_frame().sort_by_exprs(
         exprs,
-        SortMultipleOptions::new().with_order_descending_multi(descending),
+        SortMultipleOptions::new()
+            .with_order_descending_multi(descending)
+            .with_nulls_last_multi(nulls_last),
     );
     Ok(super::DataFrame::from_lazy_with_options(lf, case_sensitive))
 }

--- a/tests/issue_540_order_by_nulls_first_last.rs
+++ b/tests/issue_540_order_by_nulls_first_last.rs
@@ -1,0 +1,55 @@
+//! Regression tests for issue #540 – orderBy nulls_first / nulls_last (PySpark parity).
+//!
+//! PySpark: asc_nulls_first(), asc_nulls_last(), desc_nulls_first(), desc_nulls_last().
+//! Default: ASC → nulls first, DESC → nulls last.
+
+mod common;
+
+use common::spark;
+use robin_sparkless::{col, desc_nulls_last, SparkSession};
+
+#[test]
+fn issue_540_desc_nulls_last() {
+    let spark = spark();
+    let pl = polars::prelude::df![
+        "value" => &["A", "B", "C", "D"],
+        "ord" => &[Some(1i64), Some(2i64), None, Some(4i64)],
+    ]
+    .unwrap();
+    let df = spark.create_dataframe_from_polars(pl);
+
+    // desc_nulls_last: descending order, nulls last. So non-null 4,2,1 then null.
+    let sorted = df
+        .order_by_exprs(vec![desc_nulls_last(&col("ord"))])
+        .unwrap();
+    let rows = sorted.collect_as_json_rows().unwrap();
+    let ords: Vec<Option<i64>> = rows
+        .iter()
+        .map(|r| r.get("ord").and_then(|v| v.as_i64()))
+        .collect();
+    assert_eq!(ords, vec![Some(4), Some(2), Some(1), None], "nulls last");
+}
+
+#[test]
+fn issue_540_default_order_by_desc_null_order() {
+    // Simple order_by(refs, ascending) should use PySpark default: DESC → nulls last.
+    let spark = spark();
+    let pl = polars::prelude::df![
+        "value" => &["A", "B", "C", "D"],
+        "ord" => &[Some(1i64), Some(2i64), None, Some(4i64)],
+    ]
+    .unwrap();
+    let df = spark.create_dataframe_from_polars(pl);
+
+    let sorted = df.order_by(vec!["ord"], vec![false]).unwrap(); // descending
+    let rows = sorted.collect_as_json_rows().unwrap();
+    let ords: Vec<Option<i64>> = rows
+        .iter()
+        .map(|r| r.get("ord").and_then(|v| v.as_i64()))
+        .collect();
+    assert_eq!(
+        ords,
+        vec![Some(4), Some(2), Some(1), None],
+        "default DESC nulls last"
+    );
+}


### PR DESCRIPTION
Fixes #540.

- `order_by(refs, ascending)` now passes null placement to Polars (ASC → nulls first, DESC → nulls last).
- Plan interpreter `orderBy` accepts optional `nulls_last` array in payload for configurable null ordering.
- Regression tests in `tests/issue_540_order_by_nulls_first_last.rs`.