### PR TITLE
Fix #551: Union type coercion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **#551 – Union type coercion (PySpark parity)** — `union` now coerces columns to a common type when left and right have different dtypes (e.g. String vs Int64 → String). Fixes #551.
 - **#550 – Window function approx_count_distinct (PySpark parity)** — Plan interpreter now supports `approx_count_distinct(col).over(window)` in window expressions. Fixes #550.
 - **#549 – format_string and log() as expression op (PySpark parity)** — Plan interpreter now accepts `{"op": "format_string"|"formatString"|"log", "args": [...]}`. Fixes #549.
 - **#548 – date_trunc and to_date as expression op (PySpark parity)** — Plan interpreter now accepts `{"op": "date_trunc"|"dateTrunc"|"to_date"|"toDate", "args": [...]}`. Fixes #548.

--- a/tests/issue_551_union_type_coercion.rs
+++ b/tests/issue_551_union_type_coercion.rs
@@ -1,0 +1,30 @@
+//! Regression tests for issue #551 – Union type coercion (PySpark parity).
+
+mod common;
+
+use common::spark;
+use robin_sparkless::plan;
+use serde_json::json;
+
+#[test]
+fn issue_551_union_string_and_int64_coerces_to_string() {
+    let session = spark();
+    // Left: one row, x as string "a"
+    let data = vec![vec![json!("a")]];
+    let schema = vec![("x".to_string(), "string".to_string())];
+    // Union with right: one row, x as int 1 → common type String, so 1 becomes "1"
+    let plan_ops = vec![json!({
+        "op": "union",
+        "payload": {
+            "other_data": [[1]],
+            "other_schema": [{"name": "x", "type": "long"}]
+        }
+    })];
+    let df = plan::execute_plan(&session, data, schema, &plan_ops).unwrap();
+    let rows = df.collect_as_json_rows().unwrap();
+    assert_eq!(rows.len(), 2);
+    // First row from left: x = "a"
+    assert_eq!(rows[0].get("x").and_then(|v| v.as_str()), Some("a"));
+    // Second row from right: x was 1, coerced to string "1"
+    assert_eq!(rows[1].get("x").and_then(|v| v.as_str()), Some("1"));
+}


### PR DESCRIPTION
Union now coerces columns to a common type when left and right dtypes differ (e.g. String vs Int64). Fixes #551