### PR TITLE
Plan phases 1-3: first(ignorenulls), join key numeric, docs

### DIFF
--- a/crates/robin-sparkless-polars/src/dataframe/joins.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/joins.rs
@@ -1,7 +1,7 @@
 //! Join operations for DataFrame.
 
 use super::DataFrame;
-use crate::type_coercion::coerce_expr_pair;
+use crate::type_coercion::coerce_expr_pair_for_join;
 use polars::prelude::Expr;
 use polars::prelude::JoinType as PlJoinType;
 use polars::prelude::PolarsError;
@@ -77,7 +77,7 @@ pub fn join(
         })?;
         let target_name = left_name.as_str();
         if left_dtype != right_dtype {
-            let (l, r) = coerce_expr_pair(
+            let (l, r) = coerce_expr_pair_for_join(
                 left_name.as_str(),
                 right_name.as_str(),
                 &left_dtype,

--- a/crates/robin-sparkless-polars/src/functions/rest.rs
+++ b/crates/robin-sparkless-polars/src/functions/rest.rs
@@ -36,10 +36,14 @@ pub fn min(col: &Column) -> Column {
     Column::from_expr(col.expr().clone().min(), Some("min".to_string()))
 }
 
-/// First value in group (PySpark first). Use in groupBy.agg(). ignorenulls: when true, first non-null; Polars 0.45 uses .first() only (ignorenulls reserved for API compatibility).
+/// First value in group (PySpark first). Use in groupBy.agg(). ignorenulls: when true, first non-null (Polars first_non_null); otherwise first value in group order.
 pub fn first(col: &Column, ignorenulls: bool) -> Column {
-    let _ = ignorenulls;
-    Column::from_expr(col.expr().clone().first(), None)
+    let expr = if ignorenulls {
+        col.expr().clone().first_non_null()
+    } else {
+        col.expr().clone().first()
+    };
+    Column::from_expr(expr, None)
 }
 
 /// Any value from the group (PySpark any_value). Use in groupBy.agg(). ignorenulls reserved for API compatibility.

--- a/crates/robin-sparkless-polars/src/plan/mod.rs
+++ b/crates/robin-sparkless-polars/src/plan/mod.rs
@@ -656,7 +656,7 @@ fn apply_op(
 
 fn parse_aggs(aggs: &[Value], df: &DataFrame) -> Result<Vec<polars::prelude::Expr>, PlanError> {
     use crate::Column;
-    use crate::functions::{avg, count, max, min, sum as rs_sum};
+    use crate::functions::{avg, count, first as rs_first, max, min, sum as rs_sum};
     use std::collections::HashMap;
 
     let mut out = Vec::with_capacity(aggs.len());
@@ -702,7 +702,13 @@ fn parse_aggs(aggs: &[Value], df: &DataFrame) -> Result<Vec<polars::prelude::Exp
             "avg" => avg(&c),
             "min" => min(&c),
             "max" => max(&c),
-            "first" => Column::from_expr(c.into_expr().first(), None),
+            "first" => {
+                let ignorenulls = obj
+                    .get("ignorenulls")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false);
+                rs_first(&c, ignorenulls)
+            }
             "last" => Column::from_expr(c.into_expr().last(), None),
             _ => return Err(PlanError::InvalidPlan(format!("unsupported agg: {agg}"))),
         };

--- a/crates/robin-sparkless-polars/src/type_coercion.rs
+++ b/crates/robin-sparkless-polars/src/type_coercion.rs
@@ -89,6 +89,34 @@ pub fn find_common_type(left: &DataType, right: &DataType) -> Result<DataType, P
     }
 }
 
+/// Common type for join keys (#850). When one side is numeric and the other is String, prefer the
+/// numeric type so the result schema has a numeric key column (PySpark parity).
+pub fn find_common_type_for_join(
+    left: &DataType,
+    right: &DataType,
+) -> Result<DataType, PolarsError> {
+    let left_norm = if matches!(left, DataType::Unknown(_)) {
+        DataType::String
+    } else {
+        left.clone()
+    };
+    let right_norm = if matches!(right, DataType::Unknown(_)) {
+        DataType::String
+    } else {
+        right.clone()
+    };
+    let left = &left_norm;
+    let right = &right_norm;
+    // Prefer numeric when one is numeric and one is string (PySpark result schema has numeric key).
+    if is_numeric(left) && right == &DataType::String {
+        return Ok(left.clone());
+    }
+    if left == &DataType::String && is_numeric(right) {
+        return Ok(right.clone());
+    }
+    find_common_type(left, right)
+}
+
 /// Build (left_expr, right_expr) that cast two columns to a common type and alias to the same name.
 /// Use in join key coercion and union_by_name when both sides have the column but types differ.
 pub fn coerce_expr_pair(
@@ -99,6 +127,21 @@ pub fn coerce_expr_pair(
     alias: &str,
 ) -> Result<(Expr, Expr), PolarsError> {
     let common = find_common_type(left_dtype, right_dtype)?;
+    Ok((
+        col(left_name).cast(common.clone()).alias(alias),
+        col(right_name).cast(common).alias(alias),
+    ))
+}
+
+/// Like coerce_expr_pair but uses find_common_type_for_join so join result key is numeric when one side is numeric (#850).
+pub fn coerce_expr_pair_for_join(
+    left_name: &str,
+    right_name: &str,
+    left_dtype: &DataType,
+    right_dtype: &DataType,
+    alias: &str,
+) -> Result<(Expr, Expr), PolarsError> {
+    let common = find_common_type_for_join(left_dtype, right_dtype)?;
     Ok((
         col(left_name).cast(common.clone()).alias(alias),
         col(right_name).cast(common).alias(alias),

--- a/docs/PYSPARK_DIFFERENCES.md
+++ b/docs/PYSPARK_DIFFERENCES.md
@@ -4,6 +4,18 @@ This document lists **intentional or known divergences** from PySpark semantics 
 
 **Unimplemented API surface:** For a full list of functions and methods present in Sparkless 3.28.0 but not yet implemented in robin-sparkless, see [GAP_ANALYSIS_SPARKLESS_3.28.md](GAP_ANALYSIS_SPARKLESS_3.28.md). That list is **scoped to PySpark parity**: all listed items are standard PySpark APIs (or direct Sparkless equivalents); see [ROBIN_SPARKLESS_MISSING.md](ROBIN_SPARKLESS_MISSING.md) for the canonical “missing vs PySpark” list with PySpark references.
 
+## Array and list collect
+
+- **Collect**: List/array columns are serialized as JSON arrays in collect/to_json_rows (#846, #845). If Sparkless sees a string like `"['a', 'b']"` instead of `["a","b"]`, the source may be sending a stringified list; use JSON array in create_dataframe_from_rows or plan input.
+
+## Date and datetime
+
+- **create_dataframe_from_rows**: Schema types `date`, `timestamp`, `datetime`, `timestamp_ntz` are supported; values can be ISO date strings (`%Y-%m-%d`), ISO datetime strings, or (for timestamp) micros as number. Collect serializes Date as `"YYYY-MM-DD"` and Datetime as ISO strings (#841, #840, #839, #751, #849).
+
+## Ordering (orderBy)
+
+- **Default null ordering (#838)**: Robin follows Spark SQL default: ASC nulls first, DESC nulls last. Tests that expect nulls last for ascending sort should use `asc_nulls_last()` / `order_by_exprs([asc_nulls_last(&col("x"))])` or, when using the plan interpreter, pass `"nulls_last": [true]` in the orderBy payload.
+
 ## Window functions
 
 - **percent_rank, cume_dist, ntile, nth_value**: The **API** is implemented (Rust and Python). Parity fixtures for these (`percent_rank_window`, `cume_dist_window`, `ntile_window`, `nth_value_window`) are **covered** via a multi-step workaround in the harness (computing in separate columns then combining). See [PARITY_STATUS.md](PARITY_STATUS.md).


### PR DESCRIPTION
Implements plan phases 1-3 (fix open issues with PRs):

**Phase 1:** Doc: default orderBy null ordering; use `nulls_last` in plan when Sparkless wants nulls last.

**Phase 2:** `first(col, ignorenulls)` now uses Polars `first_non_null()` when ignorenulls=true. Plan orderBy first agg reads `ignorenulls` from payload.

**Phase 3:** Join key type: when one side is numeric and the other string, coerce to numeric so result schema has numeric key (#850). `find_common_type_for_join` / `coerce_expr_pair_for_join`.

**Docs:** PYSPARK_DIFFERENCES notes for ordering, array collect, date/datetime.

- `make check-full` passes.