### PR TITLE
Support DESCRIBE DETAIL for Delta Lake

### DIFF
--- a/crates/robin-sparkless-polars/src/delta/mod.rs
+++ b/crates/robin-sparkless-polars/src/delta/mod.rs
@@ -147,6 +147,95 @@ fn uri_to_parquet_path(uri: &str) -> Result<std::path::PathBuf, PolarsError> {
     ))
 }
 
+/// Return a single-row DataFrame with Delta table metadata (DESCRIBE DETAIL parity).
+/// Columns: format, name, id, description, location, numFiles, sizeInBytes, minReaderVersion,
+/// minWriterVersion, partitionColumns, and optionally createdAt, lastModified, properties.
+#[cfg(feature = "delta")]
+pub fn describe_delta_detail(
+    path: impl AsRef<Path>,
+    table_display_name: Option<&str>,
+    case_sensitive: bool,
+) -> Result<DataFrame, PolarsError> {
+    use deltalake::DeltaTableBuilder;
+    use polars::prelude::*;
+    use tokio::runtime::Runtime;
+
+    let path = path.as_ref();
+    let table_uri = path_to_table_uri(path)?;
+
+    let rt = Runtime::new().map_err(|e| {
+        PolarsError::ComputeError(format!("describe_delta_detail: runtime: {}", e).into())
+    })?;
+
+    let url = Url::parse(table_uri.as_str()).map_err(|e| {
+        PolarsError::ComputeError(format!("describe_delta_detail: invalid URI: {}", e).into())
+    })?;
+
+    let table = rt.block_on(async {
+        let builder =
+            DeltaTableBuilder::from_url(url.clone()).map_err(|e: deltalake::DeltaTableError| {
+                PolarsError::ComputeError(format!("describe_delta_detail: {}", e).into())
+            })?;
+        let t = builder
+            .load()
+            .await
+            .map_err(|e: deltalake::DeltaTableError| {
+                PolarsError::ComputeError(format!("describe_delta_detail: load: {}", e).into())
+            })?;
+        Ok::<_, PolarsError>(t)
+    })?;
+
+    let snapshot = table.snapshot().map_err(|e: deltalake::DeltaTableError| {
+        PolarsError::ComputeError(format!("describe_delta_detail: snapshot: {}", e).into())
+    })?;
+
+    let meta = snapshot.metadata();
+    let protocol = snapshot.protocol();
+    let log_data = snapshot.log_data();
+    let num_files = log_data.num_files();
+
+    let name = table_display_name
+        .map(String::from)
+        .or_else(|| meta.name().map(String::from))
+        .unwrap_or_else(|| path.display().to_string());
+    let id = meta.id().to_string();
+    let description = meta.description().map(String::from);
+    let location = table_uri.clone();
+    let format = "delta".to_string();
+    let min_reader_version = protocol.min_reader_version() as i64;
+    let min_writer_version = protocol.min_writer_version() as i64;
+    let partition_columns: Vec<String> = meta.partition_columns().to_vec();
+    let partition_columns_json =
+        serde_json::to_string(&partition_columns).unwrap_or_else(|_| "[]".to_string());
+
+    // sizeInBytes: sum of file sizes from add actions (LogicalFileView::size())
+    let size_in_bytes: i64 = log_data.iter().map(|view| view.size()).sum();
+
+    let created_at = meta.created_time();
+    let version = snapshot.version();
+
+    let df = polars::prelude::DataFrame::new_infer_height(vec![
+        Series::new("format".into(), [format]).into(),
+        Series::new("name".into(), [name]).into(),
+        Series::new("id".into(), [id]).into(),
+        Series::new("description".into(), [description]).into(),
+        Series::new("location".into(), [location]).into(),
+        Series::new("numFiles".into(), [num_files as i64]).into(),
+        Series::new("sizeInBytes".into(), [size_in_bytes]).into(),
+        Series::new("minReaderVersion".into(), [min_reader_version]).into(),
+        Series::new("minWriterVersion".into(), [min_writer_version]).into(),
+        Series::new("partitionColumns".into(), [partition_columns_json]).into(),
+        Series::new("createdAt".into(), [created_at]).into(),
+        Series::new("version".into(), [version]).into(),
+    ])
+    .map_err(|e| PolarsError::ComputeError(format!("describe_delta_detail: df: {}", e).into()))?;
+
+    Ok(crate::dataframe::DataFrame::from_polars_with_options(
+        df,
+        case_sensitive,
+    ))
+}
+
 /// Write this DataFrame to a Delta table at the given path.
 /// If `overwrite` is true, replaces the table; otherwise appends.
 /// Uses Parquet write + convert_to_delta for new/overwrite; appends by reading existing table, concatenating, then overwriting.

--- a/crates/robin-sparkless-polars/src/plan/mod.rs
+++ b/crates/robin-sparkless-polars/src/plan/mod.rs
@@ -599,13 +599,15 @@ fn parse_aggs(aggs: &[Value], df: &DataFrame) -> Result<Vec<polars::prelude::Exp
         };
         let mut expr = col_expr.into_expr();
         // #672: PySpark-style result column names (e.g. avg(Value)) when plan does not set alias.
-        let alias = obj.get("alias").and_then(Value::as_str).map(String::from).unwrap_or_else(|| {
-            match (agg, col_name) {
+        let alias = obj
+            .get("alias")
+            .and_then(Value::as_str)
+            .map(String::from)
+            .unwrap_or_else(|| match (agg, col_name) {
                 ("count", None) => "count".to_string(),
                 (a, Some(col)) => format!("{}({})", a, col),
                 (a, None) => format!("{}({})", a, ""),
-            }
-        });
+            });
         expr = expr.alias(&alias);
         out.push(expr);
     }
@@ -643,7 +645,7 @@ mod tests {
         let out = df.collect_inner().unwrap();
         let names = out.get_column_names();
         assert!(
-            names.iter().any(|s| s.to_string() == "avg(Value)"),
+            names.iter().any(|s| s.as_str() == "avg(Value)"),
             "expected column 'avg(Value)' in {:?}",
             names
         );

--- a/crates/robin-sparkless-polars/src/session/mod.rs
+++ b/crates/robin-sparkless-polars/src/session/mod.rs
@@ -920,6 +920,19 @@ impl SparkSession {
             .filter(|s| !s.is_empty())
     }
 
+    /// Resolve a table name to a Delta table path (warehouse/name if it contains _delta_log).
+    /// Returns None if the table is not a warehouse-backed Delta table (DESCRIBE DETAIL support).
+    #[cfg(feature = "delta")]
+    pub fn resolve_delta_table_path(&self, table_name: &str) -> Option<std::path::PathBuf> {
+        let warehouse = self.warehouse_dir()?;
+        let path = Path::new(warehouse).join(table_name);
+        if path.is_dir() && path.join("_delta_log").is_dir() {
+            Some(path)
+        } else {
+            None
+        }
+    }
+
     /// Look up a table or temp view by name (PySpark: table(name)).
     /// Resolution order: (1) global_temp.xyz from global catalog, (2) temp view, (3) saved table, (4) warehouse.
     pub fn table(&self, name: &str) -> Result<DataFrame, PolarsError> {


### PR DESCRIPTION
Fixes #678

## Summary
- **delta:** `describe_delta_detail(path, table_display_name, case_sensitive)` returns a single-row DataFrame with columns: format, name, id, description, location, numFiles, sizeInBytes, minReaderVersion, minWriterVersion, partitionColumns, createdAt, version (PySpark DESCRIBE DETAIL parity).
- **session:** `resolve_delta_table_path(table_name)` returns `Some(path)` when `spark.sql.warehouse.dir` is set and `{warehouse}/{table_name}` contains `_delta_log`.
- **sql:** `execute_sql("DESCRIBE DETAIL table_name")` is handled before parsing; resolves the table to the warehouse Delta path and returns the detail row.
- **test:** `test_sql_describe_detail_delta` (requires `sql` + `delta` features) creates a Delta table in a temp warehouse and asserts one row with `format == "delta"`, `numFiles >= 0`, `sizeInBytes >= 0`, and presence of `minReaderVersion`/`minWriterVersion`.

`make check-full` passes.