### PR TITLE
Fix #547: String functions as expression op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **#547 – String functions as expression op (PySpark parity)** — Plan interpreter now accepts translate, substring_index, levenshtein, soundex, crc32, xxhash64, get_json_object, json_tuple, and regexp_extract_all when sent as `{"op": "<name>", "args": [...]}` (and camelCase variants substringIndex, getJsonObject, jsonTuple, regexpExtractAll). Also added get_json_object and json_tuple to expr_from_fn. Fixes #547.
 - **#546 – SQL alias in aggregation SELECT (PySpark parity)** — SQL now supports aliased aggregates (e.g. `SELECT grp, COUNT(v) AS cnt FROM t GROUP BY grp`). `ExprWithAlias` in the SELECT list is handled for group columns (validation) and aggregate functions (alias used as output column name). Fixes #546.
 - **#545 – UDF expression not supported (PySpark parity)** — Plan interpreter now accepts expression `{"op": "udf", "udf"|"name": "name", "args": [<expr>, ...]}`, so Sparkless plans that use UDF expressions no longer report "unsupported expression op: udf". Fixes #545.
 - **#543 – CSV inferSchema behavior (PySpark parity)** — read_csv() and read().option("inferSchema", true).csv() infer integer, double, and boolean from CSV. Option inferSchema=false now disables inference (0 rows). Regression tests verify inferred types. Fixes #543.

--- a/tests/issue_547_string_functions_op.rs
+++ b/tests/issue_547_string_functions_op.rs
@@ -1,0 +1,79 @@
+//! Regression tests for issue #547 – String functions as op (translate, substring_index,
+//! levenshtein, soundex, crc32, xxhash64, get_json_object, json_tuple, regexp_extract_all).
+//!
+//! Plan interpreter now accepts these as {"op": "<name>", "args": [...]}.
+
+mod common;
+
+use common::spark;
+use robin_sparkless::plan;
+use serde_json::json;
+
+#[test]
+fn issue_547_plan_op_regexp_extract_all() {
+    let session = spark();
+    let data = vec![vec![json!("hello world")]];
+    let schema = vec![("s".to_string(), "string".to_string())];
+    let plan_ops = vec![json!({
+        "op": "withColumn",
+        "payload": {
+            "name": "m",
+            "expr": {
+                "op": "regexp_extract_all",
+                "args": [{"col": "s"}, {"lit": "\\w+"}]
+            }
+        }
+    })];
+    let df = plan::execute_plan(&session, data, schema, &plan_ops).unwrap();
+    let rows = df.collect_as_json_rows().unwrap();
+    assert_eq!(rows.len(), 1);
+    assert!(
+        rows[0].get("m").is_some(),
+        "regexp_extract_all should produce column m"
+    );
+}
+
+#[test]
+fn issue_547_plan_op_levenshtein() {
+    let session = spark();
+    let data = vec![vec![json!("kitten"), json!("sitting")]];
+    let schema = vec![
+        ("a".to_string(), "string".to_string()),
+        ("b".to_string(), "string".to_string()),
+    ];
+    let plan_ops = vec![json!({
+        "op": "withColumn",
+        "payload": {
+            "name": "dist",
+            "expr": {
+                "op": "levenshtein",
+                "args": [{"col": "a"}, {"col": "b"}]
+            }
+        }
+    })];
+    let df = plan::execute_plan(&session, data, schema, &plan_ops).unwrap();
+    let rows = df.collect_as_json_rows().unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].get("dist").and_then(|v| v.as_i64()), Some(3));
+}
+
+#[test]
+fn issue_547_plan_op_translate() {
+    let session = spark();
+    let data = vec![vec![json!("hello")]];
+    let schema = vec![("s".to_string(), "string".to_string())];
+    let plan_ops = vec![json!({
+        "op": "withColumn",
+        "payload": {
+            "name": "t",
+            "expr": {
+                "op": "translate",
+                "args": [{"col": "s"}, {"lit": "el"}, {"lit": "ip"}]
+            }
+        }
+    })];
+    let df = plan::execute_plan(&session, data, schema, &plan_ops).unwrap();
+    let rows = df.collect_as_json_rows().unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].get("t").and_then(|v| v.as_str()), Some("hippo"));
+}


### PR DESCRIPTION
Plan interpreter now accepts translate, substring_index, levenshtein, soundex, crc32, xxhash64, get_json_object, json_tuple, regexp_extract_all when sent as op with args. Added get_json_object and json_tuple to expr_from_fn. Fixes #547