### PR TITLE
Fix #545: UDF expression not supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **#545 – UDF expression not supported (PySpark parity)** — Plan interpreter now accepts expression `{"op": "udf", "udf"|"name": "name", "args": [<expr>, ...]}`, so Sparkless plans that use UDF expressions no longer report "unsupported expression op: udf". Fixes #545.
 - **#543 – CSV inferSchema behavior (PySpark parity)** — read_csv() and read().option("inferSchema", true).csv() infer integer, double, and boolean from CSV. Option inferSchema=false now disables inference (0 rows). Regression tests verify inferred types. Fixes #543.
 - **#542 – create_map semantics / support (PySpark parity)** — Plan interpreter accepts `createMap` (camelCase) in addition to `create_map` for op and fn, so Sparkless create_map expressions are supported. Fixes #542.
 - **#541 – withField struct update (PySpark parity)** — Plan interpreter supports `withField` and `with_field` in expressions (args: struct column, field name, value). Also added `get_field` / `getField` for struct field extraction in plans. Fixes #541.

--- a/tests/issue_545_udf_expression.rs
+++ b/tests/issue_545_udf_expression.rs
@@ -1,0 +1,42 @@
+//! Regression tests for issue #545 – UDF expression not supported (PySpark parity).
+//!
+//! Plan interpreter previously reported "unsupported expression op: udf".
+//! We now accept {"op": "udf", "udf"|"name": "name", "args": [<expr>, ...]}.
+
+mod common;
+
+use common::spark;
+use robin_sparkless::plan;
+use serde_json::json;
+
+#[test]
+fn issue_545_plan_udf_op_rust_udf() {
+    let session = spark();
+    session
+        .register_udf("inc", |cols: &[polars::prelude::Series]| Ok(&cols[0] + 1))
+        .expect("register_udf should succeed");
+
+    let data = vec![vec![json!(1)], vec![json!(2)]];
+    let schema = vec![("x".to_string(), "bigint".to_string())];
+    let plan_ops = vec![json!({
+        "op": "withColumn",
+        "payload": {
+            "name": "x_plus_one",
+            "expr": {
+                "op": "udf",
+                "udf": "inc",
+                "args": [{"col": "x"}]
+            }
+        }
+    })];
+
+    let df = plan::execute_plan(&session, data, schema, &plan_ops).unwrap();
+    let rows = df.collect_as_json_rows().unwrap();
+    assert_eq!(rows.len(), 2);
+    assert_eq!(
+        rows[0].get("x_plus_one").and_then(|v| v.as_i64()),
+        Some(2),
+        "op 'udf' with Rust UDF should be applied"
+    );
+    assert_eq!(rows[1].get("x_plus_one").and_then(|v| v.as_i64()), Some(3));
+}


### PR DESCRIPTION
Plan interpreter now accepts expression `{"op": "udf", "udf"|"name": "name", "args": [<expr>, ...]}`, so Sparkless plans that use UDF expressions no longer report "unsupported expression op: udf".

- `src/plan/expr.rs`: added match arm for `op "udf"` (udf/name + args), delegates to `column_from_udf_call` and returns Expr for Rust UDFs.
- `tests/issue_545_udf_expression.rs`: regression test (plan withColumn with op udf, Rust UDF).
- CHANGELOG: Fixed #545.

Fixes #545