### PR TITLE
Allow Null -> int/long cast for Delta schema evolution (fix #1028)

### DIFF
--- a/crates/robin-sparkless-polars/src/functions/rest.rs
+++ b/crates/robin-sparkless-polars/src/functions/rest.rs
@@ -2955,7 +2955,7 @@ pub fn stack(columns: &[&Column]) -> Column {
 mod tests {
     use super::*;
     use crate::functions::{col, lit_bool, lit_f64, lit_i32, lit_i64, lit_str};
-    use polars::prelude::{IntoLazy, df};
+    use polars::prelude::{DataType, IntoLazy, Series, df};
 
     #[test]
     fn test_col_creates_column() {
@@ -2992,6 +2992,27 @@ mod tests {
     fn test_lit_str() {
         let column = lit_str("hello");
         assert_eq!(column.name(), "<expr>");
+    }
+
+    #[test]
+    fn cast_null_literal_to_int_and_long() {
+        // Simulate F.lit(None).cast(IntegerType/LongType): casting from Null to Int32/Int64
+        // should yield typed null columns instead of erroring (#1028).
+        let s = Series::new_null("x".into(), 3);
+
+        // Cast via the lower-level helper to be explicit about the target type.
+        let col_i32 =
+            crate::udfs::apply_string_to_int(s.clone().into_column(), true, DataType::Int32)
+                .expect("cast to Int32 should succeed")
+                .expect("column should be present");
+        let col_i64 = crate::udfs::apply_string_to_int(s.into_column(), true, DataType::Int64)
+            .expect("cast to Int64 should succeed")
+            .expect("column should be present");
+
+        assert_eq!(col_i32.dtype(), &DataType::Int32);
+        assert_eq!(col_i64.dtype(), &DataType::Int64);
+        assert!(col_i32.is_null().all());
+        assert!(col_i64.is_null().all());
     }
 
     #[test]

--- a/crates/robin-sparkless-polars/src/udfs/rest.rs
+++ b/crates/robin-sparkless-polars/src/udfs/rest.rs
@@ -4377,6 +4377,10 @@ pub fn apply_string_to_int(
     let name = column.field().into_owned().name;
     let series = column.take_materialized_series();
     let out: Series = match series.dtype() {
+        DataType::Null => {
+            // PySpark parity (#1028): lit(None).cast(\"int\"/\"long\") yields a typed null column.
+            Series::new_null(name.clone(), series.len()).cast(&target)?
+        }
         DataType::String => {
             let ca = series.str().map_err(|e| compute_err("string to int", e))?;
             let mut results: Vec<Option<i64>> = Vec::with_capacity(ca.len());


### PR DESCRIPTION
## Summary

- Update the Polars-backed casting path so that **Null-typed columns can be cast to Int32/Int64** without error, matching PySpark behavior for `F.lit(None).cast(IntegerType/LongType/...)` used in Delta schema-evolution flows.
- Implemented this by teaching `apply_string_to_int` to special-case `DataType::Null`, creating a typed null series and casting it to the requested integer type instead of rejecting the cast.
- Added a focused unit test in `functions::rest` to assert that casting a Null series to `int`/`bigint` produces all-null columns with `Int32`/`Int64` dtypes.
- This removes `_native.SparklessError: casting from null to i32/i64 not supported` for patterns like `withColumn("int_col", F.lit(None).cast(IntegerType()))` that appear in the upstream Delta schema evolution tests (see issue #1028).

## Test plan

- `make check-full` (Rust fmt, clippy, deny/audit, and tests) — passes.
- `.venv/bin/ruff check python tests --exclude tests/upstream_sparkless` — passes.
- `.venv/bin/mypy python/sparkless` — passes.
- Upstream Delta/schema-evolution tests that exercise `lit(None).cast(IntegerType/LongType/...)` (e.g. `test_null_literal_casting_to_various_types`, `test_schema_merge_with_type_preservation`) are expected to pass once CI runs the full vendored suite with Delta enabled.
