### PR TITLE
fix: spark.conf() returns spark.app.name (batch 8)

### DIFF
--- a/crates/robin-sparkless-polars/src/session/builder.rs
+++ b/crates/robin-sparkless-polars/src/session/builder.rs
@@ -45,7 +45,12 @@ impl SparkSessionBuilder {
     }
 
     pub fn get_or_create(self) -> SparkSession {
-        let session = SparkSession::new(self.app_name, self.master, self.config);
+        let mut config = self.config;
+        // Batch 8 / #789: spark.conf().get("spark.app.name") should return the app name.
+        if let Some(name) = &self.app_name {
+            config.insert("spark.app.name".to_string(), name.clone());
+        }
+        let session = SparkSession::new(self.app_name, self.master, config);
         set_thread_udf_session(session.clone());
         session
     }

--- a/crates/robin-sparkless-polars/src/session/mod.rs
+++ b/crates/robin-sparkless-polars/src/session/mod.rs
@@ -2099,6 +2099,20 @@ mod tests {
         );
     }
 
+    /// Batch 8 / #789: spark.conf().get("spark.app.name") returns the app name set in builder.
+    #[test]
+    fn test_spark_session_conf_returns_app_name() {
+        let spark = SparkSession::builder()
+            .app_name("test_fixture")
+            .get_or_create();
+        let conf = spark.get_config();
+        assert_eq!(
+            conf.get("spark.app.name"),
+            Some(&"test_fixture".to_string()),
+            "conf should expose spark.app.name for PySpark parity"
+        );
+    }
+
     #[test]
     fn test_spark_session_default() {
         let spark = SparkSession::default();


### PR DESCRIPTION
Batch 8: app name in conf.

- Builder inserts spark.app.name into config when app_name() is set so conf().get("spark.app.name") returns it.
- Add test_spark_session_conf_returns_app_name.

Fixes #789.