### PR TITLE
Fix #546: SQL alias in aggregation SELECT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **#546 – SQL alias in aggregation SELECT (PySpark parity)** — SQL now supports aliased aggregates (e.g. `SELECT grp, COUNT(v) AS cnt FROM t GROUP BY grp`). `ExprWithAlias` in the SELECT list is handled for group columns (validation) and aggregate functions (alias used as output column name). Fixes #546.
 - **#545 – UDF expression not supported (PySpark parity)** — Plan interpreter now accepts expression `{"op": "udf", "udf"|"name": "name", "args": [<expr>, ...]}`, so Sparkless plans that use UDF expressions no longer report "unsupported expression op: udf". Fixes #545.
 - **#543 – CSV inferSchema behavior (PySpark parity)** — read_csv() and read().option("inferSchema", true).csv() infer integer, double, and boolean from CSV. Option inferSchema=false now disables inference (0 rows). Regression tests verify inferred types. Fixes #543.
 - **#542 – create_map semantics / support (PySpark parity)** — Plan interpreter accepts `createMap` (camelCase) in addition to `create_map` for op and fn, so Sparkless create_map expressions are supported. Fixes #542.

--- a/tests/issue_546_sql_aggregation_alias.rs
+++ b/tests/issue_546_sql_aggregation_alias.rs
@@ -1,0 +1,41 @@
+//! Regression tests for issue #546 – SQL alias in aggregation SELECT (PySpark parity).
+//!
+//! PySpark: SELECT grp, COUNT(v) AS cnt FROM t GROUP BY grp returns a column named "cnt".
+
+use polars::prelude::df;
+use robin_sparkless::{DataFrame, SparkSession};
+
+fn spark() -> SparkSession {
+    SparkSession::builder()
+        .app_name("issue_546_test")
+        .get_or_create()
+}
+
+#[test]
+fn issue_546_sql_count_as_cnt() {
+    let spark = spark();
+    if spark.sql("SELECT 1").is_err() {
+        return; // SQL feature not enabled
+    }
+    let pl = df![
+        "grp" => &[1i64, 1i64, 2i64],
+        "v"   => &[10i64, 20i64, 30i64],
+    ]
+    .unwrap();
+    let df: DataFrame = spark.create_dataframe_from_polars(pl);
+    spark.create_or_replace_temp_view("t", df);
+
+    let result = spark
+        .sql("SELECT grp, COUNT(v) AS cnt FROM t GROUP BY grp ORDER BY grp")
+        .unwrap();
+    let rows = result.collect_as_json_rows().unwrap();
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].get("grp").and_then(|v| v.as_i64()), Some(1));
+    assert_eq!(
+        rows[0].get("cnt").and_then(|v| v.as_i64()),
+        Some(2),
+        "COUNT(v) AS cnt should produce column named cnt with value 2 for grp=1"
+    );
+    assert_eq!(rows[1].get("grp").and_then(|v| v.as_i64()), Some(2));
+    assert_eq!(rows[1].get("cnt").and_then(|v| v.as_i64()), Some(1));
+}


### PR DESCRIPTION
SQL now supports aliased aggregates (e.g. `SELECT grp, COUNT(v) AS cnt FROM t GROUP BY grp`). `ExprWithAlias` in the SELECT list is handled for group columns (validation) and aggregate functions (alias used as output column name).

- `src/sql/translator.rs`: handle `SelectItem::ExprWithAlias` in `projection_to_agg_exprs`; extract `push_agg_function` helper with optional alias override.
- `tests/issue_546_sql_aggregation_alias.rs`: regression test (skips when sql feature off).
- CHANGELOG: Fixed #546.

Fixes #546