### PR TITLE
Fix row/schema case sensitivity (Key not found in row)

### DIFF
--- a/crates/robin-sparkless-polars/src/column.rs
+++ b/crates/robin-sparkless-polars/src/column.rs
@@ -136,9 +136,10 @@ impl Column {
         &self.expr
     }
 
-    /// Convert to Polars Expr (consumes self)
+    /// Convert to Polars Expr (consumes self).
+    /// Applies the Column's display name as alias so row keys match (PySpark parity #1014, #1017, #1022).
     pub fn into_expr(self) -> Expr {
-        self.expr
+        self.expr.alias(&self.name)
     }
 
     /// Get the column name

--- a/crates/robin-sparkless-polars/src/plan/mod.rs
+++ b/crates/robin-sparkless-polars/src/plan/mod.rs
@@ -380,7 +380,8 @@ fn apply_op(
                         let resolved = df
                             .resolve_column_name(expr_str)
                             .map_err(PlanError::Session)?;
-                        exprs.push(polars::prelude::col(resolved));
+                        // #1014, #1022: Preserve requested column name as output (e.g. "NaMe") so row keys match.
+                        exprs.push(polars::prelude::col(resolved).alias(name_str.as_str()));
                     }
                 }
                 df.select_exprs(exprs).map_err(PlanError::Session)

--- a/tests/expressions.rs
+++ b/tests/expressions.rs
@@ -1085,6 +1085,7 @@ fn plan_filter_case_insensitive_column_ref() {
     assert_eq!(out[0].get("id").and_then(|v| v.as_i64()), Some(2));
 }
 
+/// #1014, #1022: Row keys use requested column name (e.g. "name") so key matches what the user asked for.
 #[test]
 fn plan_select_case_insensitive_column_name() {
     let spark = spark();
@@ -1097,7 +1098,7 @@ fn plan_select_case_insensitive_column_name() {
     let df = plan::execute_plan(&spark, rows, schema, &plan_steps).unwrap();
     let out = df.collect_as_json_rows_engine().unwrap();
     assert_eq!(out.len(), 1);
-    assert_eq!(out[0].get("Name").and_then(|v| v.as_str()), Some("Alice"));
+    assert_eq!(out[0].get("name").and_then(|v| v.as_str()), Some("Alice"));
 }
 
 // ---------- issue_548 ----------


### PR DESCRIPTION
Fixes #1014, #1017, #1022

**Summary**
- **Plan select:** Use the requested column name as the output alias so collected row keys match what the user asked for (e.g. `select "NaMe"` → key `NaMe`; `select "name"` → key `name`).
- **Column::into_expr():** Apply the Column display name as alias when converting to Expr so agg/select output names match (e.g. `avg(Value1)` → key `avg(Value1)`).
- **Test:** Update `plan_select_case_insensitive_column_name` to expect the requested key `name` when selecting by `name`.

**Testing**
- `cargo test -p robin-sparkless-polars -- plan::` — all plan tests pass.
- `cargo test -p robin-sparkless-polars column::` — all column tests pass.
- `cargo test -p robin-sparkless --test expressions plan_` — 30 plan-related expression tests pass.