### PR TITLE
Fix #581: isin() on Int64 column with literal list (PySpark parity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **#581 – isin() on Int64 column with literal list (PySpark parity)** — Filtering with `col("value").isin(1, 3)` when `value` is Int64 no longer fails with "cannot check for String values in Int64 data". The plan now builds an Int64 series for integer-only value lists and Float64 for float-only lists, so numeric columns match correctly. Fixes #581.
 - **#580 – Join with column expression when both tables have same key name (PySpark parity)** — Joining on a column that has the same name on both sides (e.g. `emp.join(dept, emp.dept_id == dept.dept_id)`) no longer fails with "duplicate: column with name 'dept_id' has more than one occurrence". Right join keys are renamed to temp names and the join uses `left_on`/`right_on` so Polars produces a single key column. Fixes #580.
 - **#579 – first() after orderBy returns first row in sort order (PySpark parity)** — `DataFrame.first()` now uses `limit(1)` then collect so that the first row is the first in the applied plan (e.g. after `orderBy(col)`), not the first in storage/input order. Fixes #579.
 - **#578 – create_map() with zero arguments returns {} not null (PySpark parity)** — `collect_as_json_rows` now serializes List and Struct AnyValues; empty map column yields JSON `{}` per row instead of `null`. Fixes #578.


### PR DESCRIPTION
## Summary
Fixes [issue #581](https://github.com/eddiethedean/robin-sparkless/issues/581): `col("value").isin(1, 3)` when `value` is Int64 no longer fails with `'is_in' cannot check for String values in Int64 data`.

## Cause
`try_values_for_isin` in the plan always built a **String** series from the value list (to support string columns with numeric literals). That caused a type mismatch when the column was Int64.

## Change
- **Plan (`src/plan/expr.rs`)**: When all values in the isin list are integers, build an **Int64** series; when all are floats, build **Float64**; otherwise keep **String** for mixed/string.
- **Test**: `plan_filter_isin_int64_column` in `tests/parity.rs` runs the plan with filter `isin(1, 3)` on a bigint column and asserts 2 rows with values 1 and 3.
- **CHANGELOG**: Entry under Fixed for #581.

## Testing
`make check-full` passes (fmt, clippy, audit, deny, tests).