### PR TITLE
Fix column/alias resolution (with_column, select after agg)

### DIFF
--- a/crates/robin-sparkless-polars/src/dataframe/mod.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/mod.rs
@@ -179,6 +179,21 @@ impl DataFrame {
             }
             Ok(e)
         })?;
+        // #1008: Expr's default output name (e.g. to_timestamp_timestamp_str) must not be resolved as input column.
+        // Only add when it does not match any schema column (case-insensitive), so col("age") still resolves to "Age".
+        if let Ok(out_name) = polars_plan::utils::expr_output_name(&expr) {
+            let out_str = out_name.as_str();
+            let matches_schema = self
+                .columns()
+                .map(|cols| {
+                    cols.iter()
+                        .any(|c| c.eq_ignore_ascii_case(out_str))
+                })
+                .unwrap_or(false);
+            if !matches_schema {
+                alias_output_names.insert(out_str.to_string());
+            }
+        }
         expr.try_map_expr(move |e| {
             if let Expr::Column(name) = &e {
                 let name_str = name.as_str();


### PR DESCRIPTION
Fixes #1008, #1012

**#1008** with_column("ts", to_timestamp(col("s"))) failed with "Column 'to_timestamp_timestamp_str' not found" because the expr's default output name was being resolved as an input column. We now add the expr's output name to the don't-resolve set only when it does not match any schema column (case-insensitive), so col("age") still resolves to "Age".

**#1012** select after groupBy().agg(F.avg("value").alias("avg_value")) is addressed by PR 1 (Column::into_expr() applies display name as alias so agg result has column "avg_value").

**Testing:** `cargo test -p robin-sparkless-polars` — 195 tests + 7 doctests pass.