### PR TITLE
Support expr form in group_by for Column/select (#800)

### DIFF
--- a/crates/robin-sparkless-polars/src/plan/mod.rs
+++ b/crates/robin-sparkless-polars/src/plan/mod.rs
@@ -509,18 +509,30 @@ fn apply_op(
                 .ok_or_else(|| {
                     PlanError::InvalidPlan("groupBy must have 'group_by' array".into())
                 })?;
-            // Each element: string or object {"col": "name"} / {"name": "x"} (PR10).
+            // Each element: string, {"col"/"name": "x"}, or {"expr": <expr>} (#800: Column/expr as group key).
             let cols: Vec<String> = group_by
                 .iter()
                 .filter_map(|v| {
-                    v.as_str().map(|s| s.to_string()).or_else(|| {
-                        v.get("col")
-                            .and_then(Value::as_str)
-                            .map(|s| s.to_string())
-                            .or_else(|| {
-                                v.get("name").and_then(Value::as_str).map(|s| s.to_string())
-                            })
-                    })
+                    v.as_str()
+                        .map(|s| s.to_string())
+                        .or_else(|| {
+                            v.get("col")
+                                .and_then(Value::as_str)
+                                .map(|s| s.to_string())
+                                .or_else(|| {
+                                    v.get("name").and_then(Value::as_str).map(|s| s.to_string())
+                                })
+                        })
+                        .or_else(|| {
+                            // Expression form: resolve to output column name for group key.
+                            v.get("expr")
+                                .and_then(|e| expr_from_value(e).ok())
+                                .and_then(|expr| {
+                                    polars_plan::utils::expr_output_name(&expr)
+                                        .ok()
+                                        .map(|s| s.as_str().to_string())
+                                })
+                        })
                 })
                 .map(|s| df.resolve_column_name(s.as_str()))
                 .collect::<Result<Vec<_>, _>>()

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -314,9 +314,14 @@ fn write_delta_append_merge_schema_851() {
         .iter()
         .map(|f| f.name.clone())
         .collect();
-    let expected: std::collections::HashSet<String> =
-        ["age", "city", "name"].into_iter().map(String::from).collect();
-    assert_eq!(schema_names, expected, "mergeSchema should add city to schema");
+    let expected: std::collections::HashSet<String> = ["age", "city", "name"]
+        .into_iter()
+        .map(String::from)
+        .collect();
+    assert_eq!(
+        schema_names, expected,
+        "mergeSchema should add city to schema"
+    );
 
     let rows = back.collect_as_json_rows().unwrap();
     assert_eq!(rows.len(), 3);


### PR DESCRIPTION
Fixes #800

Parse `group_by` elements that are expression objects (e.g. `{"expr": {"col": "x"}}`) by resolving the expr and using its output column name for grouping, so Sparkless calls that pass Column-like objects are accepted.

- In `plan/mod.rs`, when parsing `group_by`, accept `{"expr": <expr>}` in addition to string and `{"col"/"name": "x"}`.
- Use `expr_from_value` and `polars_plan::utils::expr_output_name` to get the column name for the group key.

`make check-full` passes.