### PR TITLE
Fix #549: format_string and log() as expression op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **#549 – format_string and log() as expression op (PySpark parity)** — Plan interpreter now accepts `{"op": "format_string"|"formatString"|"log", "args": [...]}`. Fixes #549.
 - **#548 – date_trunc and to_date as expression op (PySpark parity)** — Plan interpreter now accepts `{"op": "date_trunc"|"dateTrunc"|"to_date"|"toDate", "args": [...]}`. Fixes #548.
 - **#547 – String functions as expression op (PySpark parity)** — Plan interpreter now accepts translate, substring_index, levenshtein, soundex, crc32, xxhash64, get_json_object, json_tuple, and regexp_extract_all when sent as `{"op": "<name>", "args": [...]}` (and camelCase variants substringIndex, getJsonObject, jsonTuple, regexpExtractAll). Also added get_json_object and json_tuple to expr_from_fn. Fixes #547.
 - **#546 – SQL alias in aggregation SELECT (PySpark parity)** — SQL now supports aliased aggregates (e.g. `SELECT grp, COUNT(v) AS cnt FROM t GROUP BY grp`). `ExprWithAlias` in the SELECT list is handled for group columns (validation) and aggregate functions (alias used as output column name). Fixes #546.

--- a/src/plan/expr.rs
+++ b/src/plan/expr.rs
@@ -355,7 +355,7 @@ pub fn expr_from_value(v: &Value) -> Result<Expr, PlanExprError> {
             "translate" | "substring_index" | "substringIndex" | "levenshtein" | "soundex"
             | "crc32" | "xxhash64" | "get_json_object" | "getJsonObject" | "json_tuple"
             | "jsonTuple" | "regexp_extract_all" | "regexpExtractAll" | "date_trunc"
-            | "dateTrunc" | "to_date" | "toDate" => {
+            | "dateTrunc" | "to_date" | "toDate" | "format_string" | "formatString" | "log" => {
                 let args = obj
                     .get("args")
                     .and_then(Value::as_array)
@@ -367,6 +367,7 @@ pub fn expr_from_value(v: &Value) -> Result<Expr, PlanExprError> {
                     "regexpExtractAll" => "regexp_extract_all",
                     "dateTrunc" => "date_trunc",
                     "toDate" => "to_date",
+                    "formatString" => "format_string",
                     other => other,
                 };
                 return expr_from_fn(fn_name, args);

--- a/tests/issue_549_format_string_log_op.rs
+++ b/tests/issue_549_format_string_log_op.rs
@@ -1,0 +1,54 @@
+//! Regression tests for issue #549 – format_string and log() as expression op.
+
+mod common;
+
+use common::spark;
+use robin_sparkless::plan;
+use serde_json::json;
+
+#[test]
+fn issue_549_plan_op_format_string() {
+    let session = spark();
+    let data = vec![vec![json!("Alice"), json!(123)]];
+    let schema = vec![
+        ("Name".to_string(), "string".to_string()),
+        ("IntegerValue".to_string(), "bigint".to_string()),
+    ];
+    let plan_ops = vec![json!({
+        "op": "withColumn",
+        "payload": {
+            "name": "formatted",
+            "expr": {
+                "op": "format_string",
+                "args": [{"lit": "%s: %d"}, {"col": "Name"}, {"col": "IntegerValue"}]
+            }
+        }
+    })];
+    let df = plan::execute_plan(&session, data, schema, &plan_ops).unwrap();
+    let rows = df.collect_as_json_rows().unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0].get("formatted").and_then(|v| v.as_str()),
+        Some("Alice: 123")
+    );
+}
+
+#[test]
+fn issue_549_plan_op_log_one_arg() {
+    let session = spark();
+    // log(col) = natural log; op "log" is accepted
+    let data = vec![vec![json!(1.0)]];
+    let schema = vec![("x".to_string(), "double".to_string())];
+    let plan_ops = vec![json!({
+        "op": "withColumn",
+        "payload": {
+            "name": "ln_x",
+            "expr": {"op": "log", "args": [{"col": "x"}]}
+        }
+    })];
+    let df = plan::execute_plan(&session, data, schema, &plan_ops).unwrap();
+    let rows = df.collect_as_json_rows().unwrap();
+    assert_eq!(rows.len(), 1);
+    let v = rows[0].get("ln_x").and_then(|v| v.as_f64()).unwrap();
+    assert!((v - 0.0).abs() < 1e-10, "ln(1) = 0, got {}", v);
+}


### PR DESCRIPTION
Plan interpreter now accepts op format_string/formatString and log with args. Fixes #549