### PR TITLE
PR 2: Long vs Int and agg column names (#734, #733, #732)

### DIFF
--- a/crates/robin-sparkless-polars/src/functions/rest.rs
+++ b/crates/robin-sparkless-polars/src/functions/rest.rs
@@ -6,9 +6,12 @@ use super::types::parse_type_name;
 use crate::column::Column;
 use polars::prelude::*;
 
-/// Count aggregation
+/// Count aggregation (PySpark LongType; cast to Int64 for schema parity #734).
 pub fn count(col: &Column) -> Column {
-    Column::from_expr(col.expr().clone().count(), Some("count".to_string()))
+    Column::from_expr(
+        col.expr().clone().count().cast(DataType::Int64),
+        Some("count".to_string()),
+    )
 }
 
 /// Sum aggregation

--- a/crates/robin-sparkless-polars/src/plan/mod.rs
+++ b/crates/robin-sparkless-polars/src/plan/mod.rs
@@ -725,11 +725,12 @@ fn parse_aggs(aggs: &[Value], df: &DataFrame) -> Result<Vec<polars::prelude::Exp
                 }
             }
         };
-        // count() without column = row count per group (PySpark count(*)); use len() (#825, #824, #822, #816, #815, #814, #806).
+        // count() without column = row count per group (PySpark count(*)); use len() (#825, #824). Cast to Int64 for LongType (#734).
         let col_expr = match agg {
-            "count" if col_name.map(|s| s.is_empty()).unwrap_or(true) => {
-                Column::from_expr(len(), Some("count".to_string()))
-            }
+            "count" if col_name.map(|s| s.is_empty()).unwrap_or(true) => Column::from_expr(
+                len().cast(polars::prelude::DataType::Int64),
+                Some("count".to_string()),
+            ),
             "count" => count(&c),
             "sum" => rs_sum(&c),
             "avg" => avg(&c),

--- a/crates/robin-sparkless-polars/src/schema_conv.rs
+++ b/crates/robin-sparkless-polars/src/schema_conv.rs
@@ -41,7 +41,8 @@ impl StructTypePolarsExt for StructType {
 fn polars_type_to_data_type(polars_type: &PlDataType) -> DataType {
     match polars_type {
         PlDataType::String => DataType::String,
-        PlDataType::Int32 | PlDataType::Int64 => DataType::Long,
+        PlDataType::Int32 => DataType::Integer,
+        PlDataType::Int64 => DataType::Long,
         PlDataType::Float32 | PlDataType::Float64 => DataType::Double,
         PlDataType::Boolean => DataType::Boolean,
         PlDataType::Date => DataType::Date,


### PR DESCRIPTION
## Plan PR 2

- **#734:** LongType vs IntegerType — schema now maps Int32 -> Integer, Int64 -> Long.
- **#733/#732:** Count returns Int64 (LongType); agg column names (e.g. count) in schema.

### Changes
- schema_conv: Int32 => IntegerType, Int64 => LongType.
- count() and count(*) cast to Int64 for PySpark LongType.
- Validation: make check-full passes.