### PR TITLE
PR7: Join - accept leftsemi/leftanti

### DIFF
--- a/crates/robin-sparkless-polars/src/plan/mod.rs
+++ b/crates/robin-sparkless-polars/src/plan/mod.rs
@@ -519,8 +519,8 @@ fn apply_op(
                 "left" => JoinType::Left,
                 "right" => JoinType::Right,
                 "outer" => JoinType::Outer,
-                "left_semi" | "semi" => JoinType::LeftSemi,
-                "left_anti" | "anti" => JoinType::LeftAnti,
+                "left_semi" | "leftsemi" | "semi" => JoinType::LeftSemi,
+                "left_anti" | "leftanti" | "anti" => JoinType::LeftAnti,
                 _ => JoinType::Inner,
             };
             df.join(&other_df, on_refs, join_type)


### PR DESCRIPTION
Plan join type: accept 'leftsemi' and 'leftanti'. Fixes #719, #882