### PR TITLE
PR-3: SQL UPDATE/DELETE and subquery in WHERE – clear errors

### DIFF
--- a/crates/robin-sparkless-polars/src/sql/mod.rs
+++ b/crates/robin-sparkless-polars/src/sql/mod.rs
@@ -478,6 +478,39 @@ mod tests {
         assert_eq!(rows[2].get("label").and_then(|v| v.as_str()), Some("other"));
     }
 
+    /// PR-3/#730,#744: UPDATE and DELETE return clear unsupported error.
+    #[test]
+    fn test_sql_update_delete_unsupported() {
+        let spark = SparkSession::builder().app_name("test").get_or_create();
+        let df = spark
+            .create_dataframe(
+                vec![(1i64, 10i64, "a".to_string())],
+                vec!["id", "v", "name"],
+            )
+            .unwrap();
+        spark.create_or_replace_temp_view("t", df);
+        let err = match spark.sql("UPDATE t SET v = 2") {
+            Ok(_) => panic!("expected UPDATE to return error"),
+            Err(e) => e,
+        };
+        assert!(
+            err.to_string()
+                .contains("UPDATE and DELETE are not supported"),
+            "expected UPDATE error message, got: {}",
+            err
+        );
+        let err2 = match spark.sql("DELETE FROM t") {
+            Ok(_) => panic!("expected DELETE to return error"),
+            Err(e) => e,
+        };
+        assert!(
+            err2.to_string()
+                .contains("UPDATE and DELETE are not supported"),
+            "expected DELETE error message, got: {}",
+            err2
+        );
+    }
+
     /// PR-2/#743: JOIN ON with different column names (e.g. a.id = b.other_id).
     #[test]
     fn test_sql_join_on_different_column_names() {

--- a/crates/robin-sparkless-polars/src/sql/translator.rs
+++ b/crates/robin-sparkless-polars/src/sql/translator.rs
@@ -172,6 +172,12 @@ pub fn translate(
                 session.is_case_sensitive(),
             ))
         }
+        Statement::Update(_) => Err(PolarsError::InvalidOperation(
+            "SQL: UPDATE and DELETE are not supported. Use DataFrame API or Spark for DML.".into(),
+        )),
+        Statement::Delete(_) => Err(PolarsError::InvalidOperation(
+            "SQL: UPDATE and DELETE are not supported. Use DataFrame API or Spark for DML.".into(),
+        )),
         _ => Err(PolarsError::InvalidOperation(
             "SQL: only SELECT, CREATE SCHEMA/DATABASE, and DROP TABLE/VIEW/SCHEMA are supported."
                 .into(),
@@ -593,6 +599,15 @@ fn sql_expr_to_polars(
             }
             Ok(expr)
         }
+        SqlExpr::InSubquery { .. } => Err(PolarsError::InvalidOperation(
+            "SQL: subquery in WHERE (e.g. col IN (SELECT ...)) is not yet supported.".into(),
+        )),
+        SqlExpr::Exists { .. } => Err(PolarsError::InvalidOperation(
+            "SQL: subquery in WHERE (EXISTS (SELECT ...)) is not yet supported.".into(),
+        )),
+        SqlExpr::Subquery(_) => Err(PolarsError::InvalidOperation(
+            "SQL: subquery in WHERE is not yet supported.".into(),
+        )),
         _ => Err(PolarsError::InvalidOperation(
             format!("SQL: unsupported expression in WHERE: {:?}. Use column, literal, =, <, >, AND, OR, IS NULL, LIKE, IN.", expr).into(),
         )),

--- a/crates/spark-sql-parser/src/lib.rs
+++ b/crates/spark-sql-parser/src/lib.rs
@@ -68,6 +68,7 @@ pub fn parse_sql(query: &str) -> Result<Statement, ParseError> {
         | Statement::ShowViews { .. }
         | Statement::ShowCreate { .. } => {}
         Statement::Insert(_) | Statement::Directory { .. } | Statement::LoadData { .. } => {}
+        Statement::Update(_) | Statement::Delete(_) => {}
         Statement::ExplainTable { .. } => {}
         Statement::Set(_) | Statement::Reset(_) => {}
         Statement::Cache { .. } | Statement::UNCache { .. } => {}
@@ -113,8 +114,8 @@ mod tests {
 
     #[test]
     fn error_unsupported_statement_type() {
-        // UPDATE is parsed by sqlparser but not in our whitelist
-        let err = parse_sql("UPDATE t SET x = 1").unwrap_err();
+        // COMMIT is parsed by sqlparser but not in our whitelist
+        let err = parse_sql("COMMIT").unwrap_err();
         assert!(err.0.contains("not supported"));
     }
 


### PR DESCRIPTION
Fixes #730, #744, #775.

- UPDATE and DELETE: return clear 'SQL: UPDATE and DELETE are not supported. Use DataFrame API or Spark for DML.'
- Subquery in WHERE (IN (SELECT ...), EXISTS (SELECT ...), (SELECT ...)): return clear 'subquery in WHERE is not yet supported.'
- Parser: allow UPDATE/DELETE through so translator can emit the message.
- Add test_sql_update_delete_unsupported.