### PR TITLE
Temp view: add test and docs for resolution

### DIFF
--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -30,6 +30,10 @@ Where no `_engine` variant exists, use the existing method and `.map_err(EngineE
 - **`StructType::to_json()`** / **`StructType::to_json_pretty()`** — Serialize the schema to a JSON string. Returns `Result<String, serde_json::Error>`.
 - **`schema_from_json(json)`** — Parse a schema from a JSON string (e.g. from the host). Returns `Result<StructType, EngineError>`.
 
+## Temp views
+
+- **Temp views** are **session-scoped**. After `create_or_replace_temp_view(name, df)`, the same session must be used for `table(name)` and `spark.sql("SELECT ... FROM name")`. If your binding (e.g. PyO3) uses a different session handle for `table()` or `sql()` than for `create_or_replace_temp_view()`, the view will not be found. Ensure the same `SparkSession` instance is used for both registration and lookup.
+
 ## Error handling
 
 - **`EngineError`** — Unified error type with variants: `User`, `Internal`, `Io`, `Sql`, `NotFound`, `Other`. Implements `From<PolarsError>`, `From<serde_json::Error>`, and `From<std::io::Error>`. Use `*_engine()` methods to get `Result<_, EngineError>` directly, or `.map_err(EngineError::from)` on APIs that still return `PolarsError`.

--- a/src/session.rs
+++ b/src/session.rs
@@ -2610,6 +2610,32 @@ mod tests {
         assert_eq!(rows[0].get("name").and_then(|v| v.as_str()), Some("Temp"));
     }
 
+    /// #629: Exact reproduction – createDataFrame, createOrReplaceTempView, then table() must resolve.
+    #[test]
+    fn test_issue_629_temp_view_visible_after_create() {
+        use serde_json::json;
+
+        let spark = SparkSession::builder().app_name("repro").get_or_create();
+        let schema = vec![
+            ("id".to_string(), "long".to_string()),
+            ("name".to_string(), "string".to_string()),
+        ];
+        let rows: Vec<Vec<JsonValue>> =
+            vec![vec![json!(1), json!("a")], vec![json!(2), json!("b")]];
+        let df = spark.create_dataframe_from_rows(rows, schema).unwrap();
+        spark.create_or_replace_temp_view("my_view", df);
+        let result = spark
+            .table("my_view")
+            .unwrap()
+            .collect_as_json_rows()
+            .unwrap();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].get("id").and_then(|v| v.as_i64()), Some(1));
+        assert_eq!(result[0].get("name").and_then(|v| v.as_str()), Some("a"));
+        assert_eq!(result[1].get("id").and_then(|v| v.as_i64()), Some(2));
+        assert_eq!(result[1].get("name").and_then(|v| v.as_str()), Some("b"));
+    }
+
     #[test]
     fn test_drop_table() {
         use crate::dataframe::SaveMode;


### PR DESCRIPTION
Fixes #629

- Add test that reproduces the issue flow (createDataFrame, createOrReplaceTempView, table). Test passes: crate behavior is correct when the same session is used.
- Document in EMBEDDING.md that temp views are session-scoped and bindings must use the same SparkSession for both create_or_replace_temp_view and table()/sql(). If "Table or view not found" appears in a binding, ensure the same session reference is used.