### PR TITLE
PR-2: SQL Case with alias and JOIN ON different column names

### DIFF
--- a/crates/robin-sparkless-polars/src/dataframe/joins.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/joins.rs
@@ -23,22 +23,29 @@ pub enum JoinType {
 /// When join key types differ (e.g. str vs int), coerces both sides to a common type (PySpark parity #274).
 /// When both tables have the same join key column name(s), renames the right's keys to temp names and
 /// uses left_on/right_on so Polars does not error with "duplicate column" (issue #580, PySpark parity).
-/// When left/right key names differ in casing (e.g. "id" vs "ID"), aliases right keys to left names
-/// so the result has one key column name and col("ID")/col("id") both resolve (PySpark parity #604).
+/// When left/right key names differ in casing or name (e.g. "id" vs "ID" or "id" vs "other_id"), aliases right keys to left names
+/// so the result has one key column name (PySpark parity #604, #743).
 /// For Right and Outer, reorders columns to match PySpark: key(s), then left non-key, then right non-key.
+/// `left_on` and `right_on` must have the same length; keys are matched by position.
 pub fn join(
     left: &DataFrame,
     right: &DataFrame,
-    on: Vec<&str>,
+    left_on: Vec<&str>,
+    right_on: Vec<&str>,
     how: JoinType,
     case_sensitive: bool,
 ) -> Result<DataFrame, PolarsError> {
     use polars::prelude::{JoinBuilder, JoinCoalesce, col};
+    if left_on.len() != right_on.len() {
+        return Err(PolarsError::ComputeError(
+            "join: left_on and right_on must have the same length".into(),
+        ));
+    }
     let mut left_lf = left.lazy_frame();
     let mut right_lf = right.lazy_frame();
 
-    // Resolve key names on both sides so we can alias right keys to left names (#604).
-    let left_key_names: Vec<String> = on
+    // Resolve key names on both sides so we can alias right keys to left names (#604, #743).
+    let left_key_names: Vec<String> = left_on
         .iter()
         .map(|k| {
             left.resolve_column_name(k).map_err(|e| {
@@ -46,7 +53,7 @@ pub fn join(
             })
         })
         .collect::<Result<_, _>>()?;
-    let right_key_names: Vec<String> = on
+    let right_key_names: Vec<String> = right_on
         .iter()
         .map(|k| {
             right.resolve_column_name(k).map_err(|e| {
@@ -56,10 +63,10 @@ pub fn join(
         .collect::<Result<_, _>>()?;
 
     // Coerce join keys to a common type when left/right dtypes differ (PySpark #274).
-    // Alias right keys to left key names so result has one key column name (#604).
+    // Alias right keys to left key names so result has one key column name (#604, #743).
     let mut left_casts: Vec<Expr> = Vec::new();
     let mut right_casts: Vec<Expr> = Vec::new();
-    for (i, key) in on.iter().enumerate() {
+    for (i, key) in left_on.iter().enumerate() {
         let left_name = &left_key_names[i];
         let right_name = &right_key_names[i];
         let left_dtype = left.get_column_dtype(left_name.as_str()).ok_or_else(|| {
@@ -90,7 +97,7 @@ pub fn join(
         right_lf = right_lf.with_columns(right_casts);
         // #614: Drop right's original key columns when we aliased to left names, so the result
         // has only the left key name (e.g. "id") and collect does not fail with "not found: ID".
-        let drop_right: std::collections::HashSet<String> = on
+        let drop_right: std::collections::HashSet<String> = left_on
             .iter()
             .enumerate()
             .filter(|(i, _)| left_key_names[*i] != right_key_names[*i])
@@ -214,7 +221,15 @@ mod tests {
     fn inner_join() {
         let left = left_df();
         let right = right_df();
-        let out = join(&left, &right, vec!["id"], JoinType::Inner, false).unwrap();
+        let out = join(
+            &left,
+            &right,
+            vec!["id"],
+            vec!["id"],
+            JoinType::Inner,
+            false,
+        )
+        .unwrap();
         assert_eq!(out.count().unwrap(), 1);
         let cols = out.columns().unwrap();
         assert!(cols.iter().any(|c| c == "id" || c.ends_with("_right")));
@@ -224,7 +239,7 @@ mod tests {
     fn left_join() {
         let left = left_df();
         let right = right_df();
-        let out = join(&left, &right, vec!["id"], JoinType::Left, false).unwrap();
+        let out = join(&left, &right, vec!["id"], vec!["id"], JoinType::Left, false).unwrap();
         assert_eq!(out.count().unwrap(), 2);
     }
 
@@ -232,7 +247,15 @@ mod tests {
     fn right_join() {
         let left = left_df();
         let right = right_df();
-        let out = join(&left, &right, vec!["id"], JoinType::Right, false).unwrap();
+        let out = join(
+            &left,
+            &right,
+            vec!["id"],
+            vec!["id"],
+            JoinType::Right,
+            false,
+        )
+        .unwrap();
         assert_eq!(out.count().unwrap(), 2); // right has id 1,3; left matches 1
     }
 
@@ -240,7 +263,15 @@ mod tests {
     fn outer_join() {
         let left = left_df();
         let right = right_df();
-        let out = join(&left, &right, vec!["id"], JoinType::Outer, false).unwrap();
+        let out = join(
+            &left,
+            &right,
+            vec!["id"],
+            vec!["id"],
+            JoinType::Outer,
+            false,
+        )
+        .unwrap();
         assert_eq!(out.count().unwrap(), 3);
     }
 
@@ -248,7 +279,15 @@ mod tests {
     fn left_semi_join() {
         let left = left_df();
         let right = right_df();
-        let out = join(&left, &right, vec!["id"], JoinType::LeftSemi, false).unwrap();
+        let out = join(
+            &left,
+            &right,
+            vec!["id"],
+            vec!["id"],
+            JoinType::LeftSemi,
+            false,
+        )
+        .unwrap();
         assert_eq!(out.count().unwrap(), 1); // left rows with match in right (id 1)
     }
 
@@ -256,7 +295,15 @@ mod tests {
     fn left_anti_join() {
         let left = left_df();
         let right = right_df();
-        let out = join(&left, &right, vec!["id"], JoinType::LeftAnti, false).unwrap();
+        let out = join(
+            &left,
+            &right,
+            vec!["id"],
+            vec!["id"],
+            JoinType::LeftAnti,
+            false,
+        )
+        .unwrap();
         assert_eq!(out.count().unwrap(), 1); // left rows with no match (id 2)
     }
 
@@ -269,7 +316,15 @@ mod tests {
         let right = spark
             .create_dataframe(vec![] as Vec<(i64, i64, String)>, vec!["id", "w", "tag"])
             .unwrap();
-        let out = join(&left, &right, vec!["id"], JoinType::Inner, false).unwrap();
+        let out = join(
+            &left,
+            &right,
+            vec!["id"],
+            vec!["id"],
+            JoinType::Inner,
+            false,
+        )
+        .unwrap();
         assert_eq!(out.count().unwrap(), 0);
     }
 
@@ -284,7 +339,15 @@ mod tests {
         let right_pl = df!("id" => &[1i64], "x" => &[10i64]).unwrap();
         let left = spark.create_dataframe_from_polars(left_pl);
         let right = spark.create_dataframe_from_polars(right_pl);
-        let out = join(&left, &right, vec!["id"], JoinType::Inner, false).unwrap();
+        let out = join(
+            &left,
+            &right,
+            vec!["id"],
+            vec!["id"],
+            JoinType::Inner,
+            false,
+        )
+        .unwrap();
         assert_eq!(out.count().unwrap(), 1);
         let rows = out.collect().unwrap();
         assert_eq!(rows.height(), 1);
@@ -304,7 +367,15 @@ mod tests {
         let right_pl = df!("id" => &["1", "3"], "value" => &[100i64, 300i64]).unwrap();
         let left = spark.create_dataframe_from_polars(left_pl);
         let right = spark.create_dataframe_from_polars(right_pl);
-        let out = join(&left, &right, vec!["id"], JoinType::Inner, false).unwrap();
+        let out = join(
+            &left,
+            &right,
+            vec!["id"],
+            vec!["id"],
+            JoinType::Inner,
+            false,
+        )
+        .unwrap();
         assert_eq!(out.count().unwrap(), 1, "inner join on id: 1 match (id=1)");
         let rows = out.collect().unwrap();
         assert_eq!(rows.height(), 1);
@@ -324,8 +395,15 @@ mod tests {
         let right_pl = df!("ID" => &[1i64], "other" => &["x"]).unwrap();
         let left = spark.create_dataframe_from_polars(left_pl);
         let right = spark.create_dataframe_from_polars(right_pl);
-        let out = join(&left, &right, vec!["id"], JoinType::Inner, false)
-            .expect("issue #604: join on id/ID must succeed");
+        let out = join(
+            &left,
+            &right,
+            vec!["id"],
+            vec!["id"],
+            JoinType::Inner,
+            false,
+        )
+        .expect("issue #604: join on id/ID must succeed");
         assert_eq!(out.count().unwrap(), 1);
         let rows = out
             .collect()

--- a/crates/robin-sparkless-polars/src/dataframe/mod.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/mod.rs
@@ -863,7 +863,14 @@ impl DataFrame {
             .map(|c| self.resolve_column_name(c))
             .collect::<Result<Vec<_>, _>>()?;
         let on_refs: Vec<&str> = resolved.iter().map(|s| s.as_str()).collect();
-        join(self, other, on_refs, how, self.case_sensitive)
+        join(
+            self,
+            other,
+            on_refs.clone(),
+            on_refs,
+            how,
+            self.case_sensitive,
+        )
     }
 
     /// Order by columns (sort).

--- a/crates/robin-sparkless-polars/src/sql/mod.rs
+++ b/crates/robin-sparkless-polars/src/sql/mod.rs
@@ -453,6 +453,58 @@ mod tests {
         assert!(ids.contains(&3));
     }
 
+    /// PR-2/#776: CASE ... END AS alias in SELECT.
+    #[test]
+    fn test_sql_case_with_alias() {
+        let spark = SparkSession::builder().app_name("test").get_or_create();
+        let df = spark
+            .create_dataframe(
+                vec![
+                    (1i64, 10i64, "".to_string()),
+                    (2i64, 20i64, "".to_string()),
+                    (3i64, 30i64, "".to_string()),
+                ],
+                vec!["id", "v", "x"],
+            )
+            .unwrap();
+        spark.create_or_replace_temp_view("t", df);
+        let result = spark
+            .sql("SELECT id, CASE WHEN id = 1 THEN 'one' WHEN id = 2 THEN 'two' ELSE 'other' END AS label FROM t")
+            .unwrap();
+        assert_eq!(result.count().unwrap(), 3);
+        let rows = result.collect_as_json_rows().unwrap();
+        assert_eq!(rows[0].get("label").and_then(|v| v.as_str()), Some("one"));
+        assert_eq!(rows[1].get("label").and_then(|v| v.as_str()), Some("two"));
+        assert_eq!(rows[2].get("label").and_then(|v| v.as_str()), Some("other"));
+    }
+
+    /// PR-2/#743: JOIN ON with different column names (e.g. a.id = b.other_id).
+    #[test]
+    fn test_sql_join_on_different_column_names() {
+        let spark = SparkSession::builder().app_name("test").get_or_create();
+        let left = spark
+            .create_dataframe(
+                vec![(1i64, 0i64, "a".to_string()), (2i64, 0i64, "b".to_string())],
+                vec!["id", "v", "name"],
+            )
+            .unwrap();
+        let right = spark
+            .create_dataframe(
+                vec![(1i64, 0i64, "x".to_string()), (3i64, 0i64, "z".to_string())],
+                vec!["other_id", "v", "tag"],
+            )
+            .unwrap();
+        spark.create_or_replace_temp_view("l", left);
+        spark.create_or_replace_temp_view("r", right);
+        let result = spark
+            .sql("SELECT l.id, l.name, r.tag FROM l INNER JOIN r ON l.id = r.other_id")
+            .unwrap();
+        assert_eq!(result.count().unwrap(), 1);
+        let rows = result.collect_as_json_rows().unwrap();
+        assert_eq!(rows[0].get("id").and_then(|v| v.as_i64()), Some(1));
+        assert_eq!(rows[0].get("tag").and_then(|v| v.as_str()), Some("x"));
+    }
+
     /// PR-B/#774: SQL UNION and UNION ALL.
     #[test]
     fn test_sql_union_all() {

--- a/crates/robin-sparkless-polars/src/sql/translator.rs
+++ b/crates/robin-sparkless-polars/src/sql/translator.rs
@@ -7,7 +7,7 @@ use crate::column::Column;
 use crate::dataframe::{DataFrame, JoinType, join};
 use crate::functions;
 use crate::session::{SparkSession, set_thread_udf_session};
-use polars::prelude::{DataFrame as PlDataFrame, Expr, PolarsError, col, lit};
+use polars::prelude::{DataFrame as PlDataFrame, Expr, PolarsError, col, lit, when};
 use sqlparser::ast::{
     BinaryOperator, Expr as SqlExpr, Function, FunctionArg, FunctionArgExpr, FunctionArguments,
     GroupByExpr, JoinConstraint, JoinOperator, ObjectType, OrderByKind, Query, Select, SelectItem,
@@ -375,12 +375,14 @@ fn translate_select_from(
                         ));
                     }
                 };
-                let on_cols = join_condition_to_on_columns(&join_spec.join_operator)?;
-                let on_refs: Vec<&str> = on_cols.iter().map(|s| s.as_str()).collect();
+                let (left_on, right_on) = join_condition_to_on_columns(&join_spec.join_operator)?;
+                let left_refs: Vec<&str> = left_on.iter().map(|s| s.as_str()).collect();
+                let right_refs: Vec<&str> = right_on.iter().map(|s| s.as_str()).collect();
                 df = join(
                     &df,
                     &right_df,
-                    on_refs,
+                    left_refs,
+                    right_refs,
                     join_type,
                     session.is_case_sensitive(),
                 )?;
@@ -419,7 +421,10 @@ fn resolve_table_factor(
     }
 }
 
-fn join_condition_to_on_columns(join_op: &JoinOperator) -> Result<Vec<String>, PolarsError> {
+/// Returns (left_column_names, right_column_names) for JOIN ON. Same length; may differ (e.g. a.id = b.other_id) (#743).
+fn join_condition_to_on_columns(
+    join_op: &JoinOperator,
+) -> Result<(Vec<String>, Vec<String>), PolarsError> {
     let constraint = match join_op {
         JoinOperator::Inner(c)
         | JoinOperator::LeftOuter(c)
@@ -429,7 +434,7 @@ fn join_condition_to_on_columns(join_op: &JoinOperator) -> Result<Vec<String>, P
         | JoinOperator::LeftAnti(c)
         | JoinOperator::Semi(c)
         | JoinOperator::Anti(c) => c,
-        JoinOperator::CrossJoin(_) => return Ok(vec![]),
+        JoinOperator::CrossJoin(_) => return Ok((vec![], vec![])),
         _ => {
             return Err(PolarsError::InvalidOperation(
                 "SQL: only INNER/LEFT/RIGHT/FULL/LEFT SEMI/LEFT ANTI/CROSS JOIN with ON are supported.".into(),
@@ -445,12 +450,7 @@ fn join_condition_to_on_columns(join_op: &JoinOperator) -> Result<Vec<String>, P
             } => {
                 let l = sql_expr_to_col_name(left.as_ref())?;
                 let r = sql_expr_to_col_name(right.as_ref())?;
-                if l != r {
-                    return Err(PolarsError::InvalidOperation(
-                            "SQL: JOIN ON must use same column name on both sides (e.g. a.id = b.id where both become 'id').".into(),
-                        ));
-                }
-                Ok(vec![l])
+                Ok((vec![l], vec![r]))
             }
             _ => Err(PolarsError::InvalidOperation(
                 "SQL: JOIN ON must be a single equality (col = col).".into(),
@@ -567,6 +567,31 @@ fn sql_expr_to_polars(
             } else {
                 in_expr
             })
+        }
+        SqlExpr::Case {
+            operand,
+            conditions,
+            else_result,
+            ..
+        } => {
+            // Simple CASE: CASE x WHEN a THEN b -> when(x.eq(a)).then(b). Searched CASE: CASE WHEN p THEN b -> when(p).then(b).
+            // Build from the end so we stay in Expr type: else_e = else; for (cond, res) in reverse, else_e = when(cond).then(res).otherwise(else_e).
+            let else_e = match else_result {
+                Some(e) => sql_expr_to_polars(e.as_ref(), session, df, having_agg_map)?,
+                None => lit(polars::prelude::NULL),
+            };
+            let mut expr = else_e;
+            for cw in conditions.iter().rev() {
+                let cond = if let Some(op) = &operand {
+                    sql_expr_to_polars(op.as_ref(), session, df, having_agg_map)?
+                        .eq(sql_expr_to_polars(&cw.condition, session, df, having_agg_map)?)
+                } else {
+                    sql_expr_to_polars(&cw.condition, session, df, having_agg_map)?
+                };
+                let res = sql_expr_to_polars(&cw.result, session, df, having_agg_map)?;
+                expr = when(cond).then(res).otherwise(expr);
+            }
+            Ok(expr)
         }
         _ => Err(PolarsError::InvalidOperation(
             format!("SQL: unsupported expression in WHERE: {:?}. Use column, literal, =, <, >, AND, OR, IS NULL, LIKE, IN.", expr).into(),
@@ -782,6 +807,11 @@ fn apply_projection(
                             ProjItem::PythonUdf(c, _) => ProjItem::PythonUdf(c, alias_str),
                         };
                         item
+                    }
+                    SqlExpr::Case { .. } => {
+                        // CASE ... END AS alias (#776)
+                        let e = sql_expr_to_polars(expr, session, Some(df), None)?;
+                        ProjItem::Expr(e, alias_str)
                     }
                     _ => {
                         return Err(PolarsError::InvalidOperation(


### PR DESCRIPTION
Fixes #776: CASE ... END AS alias in SELECT.
Fixes #743: JOIN ON with different column names (e.g. a.id = b.other_id).

- SQL: support CASE WHEN ... THEN ... ELSE ... END AS alias in projection.
- join() now takes left_on and right_on; SQL translator passes (left_cols, right_cols) from ON clause.
- Add test_sql_case_with_alias and test_sql_join_on_different_column_names.