### PR TITLE
feat: array/list serialization as JSON array (#846, #845); document RDD (#848)

### DIFF
--- a/crates/robin-sparkless-polars/src/dataframe/mod.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/mod.rs
@@ -1988,8 +1988,27 @@ fn any_value_to_json(av: &AnyValue<'_>, dtype: &DataType) -> JsonValue {
         AnyValue::UInt64(u) => JsonValue::Number(serde_json::Number::from(*u)),
         AnyValue::Float32(f) => float_to_json_number(f64::from(*f)),
         AnyValue::Float64(f) => float_to_json_number(*f),
-        AnyValue::String(s) => JsonValue::String(s.to_string()),
-        AnyValue::StringOwned(s) => JsonValue::String(s.to_string()),
+        AnyValue::String(s) => {
+            // List column may be stringified in some paths; parse back to array (#846, #845).
+            if matches!(dtype, DataType::List(_)) {
+                if let Ok(parsed) = serde_json::from_str::<JsonValue>(s) {
+                    if parsed.is_array() {
+                        return parsed;
+                    }
+                }
+            }
+            JsonValue::String(s.to_string())
+        }
+        AnyValue::StringOwned(s) => {
+            if matches!(dtype, DataType::List(_)) {
+                if let Ok(parsed) = serde_json::from_str::<JsonValue>(s.as_ref()) {
+                    if parsed.is_array() {
+                        return parsed;
+                    }
+                }
+            }
+            JsonValue::String(s.to_string())
+        }
         AnyValue::List(s) => {
             if is_map_format(dtype) {
                 // List(Struct{key, value}) -> JSON object {} (PySpark empty map #578).

--- a/docs/DEFERRED_SCOPE.md
+++ b/docs/DEFERRED_SCOPE.md
@@ -65,10 +65,11 @@ See also: [PYSPARK_DIFFERENCES.md](PYSPARK_DIFFERENCES.md), [ROBIN_SPARKLESS_MIS
 | APIs | Status | Rationale |
 |------|--------|-----------|
 | `rdd`, `foreach`, `foreachPartition`, `mapInPandas`, `mapPartitions` | Stub (raise `NotImplementedError`) | Robin-sparkless is single-process; no RDD or distributed execution. DataFrame is lazy (PySpark-like). |
+| `DataFrame.rdd.flatMap` and other RDD transformations | Not implemented | RDD API is out of scope; use DataFrame/DSL (e.g. `explode`, `array_contains`) instead. |
 
-**Workaround:** Use `collect()`, `toLocalIterator()`, or `to_pandas()` for local access. For row-wise processing, materialize with `collect()` and iterate in Python/Rust.
+**Workaround:** Use `collect()`, `toLocalIterator()`, or `to_pandas()` for local access. For row-wise processing, materialize with `collect()` and iterate in Python/Rust. For flatMap-like behavior, use `explode` on array columns.
 
-**Tracking:** GitHub issue #142
+**Tracking:** GitHub issue #142, #848 (RDD flatMap)
 
 ---
 


### PR DESCRIPTION
## Summary
- **Collect:** When column dtype is List and the value is a string (stringified list), parse as JSON array so Python receives `['a','b']` not `"['a', 'b']"`. Fixes #846, #845.
- **Docs:** DEFERRED_SCOPE: note `DataFrame.rdd.flatMap` and RDD transformations out of scope (#848).

## Validation
`make check-full` passes.