### PR TITLE
Fix #553: Empty DataFrame schema and table ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **#553 – Empty DataFrame schema and table ops (PySpark parity)** — Empty DataFrame with explicit schema is supported: `create_dataframe_from_rows([], schema)`, `saveAsTable`, and `spark.table()` work (PySpark raises "can not infer schema from empty dataset"). Regression test added. Fixes #553.
 - **#552 – Inner/left join return 0 rows (PySpark parity)** — Plan interpreter now parses join `on` as array of column refs or eq expressions (Sparkless v4 format) and aligns right join key column names to left’s so inner/left join return correct row counts. Fixes #552.
 - **#551 – Union type coercion (PySpark parity)** — `union` now coerces columns to a common type when left and right have different dtypes (e.g. String vs Int64 → String). Fixes #551.
 - **#550 – Window function approx_count_distinct (PySpark parity)** — Plan interpreter now supports `approx_count_distinct(col).over(window)` in window expressions. Fixes #550.

--- a/tests/issue_553_empty_dataframe_schema_table.rs
+++ b/tests/issue_553_empty_dataframe_schema_table.rs
@@ -1,0 +1,31 @@
+//! Regression tests for issue #553 – Empty DataFrame with explicit schema and table ops (PySpark parity).
+//!
+//! PySpark raises "can not infer schema from empty dataset"; robin-sparkless supports
+//! createDataFrame([], schema), saveAsTable, and spark.table() on empty DF.
+
+mod common;
+
+use common::spark;
+use robin_sparkless::SaveMode;
+
+#[test]
+fn issue_553_empty_df_save_as_table_then_table_count_zero() {
+    let session = spark();
+    let schema = vec![
+        ("id".to_string(), "int".to_string()),
+        ("name".to_string(), "string".to_string()),
+    ];
+    let empty = session.create_dataframe_from_rows(vec![], schema).unwrap();
+    empty
+        .write()
+        .save_as_table(&session, "my_table", SaveMode::Overwrite)
+        .unwrap();
+    let t = session.table("my_table").unwrap();
+    assert_eq!(
+        t.count().unwrap(),
+        0,
+        "spark.table() on empty saved table must return 0 rows"
+    );
+    let cols = t.columns().unwrap();
+    assert_eq!(cols, vec!["id", "name"]);
+}


### PR DESCRIPTION
Documents and regression-tests empty DF with explicit schema, saveAsTable, spark.table(). Fixes #553