### PR TITLE
Fix #550: Window approx_count_distinct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **#550 – Window function approx_count_distinct (PySpark parity)** — Plan interpreter now supports `approx_count_distinct(col).over(window)` in window expressions. Fixes #550.
 - **#549 – format_string and log() as expression op (PySpark parity)** — Plan interpreter now accepts `{"op": "format_string"|"formatString"|"log", "args": [...]}`. Fixes #549.
 - **#548 – date_trunc and to_date as expression op (PySpark parity)** — Plan interpreter now accepts `{"op": "date_trunc"|"dateTrunc"|"to_date"|"toDate", "args": [...]}`. Fixes #548.
 - **#547 – String functions as expression op (PySpark parity)** — Plan interpreter now accepts translate, substring_index, levenshtein, soundex, crc32, xxhash64, get_json_object, json_tuple, and regexp_extract_all when sent as `{"op": "<name>", "args": [...]}` (and camelCase variants substringIndex, getJsonObject, jsonTuple, regexpExtractAll). Also added get_json_object and json_tuple to expr_from_fn. Fixes #547.

--- a/tests/issue_550_window_approx_count_distinct.rs
+++ b/tests/issue_550_window_approx_count_distinct.rs
@@ -1,0 +1,54 @@
+//! Regression tests for issue #550 – Window function approx_count_distinct (PySpark parity).
+
+mod common;
+
+use common::spark;
+use robin_sparkless::plan;
+use serde_json::json;
+
+#[test]
+fn issue_550_plan_window_approx_count_distinct() {
+    let session = spark();
+    let data = vec![
+        vec![json!("A"), json!(1)],
+        vec![json!("A"), json!(10)],
+        vec![json!("B"), json!(5)],
+    ];
+    let schema = vec![
+        ("type".to_string(), "string".to_string()),
+        ("value".to_string(), "bigint".to_string()),
+    ];
+    let plan_ops = vec![json!({
+        "op": "withColumn",
+        "payload": {
+            "name": "approx_distinct",
+            "expr": {
+                "fn": "approx_count_distinct",
+                "args": [{"col": "value"}],
+                "window": {"partition_by": ["type"]}
+            }
+        }
+    })];
+    let df = plan::execute_plan(&session, data, schema, &plan_ops).unwrap();
+    let rows = df.collect_as_json_rows().unwrap();
+    assert_eq!(rows.len(), 3);
+    // Partition A: two distinct values (1, 10) -> 2; partition B: one value -> 1
+    let a_rows: Vec<_> = rows
+        .iter()
+        .filter(|r| r.get("type").and_then(|v| v.as_str()) == Some("A"))
+        .collect();
+    let b_rows: Vec<_> = rows
+        .iter()
+        .filter(|r| r.get("type").and_then(|v| v.as_str()) == Some("B"))
+        .collect();
+    assert_eq!(a_rows.len(), 2);
+    assert_eq!(b_rows.len(), 1);
+    assert_eq!(
+        a_rows[0].get("approx_distinct").and_then(|v| v.as_i64()),
+        Some(2)
+    );
+    assert_eq!(
+        b_rows[0].get("approx_distinct").and_then(|v| v.as_i64()),
+        Some(1)
+    );
+}


### PR DESCRIPTION
Plan interpreter now supports approx_count_distinct(col).over(window). Fixes #550