### PR TITLE
feat(delta): add mergeSchema support for append (#851)

### DIFF
--- a/crates/robin-sparkless-polars/src/dataframe/mod.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/mod.rs
@@ -1306,13 +1306,20 @@ impl DataFrame {
 
     /// Write this DataFrame to a Delta table at the given path.
     /// Requires the `delta` feature. If `overwrite` is true, replaces the table; otherwise appends.
+    /// When appending, `merge_schema` merges existing and new schemas (union of columns, nulls for missing). See #851.
     #[cfg(feature = "delta")]
     pub fn write_delta(
         &self,
         path: impl AsRef<std::path::Path>,
         overwrite: bool,
+        merge_schema: bool,
     ) -> Result<(), PolarsError> {
-        crate::delta::write_delta(self.collect_inner()?.as_ref(), path, overwrite)
+        crate::delta::write_delta(
+            self.collect_inner()?.as_ref(),
+            path,
+            overwrite,
+            merge_schema,
+        )
     }
 
     /// Stub when `delta` feature is disabled.
@@ -1321,6 +1328,7 @@ impl DataFrame {
         &self,
         _path: impl AsRef<std::path::Path>,
         _overwrite: bool,
+        _merge_schema: bool,
     ) -> Result<(), PolarsError> {
         Err(PolarsError::InvalidOperation(
             "Delta Lake requires the 'delta' feature. Build with --features delta.".into(),

--- a/crates/robin-sparkless-polars/src/delta/mod.rs
+++ b/crates/robin-sparkless-polars/src/delta/mod.rs
@@ -236,14 +236,79 @@ pub fn describe_delta_detail(
     ))
 }
 
+/// Align two DataFrames to a merged column order, adding null columns for missing columns.
+/// merged_columns: existing names first, then new names not in existing (PySpark mergeSchema order).
+#[cfg(feature = "delta")]
+fn align_to_merged_schema(
+    existing: &polars::prelude::DataFrame,
+    new_df: &polars::prelude::DataFrame,
+) -> Result<(polars::prelude::DataFrame, polars::prelude::DataFrame), PolarsError> {
+    use polars::prelude::*;
+    let existing_names: Vec<String> = existing
+        .get_column_names()
+        .iter()
+        .map(|s| s.as_str().to_string())
+        .collect();
+    let new_names: Vec<String> = new_df
+        .get_column_names()
+        .iter()
+        .map(|s| s.as_str().to_string())
+        .collect();
+    let existing_set: std::collections::HashSet<&str> =
+        existing_names.iter().map(String::as_str).collect();
+    let mut merged: Vec<String> = existing_names.clone();
+    for n in &new_names {
+        if !existing_set.contains(n.as_str()) {
+            merged.push(n.clone());
+        }
+    }
+    let n_existing = existing.height();
+    let n_new = new_df.height();
+    let schema_existing = existing.schema();
+    let schema_new = new_df.schema();
+    let name_into = |n: &String| n.as_str().into();
+    let mut cols_existing: Vec<polars::prelude::Column> = Vec::with_capacity(merged.len());
+    let mut cols_new: Vec<polars::prelude::Column> = Vec::with_capacity(merged.len());
+    for name in &merged {
+        if let Some(dtype) = schema_existing.get(name) {
+            if let Some(idx) = existing.get_column_index(name) {
+                cols_existing.push(existing.columns()[idx].clone());
+            } else {
+                cols_existing.push(Series::full_null(name_into(name), n_existing, dtype).into());
+            }
+        } else if let Some(dtype) = schema_new.get(name) {
+            cols_existing.push(Series::full_null(name_into(name), n_existing, dtype).into());
+        } else {
+            cols_existing
+                .push(Series::full_null(name_into(name), n_existing, &DataType::String).into());
+        }
+        if let Some(dtype) = schema_new.get(name) {
+            if let Some(idx) = new_df.get_column_index(name) {
+                cols_new.push(new_df.columns()[idx].clone());
+            } else {
+                cols_new.push(Series::full_null(name_into(name), n_new, dtype).into());
+            }
+        } else if let Some(dtype) = schema_existing.get(name) {
+            cols_new.push(Series::full_null(name_into(name), n_new, dtype).into());
+        } else {
+            cols_new.push(Series::full_null(name_into(name), n_new, &DataType::String).into());
+        }
+    }
+    let aligned_existing = polars::prelude::DataFrame::new_infer_height(cols_existing)?;
+    let aligned_new = polars::prelude::DataFrame::new_infer_height(cols_new)?;
+    Ok((aligned_existing, aligned_new))
+}
+
 /// Write this DataFrame to a Delta table at the given path.
 /// If `overwrite` is true, replaces the table; otherwise appends.
+/// When `merge_schema` is true and appending, the result schema is the union of existing and new columns (missing columns filled with null). Fixes #851.
 /// Uses Parquet write + convert_to_delta for new/overwrite; appends by reading existing table, concatenating, then overwriting.
 #[cfg(feature = "delta")]
 pub fn write_delta(
     df: &polars::prelude::DataFrame,
     path: impl AsRef<Path>,
     overwrite: bool,
+    merge_schema: bool,
 ) -> Result<(), PolarsError> {
     use deltalake::operations::convert_to_delta::ConvertToDeltaBuilder;
     use std::fs;
@@ -338,7 +403,17 @@ pub fn write_delta(
                     } else {
                         concat_lazy_frames(lfs)?.collect()?
                     };
-                    combined.vstack_mut(df)?;
+                    let to_append = if merge_schema && combined.width() > 0 {
+                        let (aligned_existing, aligned_new) =
+                            align_to_merged_schema(&combined, df)?;
+                        let mut out = aligned_existing;
+                        out.vstack_mut(&aligned_new)?;
+                        out
+                    } else {
+                        combined.vstack_mut(df)?;
+                        combined
+                    };
+                    let mut combined = to_append;
                     let _ = fs::remove_dir_all(path);
                     fs::create_dir_all(path).map_err(|e| {
                         PolarsError::ComputeError(

--- a/crates/robin-sparkless-polars/src/sql/mod.rs
+++ b/crates/robin-sparkless-polars/src/sql/mod.rs
@@ -419,7 +419,13 @@ mod tests {
                 vec!["id", "age", "name"],
             )
             .unwrap();
-        crate::delta::write_delta(df.collect_inner().unwrap().as_ref(), &table_path, true).unwrap();
+        crate::delta::write_delta(
+            df.collect_inner().unwrap().as_ref(),
+            &table_path,
+            true,
+            false,
+        )
+        .unwrap();
 
         let result = spark.sql("DESCRIBE DETAIL test_detail_basic").unwrap();
         assert_eq!(result.count().unwrap(), 1);

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -586,10 +586,15 @@ impl DataFrame {
         }
     }
 
-    /// Write to Delta table (requires delta feature). Delegates to backend.
+    /// Write to Delta table (requires delta feature). When appending, `merge_schema` merges schemas (#851).
     #[cfg(feature = "delta")]
-    pub fn write_delta(&self, path: impl AsRef<Path>, overwrite: bool) -> Result<(), PolarsError> {
-        self.0.write_delta(path, overwrite)
+    pub fn write_delta(
+        &self,
+        path: impl AsRef<Path>,
+        overwrite: bool,
+        merge_schema: bool,
+    ) -> Result<(), PolarsError> {
+        self.0.write_delta(path, overwrite, merge_schema)
     }
 
     #[cfg(not(feature = "delta"))]
@@ -597,6 +602,7 @@ impl DataFrame {
         &self,
         _path: impl AsRef<Path>,
         _overwrite: bool,
+        _merge_schema: bool,
     ) -> Result<(), PolarsError> {
         Err(PolarsError::InvalidOperation(
             "Delta Lake requires the 'delta' feature. Build with --features delta.".into(),

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -174,7 +174,7 @@ fn write_and_read_delta_round_trip_core() {
     .unwrap();
     let df: DataFrame = spark.create_dataframe_from_polars(pl);
 
-    let write_result = df.write_delta(&path, true);
+    let write_result = df.write_delta(&path, true, false);
     if let Err(e) = write_result {
         let msg = format!("{e}");
         if msg.contains("requires the 'delta' feature") {
@@ -227,7 +227,7 @@ fn write_delta_append_and_overwrite_core() {
     let df1: DataFrame = spark.create_dataframe_from_polars(pl1);
     let df2: DataFrame = spark.create_dataframe_from_polars(pl2);
 
-    if let Err(e) = df1.write_delta(&path, true) {
+    if let Err(e) = df1.write_delta(&path, true, false) {
         let msg = format!("{e}");
         if msg.contains("requires the 'delta' feature") {
             return;
@@ -235,7 +235,7 @@ fn write_delta_append_and_overwrite_core() {
         panic!("unexpected error from first write_delta: {msg}");
     }
 
-    if let Err(e) = df2.write_delta(&path, false) {
+    if let Err(e) = df2.write_delta(&path, false, false) {
         let msg = format!("{e}");
         if msg.contains("requires the 'delta' feature") {
             return;
@@ -253,6 +253,70 @@ fn write_delta_append_and_overwrite_core() {
             panic!("unexpected error from read_delta_from_path: {msg}");
         }
     };
+
+    let rows = back.collect_as_json_rows().unwrap();
+    assert_eq!(rows.len(), 3);
+}
+
+/// Delta append with mergeSchema: existing (name, age), new (name, age, city) -> result has (name, age, city). #851
+#[test]
+fn write_delta_append_merge_schema_851() {
+    let spark = spark();
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let path: PathBuf = tmp_dir.path().join("delta_merge_schema");
+
+    let pl1 = polars::prelude::df![
+        "name" => &["a", "b"],
+        "age" => &[10i32, 20i32],
+    ]
+    .unwrap();
+    let pl2 = polars::prelude::df![
+        "name" => &["c"],
+        "age" => &[30i32],
+        "city" => &["NY"],
+    ]
+    .unwrap();
+
+    let df1: DataFrame = spark.create_dataframe_from_polars(pl1);
+    let df2: DataFrame = spark.create_dataframe_from_polars(pl2);
+
+    if let Err(e) = df1.write_delta(&path, true, false) {
+        let msg = format!("{e}");
+        if msg.contains("requires the 'delta' feature") {
+            return;
+        }
+        panic!("unexpected error from first write_delta: {msg}");
+    }
+
+    if let Err(e) = df2.write_delta(&path, false, true) {
+        let msg = format!("{e}");
+        if msg.contains("requires the 'delta' feature") {
+            return;
+        }
+        panic!("unexpected error from append write_delta merge_schema: {msg}");
+    }
+
+    let back = match spark.read_delta_from_path(&path) {
+        Ok(df) => df,
+        Err(e) => {
+            let msg = format!("{e}");
+            if msg.contains("requires the 'delta' feature") {
+                return;
+            }
+            panic!("unexpected error from read_delta_from_path: {msg}");
+        }
+    };
+
+    let schema_names: std::collections::HashSet<String> = back
+        .schema()
+        .unwrap()
+        .fields()
+        .iter()
+        .map(|f| f.name.clone())
+        .collect();
+    let expected: std::collections::HashSet<String> =
+        ["age", "city", "name"].into_iter().map(String::from).collect();
+    assert_eq!(schema_names, expected, "mergeSchema should add city to schema");
 
     let rows = back.collect_as_json_rows().unwrap();
     assert_eq!(rows.len(), 3);


### PR DESCRIPTION
## Summary
Implements Delta Lake `mergeSchema` for append (schema evolution). When appending with `merge_schema: true`, the result schema is the union of existing and new columns; missing columns are filled with null.

Fixes #851 (assert `{'age', 'name'} == {'age', 'city', 'name'}`).

## Changes
- **delta/mod.rs**: Add `merge_schema: bool` to `write_delta()`. When append and `merge_schema`, align existing and new DataFrames to merged column order via `align_to_merged_schema()` (existing cols first, then new-only cols), then vstack and write.
- **DataFrame.write_delta**: Now `write_delta(path, overwrite, merge_schema)`. Public API and polars backend updated; all existing call sites pass `false`.
- **Test**: `write_delta_append_merge_schema_851` — write (name, age), append (name, age, city) with `merge_schema=true`, read and assert schema has age, city, name.

## Validation
- `make check-full` passes (fmt, clippy, audit, deny, tests with all features).
- `cargo test write_delta_append_merge_schema_851 --features delta` passes.