### PR TITLE
Fix #982: conversion from str to datetime failed

### DIFF
--- a/crates/robin-sparkless-polars/src/functions/rest.rs
+++ b/crates/robin-sparkless-polars/src/functions/rest.rs
@@ -1313,6 +1313,21 @@ fn cast_impl(column: &Column, type_name: &str, strict: bool) -> Result<Column, S
         );
         return Ok(Column::from_expr(expr, None));
     }
+    if matches!(dtype, DataType::Datetime(_, _)) {
+        use polars::datatypes::TimeUnit;
+        let expr = column.expr().clone().map(
+            move |col| {
+                crate::column::expect_col(crate::udfs::apply_string_to_datetime(col, strict))
+            },
+            |_schema, field| {
+                Ok(Field::new(
+                    field.name().clone(),
+                    DataType::Datetime(TimeUnit::Microseconds, None),
+                ))
+            },
+        );
+        return Ok(Column::from_expr(expr, None));
+    }
     if dtype == DataType::Int32 || dtype == DataType::Int64 {
         let target = dtype.clone();
         let expr = column.expr().clone().map(

--- a/crates/robin-sparkless-polars/src/functions/types.rs
+++ b/crates/robin-sparkless-polars/src/functions/types.rs
@@ -18,7 +18,9 @@ pub fn parse_type_name(name: &str) -> Result<DataType, String> {
         "string" | "str" => DataType::String,
         "boolean" | "bool" => DataType::Boolean,
         "date" => DataType::Date,
-        "timestamp" => DataType::Datetime(TimeUnit::Microseconds, None),
+        "timestamp" | "datetime" | "timestamp_ntz" => {
+            DataType::Datetime(TimeUnit::Microseconds, None)
+        }
         _ => return Err(format!("unknown type name: {name}")),
     })
 }

--- a/crates/robin-sparkless-polars/src/udfs/rest.rs
+++ b/crates/robin-sparkless-polars/src/udfs/rest.rs
@@ -4021,6 +4021,26 @@ pub fn apply_shuffle(column: Column) -> PolarsResult<Option<Column>> {
 /// Size of bitmap in bytes (32768 bits).
 const BITMAP_BYTES: usize = 4096;
 
+/// Parse string to datetime (micros since epoch). Accepts ISO and "YYYY-MM-DD HH:MM:SS", "YYYY-MM-DD" (midnight). #982.
+fn parse_str_to_datetime_micros(s: &str) -> Option<i64> {
+    use chrono::{NaiveDate, NaiveDateTime};
+    let s = s.trim();
+    NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.f")
+        .ok()
+        .or_else(|| NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S").ok())
+        .or_else(|| NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S").ok())
+        .or_else(|| {
+            if s.len() >= 10 {
+                NaiveDate::parse_from_str(&s[0..10], "%Y-%m-%d")
+                    .ok()
+                    .and_then(|d| d.and_hms_opt(0, 0, 0))
+            } else {
+                None
+            }
+        })
+        .map(|dt| dt.and_utc().timestamp_micros())
+}
+
 /// Parse string to date (PySpark cast string->date). Accepts "YYYY-MM-DD" and "YYYY-MM-DD HH:MM:SS" (truncates to date).
 fn parse_str_to_date(s: &str) -> Option<chrono::NaiveDate> {
     use chrono::{NaiveDate, NaiveDateTime};
@@ -4438,6 +4458,64 @@ pub fn apply_string_to_date(column: Column, strict: bool) -> PolarsResult<Option
                 (0..series.len()).map(|_| None::<i32>),
             );
             days.into_series().cast(&DataType::Date)?
+        }
+    };
+    Ok(Some(Column::new(name, out)))
+}
+
+/// Apply string-to-datetime cast (#982). Handles string (parse common formats); passes through Datetime; Date->Datetime at midnight; others error (cast) or null (try_cast).
+pub fn apply_string_to_datetime(column: Column, strict: bool) -> PolarsResult<Option<Column>> {
+    use polars::datatypes::TimeUnit;
+    let name = column.field().into_owned().name;
+    let series = column.take_materialized_series();
+    let dtype_out = DataType::Datetime(TimeUnit::Microseconds, None);
+    let out: Series = match series.dtype() {
+        DataType::String => {
+            let ca = series
+                .str()
+                .map_err(|e| compute_err("string to datetime", e))?;
+            let mut results = Vec::with_capacity(ca.len());
+            for opt_s in ca.into_iter() {
+                let v = opt_s.and_then(parse_str_to_datetime_micros);
+                if strict {
+                    if let Some(s) = opt_s {
+                        if v.is_none() {
+                            return Err(PolarsError::ComputeError(
+                                format!(
+                                    "conversion from `str` to `datetime` failed in column '{}' for value \"{s}\"",
+                                    name.as_str()
+                                )
+                                .into(),
+                            ));
+                        }
+                    }
+                }
+                results.push(v);
+            }
+            let chunked =
+                Int64Chunked::from_iter_options(name.as_str().into(), results.into_iter());
+            chunked.into_series().cast(&dtype_out)?
+        }
+        DataType::Datetime(_, _) => series.cast(&dtype_out)?,
+        DataType::Date => series.cast(&dtype_out)?,
+        DataType::Null => {
+            let micros = Int64Chunked::from_iter_options(
+                name.as_str().into(),
+                (0..series.len()).map(|_| None::<i64>),
+            );
+            micros.into_series().cast(&dtype_out)?
+        }
+        _ => {
+            if strict {
+                return Err(PolarsError::ComputeError(
+                    format!("casting from {} to datetime not supported", series.dtype()).into(),
+                ));
+            }
+            let micros = Int64Chunked::from_iter_options(
+                name.as_str().into(),
+                (0..series.len()).map(|_| None::<i64>),
+            );
+            micros.into_series().cast(&dtype_out)?
         }
     };
     Ok(Some(Column::new(name, out)))


### PR DESCRIPTION
Fixes #982. Add apply_string_to_datetime (parse common formats) and use it in cast/try_cast for timestamp/datetime; add timestamp_ntz and datetime to parse_type_name.