### PR TITLE
PR 1: Collect Boolean and filter dtype (#725, #713, #702, #697)

### DIFF
--- a/crates/robin-sparkless-polars/src/dataframe/mod.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/mod.rs
@@ -393,7 +393,7 @@ impl DataFrame {
         };
 
         // Then walk the tree for nested comparisons (e.g. (col("a")==1) & (col("b")==2)).
-        let mut expr = expr.try_map_expr(move |e| {
+        let expr = expr.try_map_expr(move |e| {
             if let Expr::BinaryExpr { left, op, right } = e {
                 let is_comparison_op = matches!(
                     op,
@@ -500,56 +500,7 @@ impl DataFrame {
                 Ok(e)
             }
         })?;
-        // PR-E: Coerce string to numeric for binary arithmetic (div, mul, add, sub) so "str" / 2 works.
-        expr = expr.try_map_expr(|e| {
-            if let Expr::BinaryExpr { left, op, right } = &e {
-                let is_arithmetic = matches!(
-                    op,
-                    Operator::Plus
-                        | Operator::Minus
-                        | Operator::Multiply
-                        | Operator::TrueDivide
-                        | Operator::FloorDivide
-                );
-                if !is_arithmetic {
-                    return Ok(e);
-                }
-                let col_name_and_string = |expr: &Expr| -> Option<(String, bool)> {
-                    if let Expr::Column(n) = expr {
-                        let name = n.as_str();
-                        let dt = self.get_column_dtype(name)?;
-                        Some((name.to_string(), dt == DataType::String))
-                    } else {
-                        None
-                    }
-                };
-                let left_info = col_name_and_string(left.as_ref());
-                let right_info = col_name_and_string(right.as_ref());
-                let wrap_string_to_number = |expr: Expr| {
-                    let col = crate::column::Column::from_expr(expr, None);
-                    crate::functions::try_to_number(&col, None)
-                        .map(|c| c.into_expr())
-                        .map_err(|e| PolarsError::ComputeError(e.into()))
-                };
-                if let Some((_, true)) = left_info {
-                    let new_left = wrap_string_to_number((**left).clone())?;
-                    return Ok(Expr::BinaryExpr {
-                        left: Arc::new(new_left),
-                        op: *op,
-                        right: right.clone(),
-                    });
-                }
-                if let Some((_, true)) = right_info {
-                    let new_right = wrap_string_to_number((**right).clone())?;
-                    return Ok(Expr::BinaryExpr {
-                        left: left.clone(),
-                        op: *op,
-                        right: Arc::new(new_right),
-                    });
-                }
-            }
-            Ok(e)
-        })?;
+        // #697: PySpark does not allow arithmetic on string and numeric; do not coerce (reject at runtime).
         Ok(expr)
     }
 

--- a/crates/robin-sparkless-polars/src/dataframe/transformations.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/transformations.rs
@@ -122,6 +122,8 @@ pub fn filter(
     let condition = df.resolve_expr_column_names(condition)?;
     let condition = df.coerce_string_numeric_comparisons(condition)?;
     let condition = crate::functions::expr_coerce_to_boolean(condition);
+    // #725, #713, #702: Ensure Polars always receives Boolean (cast safety net for any edge case).
+    let condition = condition.cast(DataType::Boolean);
     let lf = df.lazy_frame().filter(condition);
     Ok(super::DataFrame::from_lazy_with_options(lf, case_sensitive))
 }

--- a/tests/expressions.rs
+++ b/tests/expressions.rs
@@ -828,6 +828,28 @@ fn plan_select_concat_as_full_name() {
     );
 }
 
+/// #784: orderBy name ascending: first row must be Alice (not Bob).
+#[test]
+fn plan_order_by_first_row_expected() {
+    let spark = spark();
+    let schema = vec![("name".to_string(), "string".to_string())];
+    let rows = vec![vec![json!("Bob")], vec![json!("Alice")]];
+    let plan_steps = vec![json!({
+        "op": "orderBy",
+        "payload": {"columns": ["name"], "ascending": [true]}
+    })];
+    let df = plan::execute_plan(&spark, rows, schema, &plan_steps).unwrap();
+    let out = df.collect_as_json_rows_engine().unwrap();
+    assert_eq!(out.len(), 2);
+    assert_eq!(
+        out[0].get("name").and_then(|v| v.as_str()),
+        Some("Alice"),
+        "first row after orderBy name ASC must be Alice (#784); got: {:?}",
+        out[0].get("name")
+    );
+    assert_eq!(out[1].get("name").and_then(|v| v.as_str()), Some("Bob"));
+}
+
 /// #779, #746, #736: Boolean and substring in collect (not null/not False when value present).
 #[test]
 fn plan_collect_boolean_and_substring() {


### PR DESCRIPTION
## Plan PR 1: Collect Boolean and filter dtype

- **Issues:** #725, #713, #702 (collect failed: invalid series dtype: expected Boolean); #697 (arithmetic on string and numeric not allowed).

### Changes
- **Filter:** Cast filter condition to Boolean after `expr_coerce_to_boolean` so Polars always receives Boolean (fixes collect "expected Boolean").
- **#697:** Remove coercion of string to numeric in binary arithmetic; PySpark does not allow string + numeric — reject at runtime.

### Validation
- `make check-full` passes.