### PR TITLE
session: resolve schema-qualified table in warehouse (Fixes #760)

### DIFF
--- a/crates/robin-sparkless-polars/src/session/mod.rs
+++ b/crates/robin-sparkless-polars/src/session/mod.rs
@@ -1034,14 +1034,27 @@ impl SparkSession {
         {
             return Ok(df);
         }
-        // Warehouse fallback (disk-backed saveAsTable)
+        // Warehouse fallback (disk-backed saveAsTable). #760: schema-qualified name try both
+        // "schema.table" as single dir and "schema/table" (schema as subdir).
         if let Some(warehouse) = self.warehouse_dir() {
-            let dir = Path::new(warehouse).join(name);
+            let wh = Path::new(warehouse);
+            let dir = wh.join(name);
             if dir.is_dir() {
-                // Read data.parquet (our convention) or the dir (Polars accepts dirs with parquet files)
                 let data_file = dir.join("data.parquet");
                 let read_path = if data_file.is_file() { data_file } else { dir };
                 return self.read_parquet(&read_path);
+            }
+            if name.contains('.') {
+                let dir_qualified = wh.join(name.replace('.', std::path::MAIN_SEPARATOR_STR));
+                if dir_qualified.is_dir() {
+                    let data_file = dir_qualified.join("data.parquet");
+                    let read_path = if data_file.is_file() {
+                        data_file
+                    } else {
+                        dir_qualified
+                    };
+                    return self.read_parquet(&read_path);
+                }
             }
         }
         Err(PolarsError::InvalidOperation(


### PR DESCRIPTION
Fixes #760.

- `table(name)` already resolves temp view and saved table by full name (e.g. `my_schema.my_table`).
- Warehouse fallback now also tries path with dots replaced by path separator (e.g. `schema.table` → `warehouse/schema/table`) so tables saved under a schema subdir are found.
- Existing test `test_list_tables_and_schema_qualified_name` already covers `save_as_table("my_schema.my_table")` and `table("my_schema.my_table")`.