### PR TITLE
PR18: Parity - smallint/tinyint type names in schema

### DIFF
--- a/crates/robin-sparkless-polars/src/session/mod.rs
+++ b/crates/robin-sparkless-polars/src/session/mod.rs
@@ -1221,7 +1221,7 @@ impl SparkSession {
         for (col_idx, (name, type_str)) in schema.iter().enumerate() {
             let type_lower = type_str.trim().to_lowercase();
             let s = match type_lower.as_str() {
-                "int" | "integer" | "bigint" | "long" => {
+                "int" | "integer" | "bigint" | "long" | "smallint" | "tinyint" => {
                     let vals: Vec<Option<i64>> = rows
                         .iter()
                         .map(|row| {


### PR DESCRIPTION
create_dataframe_from_rows: accept smallint and tinyint as schema type names (PySpark parity).