### PR TITLE
SQL: CREATE VIEW, DESCRIBE EXTENDED, join type error — Fixes #1010, #1011, #1013, #1020

### DIFF
--- a/crates/robin-sparkless-polars/src/sql/mod.rs
+++ b/crates/robin-sparkless-polars/src/sql/mod.rs
@@ -109,8 +109,12 @@ pub fn execute_sql(session: &SparkSession, query: &str) -> Result<DataFrame, Pol
     };
     if !rest.is_empty() && (is_describe || is_desc) {
         let parts: Vec<&str> = rest.split_whitespace().collect();
-        let table_name = parts.first().copied().unwrap_or("");
-        let col_name = parts.get(1).copied();
+        // #1013: DESCRIBE [TABLE] [EXTENDED] table_name [col_name] — skip TABLE/EXTENDED to get table name.
+        let idx = parts.iter().position(|p| {
+            !p.eq_ignore_ascii_case("TABLE") && !p.eq_ignore_ascii_case("EXTENDED")
+        });
+        let table_name = idx.and_then(|i| parts.get(i)).copied().unwrap_or("");
+        let col_name = idx.and_then(|i| parts.get(i + 1)).copied();
         if !table_name.is_empty() {
             return translator::translate_describe_table_optional_col(
                 session, table_name, col_name,
@@ -626,6 +630,49 @@ mod tests {
             rows[0].get("data_type").and_then(|v| v.as_str()),
             Some("long")
         );
+    }
+
+    /// DESCRIBE TABLE EXTENDED table_name (#1013): TABLE/EXTENDED skipped to get table name.
+    #[test]
+    fn test_sql_describe_table_extended() {
+        let spark = SparkSession::builder().app_name("test").get_or_create();
+        let df = spark
+            .create_dataframe(
+                vec![(1i64, 25i64, "a".to_string())],
+                vec!["id", "age", "name"],
+            )
+            .unwrap();
+        spark.create_or_replace_temp_view("t", df);
+        let result = spark.sql("DESCRIBE TABLE EXTENDED t").unwrap();
+        let rows = result.collect_as_json_rows().unwrap();
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows[0].get("col_name").and_then(|v| v.as_str()), Some("id"));
+        assert_eq!(rows[1].get("col_name").and_then(|v| v.as_str()), Some("age"));
+        assert_eq!(rows[2].get("col_name").and_then(|v| v.as_str()), Some("name"));
+    }
+
+    /// CREATE OR REPLACE TEMP VIEW ... AS SELECT (#1011).
+    #[test]
+    fn test_sql_create_or_replace_temp_view() {
+        let spark = SparkSession::builder().app_name("test").get_or_create();
+        let df = spark
+            .create_dataframe(
+                vec![
+                    (1i64, 10i64, "x".to_string()),
+                    (2i64, 20i64, "y".to_string()),
+                ],
+                vec!["id", "age", "label"],
+            )
+            .unwrap();
+        spark.create_or_replace_temp_view("base", df);
+        spark
+            .sql("CREATE OR REPLACE TEMP VIEW v AS SELECT id, label FROM base WHERE id > 1")
+            .unwrap();
+        let result = spark.sql("SELECT * FROM v").unwrap();
+        let rows = result.collect_as_json_rows().unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].get("id"), Some(&serde_json::json!(2)));
+        assert_eq!(rows[0].get("label"), Some(&serde_json::json!("y")));
     }
 
     #[test]

--- a/crates/robin-sparkless-polars/src/sql/translator.rs
+++ b/crates/robin-sparkless-polars/src/sql/translator.rs
@@ -110,6 +110,16 @@ pub fn translate(
     set_thread_udf_session(session.clone());
     match stmt {
         Statement::Query(q) => translate_query(session, q.as_ref()),
+        Statement::CreateView(create_view) => {
+            // CREATE [OR REPLACE] [TEMP] VIEW name AS SELECT ... (#1011).
+            let view_name = table_name_from_object_name(&create_view.name);
+            let df = translate_query(session, create_view.query.as_ref())?;
+            session.create_or_replace_temp_view(&view_name, df);
+            Ok(DataFrame::from_polars_with_options(
+                PlDataFrame::empty(),
+                session.is_case_sensitive(),
+            ))
+        }
         Statement::CreateTable(create_table) => {
             let table_name = create_table.name.to_string();
             if session.table_exists(&table_name) {
@@ -256,7 +266,7 @@ pub fn translate(
         Statement::Delete(d) => translate_delete(session, d),
         Statement::ExplainTable { table_name, .. } => translate_describe_table(session, table_name),
         _ => Err(PolarsError::InvalidOperation(
-            "SQL: only SELECT, CREATE SCHEMA/DATABASE, DROP TABLE/VIEW/SCHEMA/DATABASE, and DESCRIBE are supported."
+            "SQL: only SELECT, CREATE TABLE/VIEW, CREATE SCHEMA/DATABASE, DROP TABLE/VIEW/SCHEMA/DATABASE, and DESCRIBE are supported."
                 .into(),
         )),
     }
@@ -611,9 +621,13 @@ fn translate_select_from(
                     JoinOperator::LeftAnti(_) => JoinType::LeftAnti,
                     JoinOperator::Semi(_) => JoinType::LeftSemi,
                     JoinOperator::Anti(_) => JoinType::LeftAnti,
-                    _ => {
+                    other => {
                         return Err(PolarsError::InvalidOperation(
-                            "SQL: only INNER, LEFT, RIGHT, FULL, LEFT SEMI, LEFT ANTI, CROSS JOIN are supported.".into(),
+                            format!(
+                                "SQL: unsupported join type {:?}; only INNER, LEFT, RIGHT, FULL, LEFT SEMI, LEFT ANTI, CROSS JOIN are supported.",
+                                other
+                            )
+                            .into(),
                         ));
                     }
                 };
@@ -692,9 +706,13 @@ fn join_condition_to_on_columns(
         | JoinOperator::Semi(c)
         | JoinOperator::Anti(c) => c,
         JoinOperator::CrossJoin(_) => return Ok((vec![], vec![])),
-        _ => {
+        other => {
             return Err(PolarsError::InvalidOperation(
-                "SQL: only INNER/LEFT/RIGHT/FULL/LEFT SEMI/LEFT ANTI/CROSS JOIN with ON are supported.".into(),
+                format!(
+                    "SQL: unsupported join type {:?}; only INNER/LEFT/RIGHT/FULL/LEFT SEMI/LEFT ANTI/CROSS JOIN with ON are supported.",
+                    other
+                )
+                .into(),
             ));
         }
     };


### PR DESCRIPTION
Fixes #1011, #1013, #1020. Documents #1010.

**#1011** — CREATE OR REPLACE TEMP VIEW ... AS SELECT: handle `Statement::CreateView`, translate the query, register via `create_or_replace_temp_view`, return empty DataFrame. Test: `test_sql_create_or_replace_temp_view`.

**#1013** — DESCRIBE TABLE EXTENDED / DESCRIBE col: parse `DESCRIBE [TABLE] [EXTENDED] table_name [col_name]` by skipping TABLE/EXTENDED when resolving the table name. Test: `test_sql_describe_table_extended`.

**#1020** — Join type error message now includes the unsupported variant (e.g. `NaturalJoin`) so users see which type is missing.

**#1010** — Subquery in WHERE (e.g. `col IN (SELECT ...)`) remains unsupported; existing error message retained.