### PR TITLE
PR3: Coercion - allow cast string to Boolean

### DIFF
--- a/crates/robin-sparkless-polars/src/dataframe/transformations.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/transformations.rs
@@ -108,6 +108,7 @@ pub fn select_items(
 /// Filter rows using a Polars expression. Preserves case_sensitive on result.
 /// Column names in the condition are resolved per df's case sensitivity (PySpark parity).
 /// #646: Coerce predicate to Boolean so Polars never receives a non-Boolean filter (e.g. string-involving predicates).
+/// Uses expr_coerce_to_boolean so string columns cast via "true"/"false"/"1"/"0" (PySpark parity).
 pub fn filter(
     df: &DataFrame,
     condition: Expr,
@@ -115,7 +116,7 @@ pub fn filter(
 ) -> Result<DataFrame, PolarsError> {
     let condition = df.resolve_expr_column_names(condition)?;
     let condition = df.coerce_string_numeric_comparisons(condition)?;
-    let condition = condition.cast(DataType::Boolean);
+    let condition = crate::functions::expr_coerce_to_boolean(condition);
     let lf = df.lazy_frame().filter(condition);
     Ok(super::DataFrame::from_lazy_with_options(lf, case_sensitive))
 }

--- a/crates/robin-sparkless-polars/src/functions/rest.rs
+++ b/crates/robin-sparkless-polars/src/functions/rest.rs
@@ -430,17 +430,17 @@ pub fn regr_r2_expr(y_col: &str, x_col: &str) -> Expr {
 ///     .then(&lit_str("adult"))
 ///     .otherwise(&lit_str("minor"));
 /// ```
-/// Condition must be Boolean; then/else can be any type (#680).
+/// Condition must be Boolean; then/else can be any type (#680). String conditions coerced via expr_coerce_to_boolean.
 pub fn when(condition: &Column) -> WhenBuilder {
-    WhenBuilder::new(condition.expr().clone().cast(DataType::Boolean))
+    WhenBuilder::new(expr_coerce_to_boolean(condition.expr().clone()))
 }
 
 /// Two-arg when(condition, value): returns value where condition is true, null otherwise (PySpark when(cond, val)).
-/// Condition must be Boolean; value can be any type (#680).
+/// Condition must be Boolean; value can be any type (#680). String conditions coerced via expr_coerce_to_boolean.
 pub fn when_then_otherwise_null(condition: &Column, value: &Column) -> Column {
     use polars::prelude::*;
     let null_expr = lit(NULL);
-    let expr = polars::prelude::when(condition.expr().clone().cast(DataType::Boolean))
+    let expr = polars::prelude::when(expr_coerce_to_boolean(condition.expr().clone()))
         .then(value.expr().clone())
         .otherwise(null_expr);
     crate::column::Column::from_expr(expr, None)
@@ -505,9 +505,9 @@ impl ThenBuilder {
     }
 
     /// Chain an additional when-then clause (PySpark: when(a).then(x).when(b).then(y).otherwise(z)).
-    /// Condition must be Boolean (#680).
+    /// Condition must be Boolean (#680). String conditions coerced via expr_coerce_to_boolean.
     pub fn when(self, condition: &Column) -> ChainedWhenBuilder {
-        let cond = condition.expr().clone().cast(DataType::Boolean);
+        let cond = expr_coerce_to_boolean(condition.expr().clone());
         let chained_when = match self.state {
             WhenThenState::Single(t) => t.when(cond),
             WhenThenState::Chained(ct) => ct.when(cond),
@@ -1278,6 +1278,16 @@ pub fn signum(column: &Column) -> Column {
 /// Alias for signum (PySpark sign).
 pub fn sign(column: &Column) -> Column {
     signum(column)
+}
+
+/// Coerce expression to Boolean (PySpark semantics). String -> boolean via "true"/"false"/"1"/"0";
+/// numeric -> boolean (0/0.0 false, else true); already Boolean passed through.
+/// Use for filter predicates and when/not conditions so string columns never hit Polars' unsupported Utf8->Boolean cast.
+pub fn expr_coerce_to_boolean(expr: Expr) -> Expr {
+    expr.map(
+        move |col| crate::column::expect_col(crate::udfs::apply_string_to_boolean(col, false)),
+        |_schema, field| Ok(Field::new(field.name().clone(), DataType::Boolean)),
+    )
 }
 
 fn cast_impl(column: &Column, type_name: &str, strict: bool) -> Result<Column, String> {
@@ -2972,7 +2982,9 @@ mod tests {
             .collect()
             .unwrap();
         let out = result_df.column("out").unwrap();
-        let values: Vec<Option<i64>> = out.i64().unwrap().into_iter().collect();
+        // Polars may infer i32 for when/then/otherwise with small literals; cast to i64 for stable assertion.
+        let out_i64 = out.cast(&DataType::Int64).unwrap();
+        let values: Vec<Option<i64>> = out_i64.i64().unwrap().into_iter().collect();
         assert_eq!(values, vec![Some(0), Some(100), Some(100)]);
     }
 

--- a/crates/robin-sparkless-polars/src/plan/expr.rs
+++ b/crates/robin-sparkless-polars/src/plan/expr.rs
@@ -156,12 +156,12 @@ pub fn expr_from_value(v: &Value) -> Result<Expr, PlanExprError> {
                 return Ok(expr_from_value(left)?.or(expr_from_value(right)?));
             }
             "not" => {
-                // #682: Cast to Boolean before .not() so Unknown(Any) or non-Boolean columns work (PySpark parity).
+                // #682: Coerce to Boolean before .not() so Unknown(Any) or string columns work (PySpark parity; string->boolean via expr_coerce_to_boolean).
                 let arg = obj
                     .get("arg")
                     .ok_or_else(|| PlanExprError("op 'not' requires 'arg'".to_string()))?;
                 let arg_expr = expr_from_value(arg)?;
-                return Ok(arg_expr.cast(DataType::Boolean).not());
+                return Ok(crate::functions::expr_coerce_to_boolean(arg_expr).not());
             }
             "between" => {
                 let left_v = obj
@@ -1202,8 +1202,8 @@ fn expr_from_fn(name: &str, args: &[Value]) -> Result<Expr, PlanExprError> {
                     "fn '{name}' two-arg form requires [condition, then_expr]"
                 )));
             }
-            // #680: only the condition must be Boolean; then/else can be any type
-            let cond_expr = arg_expr(args, 0)?.cast(DataType::Boolean);
+            // #680: only the condition must be Boolean; then/else can be any type (string->boolean via expr_coerce_to_boolean).
+            let cond_expr = crate::functions::expr_coerce_to_boolean(arg_expr(args, 0)?);
             let cond = expr_to_column(cond_expr);
             let then_val = expr_to_column(arg_expr(args, 1)?);
             Ok(when_then_otherwise_null(&cond, &then_val).into_expr())


### PR DESCRIPTION
## Summary
Implements **PR3** from the open-issues grouped PR plan: allow cast string to Boolean so Sparkless backend no longer fails with "casting from Utf8View to Boolean not supported".

## Changes
- Add `expr_coerce_to_boolean()` that uses existing string→boolean parsing ("true"/"false"/"1"/"0") via `apply_string_to_boolean` instead of Polars' direct cast.
- Use it in: `filter()`, plan `not`, plan `when` two-arg, and `when()` / `when_then_otherwise_null` / `ThenBuilder::when` so string conditions work.
- Fix `test_when_then_otherwise_numeric_then_else` to cast result to i64 for stable assertion.

## Issues
Fixes #693, #702, #713, #726, #857, #864, #871, #872