### PR TITLE
PR-7 remaining: datetime format, astype→try_cast, bitwise_not (Fixes #737, #753, #859)

### DIFF
--- a/crates/robin-sparkless-polars/src/column.rs
+++ b/crates/robin-sparkless-polars/src/column.rs
@@ -766,9 +766,14 @@ impl Column {
     }
 
     /// Bitwise NOT of an integer/boolean column (PySpark bitwise_not / bitwiseNOT).
+    /// #859: Coerce via map so Unknown(Any) from when/otherwise is cast to Int64 at execution time.
     pub fn bitwise_not(&self) -> Column {
-        // Use arithmetic identity: !n == -1 - n for two's-complement integers.
-        let expr = (lit(-1i64) - self.expr().clone().cast(DataType::Int64)).cast(DataType::Int64);
+        use polars::prelude::Field;
+        let expr = self.expr().clone().map(
+            move |col| expect_col(crate::udfs::apply_coerce_to_int64_for_bitwise(col)),
+            |_schema, field| Ok(Field::new(field.name().clone(), DataType::Int64)),
+        );
+        let expr = (lit(-1i64) - expr).cast(DataType::Int64);
         Self::from_expr(expr, None)
     }
 

--- a/crates/robin-sparkless-polars/src/plan/expr.rs
+++ b/crates/robin-sparkless-polars/src/plan/expr.rs
@@ -1824,6 +1824,13 @@ fn expr_from_fn_rest(name: &str, args: &[Value]) -> Result<Expr, PlanExprError> 
             let type_name = arg_lit_str(args, 1)?;
             Ok(try_cast(&c, &type_name).map_err(PlanExprError)?.into_expr())
         }
+        // #753: astype with null-on-invalid (PySpark astype returns null for invalid conversions).
+        "astype" => {
+            require_args(name, args, 2)?;
+            let c = expr_to_column(arg_expr(args, 0)?);
+            let type_name = arg_lit_str(args, 1)?;
+            Ok(try_cast(&c, &type_name).map_err(PlanExprError)?.into_expr())
+        }
         "nvl" | "ifnull" => {
             require_args(name, args, 2)?;
             let a = expr_to_column(arg_expr(args, 0)?);

--- a/crates/robin-sparkless-polars/src/session/mod.rs
+++ b/crates/robin-sparkless-polars/src/session/mod.rs
@@ -381,6 +381,11 @@ fn json_values_to_series(
                                     )
                                 })
                                 .or_else(|_| {
+                                    NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S").map_err(
+                                        |e| PolarsError::ComputeError(e.to_string().into()),
+                                    )
+                                })
+                                .or_else(|_| {
                                     NaiveDate::parse_from_str(s, "%Y-%m-%d")
                                         .map_err(|e| {
                                             PolarsError::ComputeError(e.to_string().into())
@@ -1410,6 +1415,12 @@ impl SparkSession {
                                         })
                                         .or_else(|_| {
                                             NaiveDateTime::parse_from_str(&s, "%Y-%m-%dT%H:%M:%S")
+                                                .map_err(|e| {
+                                                    PolarsError::ComputeError(e.to_string().into())
+                                                })
+                                        })
+                                        .or_else(|_| {
+                                            NaiveDateTime::parse_from_str(&s, "%Y-%m-%d %H:%M:%S")
                                                 .map_err(|e| {
                                                     PolarsError::ComputeError(e.to_string().into())
                                                 })

--- a/crates/robin-sparkless-polars/src/udfs/rest.rs
+++ b/crates/robin-sparkless-polars/src/udfs/rest.rs
@@ -2082,6 +2082,16 @@ pub fn apply_bit_or(columns: &mut [Column]) -> PolarsResult<Option<Column>> {
     Ok(Some(Column::new(name, out.into_series())))
 }
 
+/// Coerce column to Int64 for bitwise_not. Handles Unknown(Any) from when/otherwise (#859).
+pub fn apply_coerce_to_int64_for_bitwise(column: Column) -> PolarsResult<Option<Column>> {
+    let name = column.field().into_owned().name;
+    let series = column.take_materialized_series();
+    let out = series.cast(&DataType::Int64).or_else(|_| {
+        Series::new_null(PlSmallStr::from(name.as_str()), series.len()).cast(&DataType::Int64)
+    })?;
+    Ok(Some(Column::new(name, out)))
+}
+
 /// Apply bitwise XOR for two integer columns (PySpark bit_xor).
 pub fn apply_bit_xor(columns: &mut [Column]) -> PolarsResult<Option<Column>> {
     if columns.len() < 2 {


### PR DESCRIPTION
Fixes #737, #753, #859.

- **#737** Session: accept datetime string with space (`2023-01-01 12:00:00`) in timestamp parsing (json_values_to_series and create_dataframe_from_rows).
- **#753** Plan: add `astype` as `try_cast` so invalid string→int yields null (PySpark astype behavior).
- **#859** bitwise_not: coerce to Int64 via map so `Unknown(Any)` from when/otherwise works; add `apply_coerce_to_int64_for_bitwise` in udfs.