### PR TITLE
Arrays & posexplode parity: avoid list.eval, infer array columns (fix #1027)

### DIFF
--- a/crates/robin-sparkless-polars/src/column.rs
+++ b/crates/robin-sparkless-polars/src/column.rs
@@ -2770,7 +2770,29 @@ impl Column {
 
     /// Posexplode with null preservation (PySpark posexplode_outer).
     pub fn posexplode_outer(&self) -> (Column, Column) {
-        self.posexplode()
+        use polars::prelude::{DataType, ExplodeOptions, Field};
+        let opts = ExplodeOptions {
+            empty_as_null: true,
+            keep_nulls: true,
+        };
+        let pos_expr = self
+            .expr()
+            .clone()
+            .map(
+                |col| expect_col(crate::udfs::apply_posexplode_positions(col)),
+                |_schema, field| {
+                    Ok(Field::new(
+                        field.name().clone(),
+                        DataType::List(Box::new(DataType::Int64)),
+                    ))
+                },
+            )
+            .explode(opts);
+        let val_expr = self.expr().clone().explode(opts);
+        (
+            Self::from_expr(pos_expr, Some("pos".to_string())),
+            Self::from_expr(val_expr, Some("col".to_string())),
+        )
     }
 
     /// Zip two arrays element-wise into array of structs (PySpark arrays_zip).
@@ -3020,9 +3042,9 @@ impl Column {
     }
 
     /// Explode list with position (PySpark posexplode). Returns (pos_col, value_col).
-    /// pos is 1-based; uses list.eval(cum_count()).explode() and explode().
+    /// pos is 0-based; implemented via UDF to avoid list.eval limitations on i64.
     pub fn posexplode(&self) -> (Column, Column) {
-        use polars::prelude::ExplodeOptions;
+        use polars::prelude::{DataType, ExplodeOptions, Field};
         let opts = ExplodeOptions {
             empty_as_null: false,
             keep_nulls: false,
@@ -3030,8 +3052,15 @@ impl Column {
         let pos_expr = self
             .expr()
             .clone()
-            .list()
-            .eval(col("").cum_count(false))
+            .map(
+                |col| expect_col(crate::udfs::apply_posexplode_positions(col)),
+                |_schema, field| {
+                    Ok(Field::new(
+                        field.name().clone(),
+                        DataType::List(Box::new(DataType::Int64)),
+                    ))
+                },
+            )
             .explode(opts);
         let val_expr = self.expr().clone().explode(opts);
         (

--- a/crates/robin-sparkless-polars/src/udfs/rest.rs
+++ b/crates/robin-sparkless-polars/src/udfs/rest.rs
@@ -276,6 +276,39 @@ pub fn apply_array_flatten(column: Column) -> PolarsResult<Option<Column>> {
     Ok(Some(Column::new(name, out.into_series())))
 }
 
+/// Build per-row position lists for posexplode (0-based indices).
+/// Input must be a List column; each list [v0, v1, ..., v{n-1}] yields [0, 1, ..., n-1].
+/// Used by Column::posexplode / posexplode_outer to avoid list.eval limitations on i64.
+pub fn apply_posexplode_positions(column: Column) -> PolarsResult<Option<Column>> {
+    let name = column.field().into_owned().name;
+    let series = column.take_materialized_series();
+    let list_ca = series
+        .list()
+        .map_err(|e| compute_err("posexplode_positions", e))?;
+
+    // Heuristic capacity: assume small average list length.
+    let values_capacity = list_ca.len().saturating_mul(4);
+    let mut builder = ListPrimitiveChunkedBuilder::<Int64Type>::new(
+        name.as_str().into(),
+        list_ca.len(),
+        values_capacity,
+        DataType::Int64,
+    );
+
+    for opt_s in list_ca.into_iter() {
+        match opt_s {
+            Some(s) => {
+                let len = s.len();
+                builder.append_iter((0..len).map(|i| Some(i as i64)));
+            }
+            None => builder.append_null(),
+        }
+    }
+
+    let out = builder.finish().into_series();
+    Ok(Some(Column::new(name, out)))
+}
+
 /// Distinct elements in list preserving first-occurrence order (PySpark array_distinct parity).
 pub fn apply_array_distinct_first_order(column: Column) -> PolarsResult<Option<Column>> {
     let name = column.field().into_owned().name;

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1646,6 +1646,11 @@ fn infer_type_from_py_value(v: &Bound<'_, PyAny>) -> String {
     if v.extract::<f64>().is_ok() {
         return "double".to_string();
     }
+    // Treat Python list/tuple as array so createDataFrame infers List dtype
+    // for columns backed by sequence values (PySpark parity for array columns).
+    if v.downcast::<PyList>().is_ok() || v.downcast::<PyTuple>().is_ok() {
+        return "array".to_string();
+    }
     if v.downcast::<PyBytes>().is_ok() {
         return "binary".to_string();
     }


### PR DESCRIPTION
## Summary

- **Posexplode**: Reimplement `Column::posexplode` and `posexplode_outer` using a UDF (`apply_posexplode_positions`) that builds per-row position lists instead of Polars `list.eval(cum_count())`, avoiding "list.eval operation not supported for dtype `i64`" when array columns were not true List type.
- **createDataFrame array inference**: In the Python binding, treat Python `list`/`tuple` values as `array` in `infer_type_from_py_value` so schema-inferred columns from dict rows get List dtype and posexplode sees List inputs.

## Test plan

- `make check-full` — passes.
- Posexplode Rust usage builds; upstream posexplode tests still hit `createDataFrame` paths that may need explicit schema (e.g. `array` or `array<int>`) for full parity depending on test harness.

Fixes #1027