### PR TITLE
Fix #579: first() after orderBy returns first row in sort order (PySpark parity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **#579 – first() after orderBy returns first row in sort order (PySpark parity)** — `DataFrame.first()` now uses `limit(1)` then collect so that the first row is the first in the applied plan (e.g. after `orderBy(col)`), not the first in storage/input order. Fixes #579.
 - **#578 – create_map() with zero arguments returns {} not null (PySpark parity)** — `collect_as_json_rows` now serializes List and Struct AnyValues; empty map column yields JSON `{}` per row instead of `null`. Fixes #578.
 
 ### Planned


### PR DESCRIPTION
## Summary
`DataFrame.first()` after `orderBy(col)` now returns the **first row in sort order** (PySpark behavior), not the first row in storage/input order.

## Changes
- **`transformations::first()`**: Implemented as `limit(1)` then `collect_inner()`, so the first row is taken from the result of the full lazy plan (including any `orderBy`), not from a full collect then `.head(1)`.
- **Regression test**: `first_after_order_by_returns_first_in_sort_order` — creates df with (Charlie, 3), (Alice, 1), (Bob, 2), `orderBy("value")`, `first()`, asserts first row `name` is "Alice".

Fixes #579