### PR TITLE
Fixes #842, #843, #849: Date/Datetime in collect; timestamp in createDataFrame

### DIFF
--- a/crates/robin-sparkless-polars/src/dataframe/mod.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/mod.rs
@@ -23,6 +23,7 @@ use polars::prelude::{
     AnyValue, DataFrame as PlDataFrame, DataType, Expr, IntoLazy, LazyFrame, PlSmallStr,
     PolarsError, Schema, SchemaNamesAndDtypes, UnknownKind, col, lit,
 };
+use polars::datatypes::TimeUnit;
 use serde_json::Value as JsonValue;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
@@ -1913,9 +1914,23 @@ fn float_to_json_number(f: f64) -> JsonValue {
         .unwrap_or(JsonValue::Null)
 }
 
+/// Convert Polars Datetime AnyValue (i64 + TimeUnit) to ISO string for collect (#842, #843, #849).
+fn datetime_anyvalue_to_json_iso(val: i64, unit: &TimeUnit) -> JsonValue {
+    let micros = match unit {
+        TimeUnit::Nanoseconds => val.checked_div(1000),
+        TimeUnit::Microseconds => Some(val),
+        TimeUnit::Milliseconds => val.checked_mul(1000),
+    };
+    micros
+        .and_then(|m| chrono::DateTime::from_timestamp_micros(m))
+        .map(|dt| JsonValue::String(dt.format("%Y-%m-%dT%H:%M:%S%.6f").to_string()))
+        .unwrap_or(JsonValue::Null)
+}
+
 /// Convert Polars AnyValue to serde_json::Value for language bindings (Node, etc.).
 /// Handles List and Struct so that create_map() with no args yields {} not null (#578).
 /// Float values close to integers are rounded for collect parity (#747, #748).
+/// Date and Datetime output ISO strings so Python bindings get date/datetime (#842, #843, #849).
 fn any_value_to_json(av: &AnyValue<'_>, dtype: &DataType) -> JsonValue {
     use serde_json::Map;
     match av {
@@ -2002,6 +2017,15 @@ fn any_value_to_json(av: &AnyValue<'_>, dtype: &DataType) -> JsonValue {
             }
             JsonValue::Object(obj)
         }
+        AnyValue::Date(days) => {
+            let epoch = robin_sparkless_core::date_utils::epoch_naive_date();
+            epoch
+                .checked_add_signed(chrono::TimeDelta::days(*days as i64))
+                .map(|d| JsonValue::String(d.format("%Y-%m-%d").to_string()))
+                .unwrap_or(JsonValue::Null)
+        }
+        AnyValue::Datetime(val, unit, _) => datetime_anyvalue_to_json_iso(*val, unit),
+        AnyValue::DatetimeOwned(val, unit, _) => datetime_anyvalue_to_json_iso(*val, unit),
         _ => JsonValue::Null,
     }
 }

--- a/crates/robin-sparkless-polars/src/session/mod.rs
+++ b/crates/robin-sparkless-polars/src/session/mod.rs
@@ -446,10 +446,47 @@ fn json_value_to_series_single(
             let s = Series::new(name.into(), vec![days]).cast(&DataType::Date)?;
             Ok(s)
         }
+        (JsonValue::String(s), "timestamp" | "datetime" | "timestamp_ntz") => {
+            let micros = parse_timestamp_str_to_micros(s)?;
+            let s = Series::new(name.into(), vec![Some(micros)])
+                .cast(&DataType::Datetime(TimeUnit::Microseconds, None))?;
+            Ok(s)
+        }
+        (JsonValue::Number(n), "timestamp" | "datetime" | "timestamp_ntz") => {
+            let micros = n.as_i64();
+            let s = Series::new(name.into(), vec![micros])
+                .cast(&DataType::Datetime(TimeUnit::Microseconds, None))?;
+            Ok(s)
+        }
         _ => Err(PolarsError::ComputeError(
             format!("json_value_to_series: unsupported {type_str} for {value:?}").into(),
         )),
     }
+}
+
+/// Parse a single timestamp string to microseconds since epoch (for json_value_to_series_single).
+fn parse_timestamp_str_to_micros(s: &str) -> Result<i64, PolarsError> {
+    use chrono::{NaiveDate, NaiveDateTime};
+    let s = s.trim();
+    NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.f")
+        .map_err(|e| PolarsError::ComputeError(e.to_string().into()))
+        .or_else(|_| {
+            NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S")
+                .map_err(|e| PolarsError::ComputeError(e.to_string().into()))
+        })
+        .or_else(|_| {
+            NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S")
+                .map_err(|e| PolarsError::ComputeError(e.to_string().into()))
+        })
+        .or_else(|_| {
+            NaiveDate::parse_from_str(s, "%Y-%m-%d")
+                .map_err(|e| PolarsError::ComputeError(e.to_string().into()))
+                .and_then(|d| {
+                    d.and_hms_opt(0, 0, 0)
+                        .ok_or_else(|| PolarsError::ComputeError("date to datetime (0:0:0)".into()))
+                })
+        })
+        .map(|dt| dt.and_utc().timestamp_micros())
 }
 
 /// Build a struct Series from JsonValue::Object or JsonValue::Array (field-order) or Null.


### PR DESCRIPTION
## Summary
- **collect_as_json_rows**: Serialize `AnyValue::Date` and `AnyValue::Datetime` / `DatetimeOwned` to ISO strings so Python bindings receive date/datetime instead of null (fixes #842, #843, #849).
- **create_dataframe_from_rows**: Support `timestamp` / `datetime` / `timestamp_ntz` in `json_value_to_series_single` for struct and array elements (string or number).

## Changes
- `crates/robin-sparkless-polars/src/dataframe/mod.rs`: Handle Date and Datetime in `any_value_to_json`; add `datetime_anyvalue_to_json_iso`.
- `crates/robin-sparkless-polars/src/session/mod.rs`: Add timestamp parsing in `json_value_to_series_single` and `parse_timestamp_str_to_micros`.