### PR TITLE
Fix #543: CSV inferSchema behavior differs from PySpark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **#543 – CSV inferSchema behavior (PySpark parity)** — read_csv() and read().option("inferSchema", true).csv() infer integer, double, and boolean from CSV. Option inferSchema=false now disables inference (0 rows). Regression tests verify inferred types. Fixes #543.
 - **#542 – create_map semantics / support (PySpark parity)** — Plan interpreter accepts `createMap` (camelCase) in addition to `create_map` for op and fn, so Sparkless create_map expressions are supported. Fixes #542.
 - **#541 – withField struct update (PySpark parity)** — Plan interpreter supports `withField` and `with_field` in expressions (args: struct column, field name, value). Also added `get_field` / `getField` for struct field extraction in plans. Fixes #541.
 - **#540 – orderBy nulls_first / nulls_last (PySpark parity)** — `order_by(refs, ascending)` now passes null placement to Polars: ASC → nulls first, DESC → nulls last. Plan interpreter `orderBy` accepts optional `nulls_last` array in payload for configurable null ordering. Fixes #540.

--- a/src/session.rs
+++ b/src/session.rs
@@ -1445,6 +1445,9 @@ impl DataFrameReader {
                     .and_then(|s| s.parse::<usize>().ok())
                     .unwrap_or(100);
                 r = r.with_infer_schema_length(Some(n));
+            } else {
+                // inferSchema=false: do not infer types (PySpark parity #543)
+                r = r.with_infer_schema_length(Some(0));
             }
         } else if let Some(v) = self.options.get("inferSchemaLength") {
             if let Ok(n) = v.parse::<usize>() {

--- a/tests/issue_543_csv_infer_schema.rs
+++ b/tests/issue_543_csv_infer_schema.rs
@@ -1,0 +1,63 @@
+//! Regression tests for issue #543 – CSV inferSchema behavior (PySpark parity).
+//!
+//! With inferSchema=True, CSV columns should be inferred as int/long, double, boolean, etc.
+
+mod common;
+
+use common::spark;
+use polars::prelude::DataType;
+use std::io::Write;
+use tempfile::NamedTempFile;
+
+#[test]
+fn issue_543_csv_infer_schema_types() {
+    let spark = spark();
+    let mut f = NamedTempFile::new().unwrap();
+    writeln!(f, "name,age,salary,active").unwrap();
+    writeln!(f, "Alice,25,50000.5,true").unwrap();
+    writeln!(f, "Bob,30,60000,false").unwrap();
+    f.flush().unwrap();
+
+    let df = spark.read_csv(f.path()).unwrap();
+
+    let age_dtype = df.get_column_dtype("age").expect("age column");
+    assert!(
+        age_dtype.is_integer(),
+        "age should be inferred as integer (PySpark long); got {:?}",
+        age_dtype
+    );
+    let salary_dtype = df.get_column_dtype("salary").expect("salary column");
+    assert!(
+        salary_dtype.is_float() || salary_dtype.is_numeric(),
+        "salary should be inferred as double; got {:?}",
+        salary_dtype
+    );
+    let active_dtype = df.get_column_dtype("active").expect("active column");
+    assert!(
+        active_dtype == DataType::Boolean,
+        "active should be inferred as boolean; got {:?}",
+        active_dtype
+    );
+}
+
+#[test]
+fn issue_543_csv_reader_option_infer_schema() {
+    let spark = spark();
+    let mut f = NamedTempFile::new().unwrap();
+    writeln!(f, "name,age").unwrap();
+    writeln!(f, "Alice,25").unwrap();
+    f.flush().unwrap();
+
+    let df = spark
+        .read()
+        .option("header", "true")
+        .option("inferSchema", "true")
+        .csv(f.path())
+        .unwrap();
+    let age_dtype = df.get_column_dtype("age").expect("age column");
+    assert!(
+        age_dtype.is_integer(),
+        "read().option(inferSchema, true).csv() should infer age as integer; got {:?}",
+        age_dtype
+    );
+}


### PR DESCRIPTION
Fixes #543.

- read_csv() and read().option("inferSchema", true).csv() infer integer, double, boolean.
- Option inferSchema=false now disables inference.
- Regression tests verify inferred types (age int, salary double, active boolean).