### PR TITLE
Column name case (#786, #785)

### DIFF
--- a/docs/PYSPARK_DIFFERENCES.md
+++ b/docs/PYSPARK_DIFFERENCES.md
@@ -78,6 +78,7 @@ This document lists **intentional or known divergences** from PySpark semantics 
   - **verify_schema**: Accepted (default True); data is validated when building the DataFrame.
   - Use **`spark.createDataFrame(data, schema)`** for all cases (list of dicts, list of tuples with column names, DDL schema, or explicit schema).
 - **Robin-sparkless (Rust)** — **`create_dataframe(data, column_names)`** accepts only 3-tuples `(i64, i64, String)` and three column names. For arbitrary schemas use **`create_dataframe_from_rows(rows, schema)`** (Rust).
+- **Column name case (#786, #785)**: Column names from the schema are preserved as returned by `columns()` and in collect row keys. Pass the exact case you need (e.g. `NaMe`) in the schema so `'NaMe' in df.columns` succeeds.
 
 ## JVM / runtime stubs
 

--- a/tests/expressions.rs
+++ b/tests/expressions.rs
@@ -828,6 +828,30 @@ fn plan_select_concat_as_full_name() {
     );
 }
 
+/// #786, #785: Mixed-case column names (e.g. NaMe) must appear in columns() as provided in schema.
+#[test]
+fn plan_columns_preserve_mixed_case() {
+    let spark = spark();
+    let schema = vec![
+        ("NaMe".to_string(), "string".to_string()),
+        ("value".to_string(), "bigint".to_string()),
+        ("score".to_string(), "double".to_string()),
+    ];
+    let rows = vec![
+        vec![json!("Alice"), json!(10), json!(3.5)],
+        vec![json!("Bob"), json!(20), json!(4.0)],
+    ];
+    let df = plan::execute_plan(&spark, rows, schema, &[]).unwrap();
+    let columns = df.columns_engine().unwrap();
+    assert!(
+        columns.contains(&"NaMe".to_string()),
+        "NaMe must be in columns (#786, #785); got: {:?}",
+        columns
+    );
+    assert!(columns.contains(&"value".to_string()));
+    assert!(columns.contains(&"score".to_string()));
+}
+
 // ---------- issue_636 ----------
 
 #[test]


### PR DESCRIPTION
Fixes #786, #785

- Column names from schema are already preserved in `columns()` and collect; add test `plan_columns_preserve_mixed_case` to lock this in.
- Document in PYSPARK_DIFFERENCES: pass the exact case needed in the schema so `'NaMe' in df.columns` succeeds.

`make check-full` passes.