### PR TITLE
PR-4: Not-implemented batch – clearer errors, cume_dist, keys, rollup/cube

### DIFF
--- a/crates/robin-sparkless-polars/src/plan/expr.rs
+++ b/crates/robin-sparkless-polars/src/plan/expr.rs
@@ -693,8 +693,12 @@ fn expr_from_window_fn(
             let partition_exprs: Vec<Expr> = part_refs.iter().map(|s| col(*s)).collect();
             Ok(n_unique_expr.over(partition_exprs))
         }
+        "cume_dist" => {
+            let c = order_col.cume_dist(&part_refs, false);
+            Ok(c.into_expr())
+        }
         _ => Err(PlanExprError(format!(
-            "unsupported window fn '{fn_name}' (supported: row_number, rank, dense_rank, percent_rank, ntile, lag, lead, sum, avg, approx_count_distinct)"
+            "unsupported window fn '{fn_name}' (supported: row_number, rank, dense_rank, percent_rank, cume_dist, ntile, lag, lead, sum, avg, approx_count_distinct)"
         ))),
     }
 }
@@ -2488,7 +2492,7 @@ fn expr_from_fn_rest(name: &str, args: &[Value]) -> Result<Expr, PlanExprError> 
                 .map_err(|e| PlanExprError(e.to_string()))?
                 .into_expr())
         }
-        "map_keys" => {
+        "map_keys" | "keys" => {
             require_args(name, args, 1)?;
             Ok(map_keys(&expr_to_column(arg_expr(args, 0)?)).into_expr())
         }

--- a/crates/robin-sparkless-polars/src/plan/mod.rs
+++ b/crates/robin-sparkless-polars/src/plan/mod.rs
@@ -631,7 +631,15 @@ fn apply_op(
                 .map_err(PlanError::Session)?;
             df.cross_join(&other_df).map_err(PlanError::Session)
         }
-        _ => Err(PlanError::UnsupportedOp(op_name.to_string())),
+        "rollup" => Err(PlanError::UnsupportedOp(
+            "Plan op 'rollup' is not yet supported. Use groupBy for now. See docs for supported operations.".into(),
+        )),
+        "cube" => Err(PlanError::UnsupportedOp(
+            "Plan op 'cube' is not yet supported. Use groupBy for now. See docs for supported operations.".into(),
+        )),
+        _ => Err(PlanError::UnsupportedOp(format!(
+            "Plan op '{op_name}' is not supported. See docs for supported operations (e.g. select, filter, groupBy, join, orderBy, limit)."
+        ))),
     }
 }
 


### PR DESCRIPTION
Fixes #727, #738, #861, #862.

- Plan: UnsupportedOp now names the op and points to docs.
- Explicit clear errors for rollup and cube (not yet supported).
- Add cume_dist to window function dispatch.
- Add 'keys' as alias for map_keys in plan expr.