### PR TITLE
PR4: Type coercion - string vs numeric in select paths

### DIFF
--- a/crates/robin-sparkless-polars/src/dataframe/transformations.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/transformations.rs
@@ -48,6 +48,10 @@ pub fn select_with_exprs(
         .into_iter()
         .map(|e| df.resolve_expr_column_names(e))
         .collect::<Result<Vec<_>, _>>()?;
+    let exprs: Vec<Expr> = exprs
+        .into_iter()
+        .map(|e| df.coerce_string_numeric_comparisons(e))
+        .collect::<Result<Vec<_>, _>>()?;
     let mut name_count: HashMap<String, u32> = HashMap::new();
     let exprs: Vec<Expr> = exprs
         .into_iter()
@@ -98,7 +102,8 @@ pub fn select_items(
             }
             SelectItem::Expr(e) => {
                 let resolved = df.resolve_expr_column_names(e)?;
-                exprs.push(resolved);
+                let coerced = df.coerce_string_numeric_comparisons(resolved)?;
+                exprs.push(coerced);
             }
         }
     }


### PR DESCRIPTION
## Summary
Apply string–numeric coercion in select paths so schema/select with comparisons behave like PySpark.

## Changes
- `select_with_exprs`: coerce each expression via `coerce_string_numeric_comparisons` after resolve.
- `select_items`: coerce each `Expr` item via `coerce_string_numeric_comparisons`.

Fixes #763, #769, #772, #697, #855, #856, #870, #883, #731, #733