### PR TITLE
Docs: group_by Column and dense_rank (#756, #755)

### DIFF
--- a/docs/PYSPARK_DIFFERENCES.md
+++ b/docs/PYSPARK_DIFFERENCES.md
@@ -23,6 +23,7 @@ This document lists **intentional or known divergences** from PySpark semantics 
 
 ## GroupBy
 
+- **Column/expr in group_by (#756)**: The plan interpreter accepts group_by elements as strings, `{"col":"name"}`, `{"name":"x"}`, or `{"expr": <expr>}` (Column-like). Use the expr form when the Sparkless adapter sends Column objects.
 - **Null keys and empty groups**: groupBy + aggregates are tested with fixtures `groupby_null_keys`, `groupby_single_group`, and `groupby_single_row_groups`. Behavior is aligned with PySpark for these cases (nulls in grouping keys produce one group per null; single-group and single-row groups behave as in PySpark). Any future divergence discovered will be listed here.
 
 ## Join


### PR DESCRIPTION
Fixes #756, #755

Document that group_by accepts `{"expr": ...}` for Column-like refs (#756). dense_rank already documented in Window functions section.

`make check-full` passes.