### PR TITLE
Join/union type coercion String vs Int64 (fixes #681)

### DIFF
--- a/crates/robin-sparkless-polars/src/dataframe/joins.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/joins.rs
@@ -293,6 +293,26 @@ mod tests {
         assert!(rows.column("x").is_ok());
     }
 
+    /// #681: Join when key types differ (Int64 on left, String on right): coerces to common type (String).
+    #[test]
+    fn join_key_type_coercion_int_str() {
+        use polars::prelude::df;
+        let spark = SparkSession::builder()
+            .app_name("join_tests")
+            .get_or_create();
+        let left_pl = df!("id" => &[1i64, 2i64], "name" => &["alice", "bob"]).unwrap();
+        let right_pl = df!("id" => &["1", "3"], "value" => &[100i64, 300i64]).unwrap();
+        let left = spark.create_dataframe_from_polars(left_pl);
+        let right = spark.create_dataframe_from_polars(right_pl);
+        let out = join(&left, &right, vec!["id"], JoinType::Inner, false).unwrap();
+        assert_eq!(out.count().unwrap(), 1, "inner join on id: 1 match (id=1)");
+        let rows = out.collect().unwrap();
+        assert_eq!(rows.height(), 1);
+        assert!(rows.column("id").is_ok());
+        assert!(rows.column("name").is_ok());
+        assert!(rows.column("value").is_ok());
+    }
+
     /// Issue #604: join when key names differ in case (left "id", right "ID"); collect must not fail with "not found: ID".
     #[test]
     fn join_column_resolution_case_insensitive() {

--- a/crates/robin-sparkless-polars/src/dataframe/transformations.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/transformations.rs
@@ -1413,7 +1413,9 @@ pub fn intersect_all(
 
 #[cfg(test)]
 mod tests {
-    use super::{distinct, drop, dropna, first, head, limit, offset, order_by, union_by_name};
+    use super::{
+        distinct, drop, dropna, first, head, limit, offset, order_by, union, union_by_name,
+    };
     use crate::{DataFrame, SparkSession};
     use serde_json::json;
 
@@ -1518,6 +1520,26 @@ mod tests {
         let cols = out.columns().unwrap();
         assert!(!cols.contains(&"v".to_string()));
         assert_eq!(out.count().unwrap(), 3);
+    }
+
+    /// #681: union (same column order) with Int64 vs String in same position coerces to common type.
+    #[test]
+    fn union_coerces_int_str_same_position() {
+        use polars::prelude::df;
+
+        let spark = SparkSession::builder()
+            .app_name("transform_tests")
+            .get_or_create();
+        let left_pl = df!("id" => &[1i64, 2i64], "name" => &["a", "b"]).unwrap();
+        let right_pl = df!("id" => &["3", "4"], "name" => &["c", "d"]).unwrap();
+        let left = spark.create_dataframe_from_polars(left_pl);
+        let right = spark.create_dataframe_from_polars(right_pl);
+        let out = union(&left, &right, false).expect("#681: union must coerce id Int64 vs String");
+        assert_eq!(out.count().unwrap(), 4);
+        let cols = out.columns().unwrap();
+        assert_eq!(cols.len(), 2);
+        assert!(cols.contains(&"id".to_string()));
+        assert!(cols.contains(&"name".to_string()));
     }
 
     /// Issue #603: unionByName with same-named columns of different types (e.g. id Int vs id String) must coerce and succeed.

--- a/crates/robin-sparkless-polars/src/type_coercion.rs
+++ b/crates/robin-sparkless-polars/src/type_coercion.rs
@@ -32,8 +32,21 @@ fn dtype_to_precedence(dtype: &DataType) -> Option<TypePrecedence> {
 }
 
 /// Determine the common type for two columns based on PySpark's type precedence rules
-/// Returns the tightest (highest precedence) common type that both can be coerced to
+/// Returns the tightest (highest precedence) common type that both can be coerced to.
+/// #681: Unknown dtype is treated as String so join/union with Int64 vs Unknown coerce to String (PySpark parity).
 pub fn find_common_type(left: &DataType, right: &DataType) -> Result<DataType, PolarsError> {
+    let left_norm = if matches!(left, DataType::Unknown(_)) {
+        DataType::String
+    } else {
+        left.clone()
+    };
+    let right_norm = if matches!(right, DataType::Unknown(_)) {
+        DataType::String
+    } else {
+        right.clone()
+    };
+    let left = &left_norm;
+    let right = &right_norm;
     let left_prec = dtype_to_precedence(left);
     let right_prec = dtype_to_precedence(right);
 


### PR DESCRIPTION
Fixes #681

- **type_coercion**: In `find_common_type`, treat `Unknown` dtype as `String` so join and union with Int64 vs Unknown (or untyped) coerce to String (PySpark parity, same as union_by_name #613).
- **joins**: Add `join_key_type_coercion_int_str` test (left id Int64, right id String; inner join yields 1 row).
- **transformations**: Add `union_coerces_int_str_same_position` test for union with Int64 vs String in same column position.