### PR TITLE
Fix #548: date_trunc and to_date as expression op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **#548 – date_trunc and to_date as expression op (PySpark parity)** — Plan interpreter now accepts `{"op": "date_trunc"|"dateTrunc"|"to_date"|"toDate", "args": [...]}`. Fixes #548.
 - **#547 – String functions as expression op (PySpark parity)** — Plan interpreter now accepts translate, substring_index, levenshtein, soundex, crc32, xxhash64, get_json_object, json_tuple, and regexp_extract_all when sent as `{"op": "<name>", "args": [...]}` (and camelCase variants substringIndex, getJsonObject, jsonTuple, regexpExtractAll). Also added get_json_object and json_tuple to expr_from_fn. Fixes #547.
 - **#546 – SQL alias in aggregation SELECT (PySpark parity)** — SQL now supports aliased aggregates (e.g. `SELECT grp, COUNT(v) AS cnt FROM t GROUP BY grp`). `ExprWithAlias` in the SELECT list is handled for group columns (validation) and aggregate functions (alias used as output column name). Fixes #546.
 - **#545 – UDF expression not supported (PySpark parity)** — Plan interpreter now accepts expression `{"op": "udf", "udf"|"name": "name", "args": [<expr>, ...]}`, so Sparkless plans that use UDF expressions no longer report "unsupported expression op: udf". Fixes #545.

--- a/src/plan/expr.rs
+++ b/src/plan/expr.rs
@@ -354,7 +354,8 @@ pub fn expr_from_value(v: &Value) -> Result<Expr, PlanExprError> {
             // #547: Sparkless may send string/JSON functions as op with "args" (same semantics as fn)
             "translate" | "substring_index" | "substringIndex" | "levenshtein" | "soundex"
             | "crc32" | "xxhash64" | "get_json_object" | "getJsonObject" | "json_tuple"
-            | "jsonTuple" | "regexp_extract_all" | "regexpExtractAll" => {
+            | "jsonTuple" | "regexp_extract_all" | "regexpExtractAll" | "date_trunc"
+            | "dateTrunc" | "to_date" | "toDate" => {
                 let args = obj
                     .get("args")
                     .and_then(Value::as_array)
@@ -364,6 +365,8 @@ pub fn expr_from_value(v: &Value) -> Result<Expr, PlanExprError> {
                     "getJsonObject" => "get_json_object",
                     "jsonTuple" => "json_tuple",
                     "regexpExtractAll" => "regexp_extract_all",
+                    "dateTrunc" => "date_trunc",
+                    "toDate" => "to_date",
                     other => other,
                 };
                 return expr_from_fn(fn_name, args);

--- a/tests/issue_548_date_trunc_to_date_op.rs
+++ b/tests/issue_548_date_trunc_to_date_op.rs
@@ -1,0 +1,53 @@
+//! Regression tests for issue #548 – date_trunc and to_date as expression op (PySpark parity).
+
+mod common;
+
+use common::spark;
+use robin_sparkless::plan;
+use serde_json::json;
+
+#[test]
+fn issue_548_plan_op_to_date() {
+    let session = spark();
+    let data = vec![vec![json!("2024-03-15")]];
+    let schema = vec![("d".to_string(), "string".to_string())];
+    let plan_ops = vec![json!({
+        "op": "withColumn",
+        "payload": {
+            "name": "dt",
+            "expr": {"op": "to_date", "args": [{"col": "d"}]}
+        }
+    })];
+    let df = plan::execute_plan(&session, data, schema, &plan_ops).unwrap();
+    let rows = df.collect_as_json_rows().unwrap();
+    assert_eq!(rows.len(), 1);
+    assert!(rows[0].get("dt").is_some());
+}
+
+#[test]
+fn issue_548_plan_op_date_trunc() {
+    let session = spark();
+    let data = vec![vec![json!("2024-03-15 12:30:45")]];
+    let schema = vec![("ts".to_string(), "string".to_string())];
+    // to_date then date_trunc with Polars duration "1d" (day)
+    let plan_ops = vec![
+        json!({
+            "op": "withColumn",
+            "payload": {
+                "name": "dt",
+                "expr": {"op": "to_date", "args": [{"col": "ts"}]}
+            }
+        }),
+        json!({
+            "op": "withColumn",
+            "payload": {
+                "name": "truncated",
+                "expr": {"op": "date_trunc", "args": [{"lit": "1d"}, {"col": "dt"}]}
+            }
+        }),
+    ];
+    let df = plan::execute_plan(&session, data, schema, &plan_ops).unwrap();
+    let rows = df.collect_as_json_rows().unwrap();
+    assert_eq!(rows.len(), 1);
+    assert!(rows[0].get("truncated").is_some());
+}


### PR DESCRIPTION
Plan interpreter now accepts op date_trunc/dateTrunc and to_date/toDate with args. Fixes #548