### PR TITLE
PR2: orderBy - accept columns as objects (col/name)

### DIFF
--- a/crates/robin-sparkless-polars/src/plan/mod.rs
+++ b/crates/robin-sparkless-polars/src/plan/mod.rs
@@ -350,10 +350,18 @@ fn apply_op(
                 .ok_or_else(|| {
                     PlanError::InvalidPlan("orderBy payload must have 'columns' array".into())
                 })?;
+            // Each element: string (column name) or object {"col": "name"} / {"type": "column", "name": "x"} (PR2).
             let col_names: Vec<String> = columns
                 .iter()
-                .filter_map(|v| v.as_str())
-                .map(|s| df.resolve_column_name(s))
+                .filter_map(|v| {
+                    v.as_str()
+                        .map(|s| s.to_string())
+                        .or_else(|| {
+                            v.get("col").and_then(Value::as_str).map(|s| s.to_string())
+                                .or_else(|| v.get("name").and_then(Value::as_str).map(|s| s.to_string()))
+                        })
+                })
+                .map(|s| df.resolve_column_name(s.as_str()))
                 .collect::<Result<Vec<_>, _>>()
                 .map_err(PlanError::Session)?;
             let ascending = payload


### PR DESCRIPTION
orderBy: support columns array elements as {"col": "name"} or {"name": "x"}. Fixes #739, #757, #758, #865, #866, #867, #868, #864, #740