### PR TITLE
Fix #1058: Add 'cannot resolve' to column-not-found error messages

### DIFF
--- a/crates/robin-sparkless-polars/src/dataframe/aggregations.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/aggregations.rs
@@ -68,7 +68,7 @@ impl GroupedData {
         let available = names.join(", ");
         Err(PolarsError::ColumnNotFound(
             format!(
-                "Column '{}' not found in grouped DataFrame. Available: [{}].",
+                "cannot resolve: column '{}' not found in grouped DataFrame. Available: [{}].",
                 name, available
             )
             .into(),
@@ -102,7 +102,7 @@ impl GroupedData {
                     let rest = &parts[1..];
                     if rest.is_empty() {
                         return Err(PolarsError::ColumnNotFound(
-                            format!("Column '{}': trailing dot not allowed", name_str).into(),
+                            format!("cannot resolve: Column '{}': trailing dot not allowed", name_str).into(),
                         ));
                     }
                     let resolved = gd.resolve_column(first)?;
@@ -869,7 +869,7 @@ impl PivotedGroupedData {
         let available = names.join(", ");
         Err(PolarsError::ColumnNotFound(
             format!(
-                "Column '{}' not found in pivot DataFrame. Available: [{}].",
+                "cannot resolve: column '{}' not found in pivot DataFrame. Available: [{}].",
                 name, available
             )
             .into(),

--- a/crates/robin-sparkless-polars/src/dataframe/mod.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/mod.rs
@@ -208,7 +208,7 @@ impl DataFrame {
                     let rest = &parts[1..];
                     if rest.is_empty() {
                         return Err(PolarsError::ColumnNotFound(
-                            format!("Column '{}': trailing dot not allowed", name_str).into(),
+                            format!("cannot resolve: Column '{}': trailing dot not allowed", name_str).into(),
                         ));
                     }
                     let resolved = df.resolve_column_name(first)?;
@@ -216,7 +216,7 @@ impl DataFrame {
                     let mut current_dtype =
                         df.get_column_dtype(resolved.as_str()).ok_or_else(|| {
                             PolarsError::ColumnNotFound(
-                                format!("Column '{}' not found", resolved).into(),
+                                format!("cannot resolve: column '{}' not found", resolved).into(),
                             )
                         })?;
                     let mut context_name = resolved.to_string();
@@ -714,7 +714,7 @@ impl DataFrame {
             _ => {
                 return Err(PolarsError::ColumnNotFound(
                     format!(
-                        "Expected struct for nested access '{}'; got non-struct type.",
+                        "cannot resolve: Expected struct for nested access '{}'; got non-struct type.",
                         context_name
                     )
                     .into(),
@@ -735,7 +735,7 @@ impl DataFrame {
         let available: Vec<String> = fields.iter().map(|f| f.name.to_string()).collect();
         Err(PolarsError::ColumnNotFound(
             format!(
-                "Struct field '{}' not found in '{}'. Available: [{}].",
+                "cannot resolve: Struct field '{}' not found in '{}'. Available: [{}].",
                 field_name,
                 context_name,
                 available.join(", ")
@@ -751,12 +751,14 @@ impl DataFrame {
         field_name: &str,
     ) -> Result<String, PolarsError> {
         let dt = self.get_column_dtype(struct_col_name).ok_or_else(|| {
-            PolarsError::ColumnNotFound(format!("Column '{}' not found", struct_col_name).into())
+            PolarsError::ColumnNotFound(
+                format!("cannot resolve: column '{}' not found", struct_col_name).into(),
+            )
         })?;
         if !matches!(dt, DataType::Struct(_)) {
             return Err(PolarsError::ColumnNotFound(
                 format!(
-                    "Column '{}' is not a struct; cannot access field '{}'.",
+                    "cannot resolve: Column '{}' is not a struct; cannot access field '{}'.",
                     struct_col_name, field_name
                 )
                 .into(),

--- a/crates/robin-sparkless-polars/src/dataframe/transformations.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/transformations.rs
@@ -948,7 +948,7 @@ pub fn subtract(
                     .cloned()
                     .ok_or_else(|| {
                         PolarsError::ColumnNotFound(
-                            format!("subtract: column '{}' not found on right", ln).into(),
+                            format!("cannot resolve: subtract: column '{}' not found on right", ln).into(),
                         )
                     })?
             } else {
@@ -959,7 +959,7 @@ pub fn subtract(
                     .cloned()
                     .ok_or_else(|| {
                         PolarsError::ColumnNotFound(
-                            format!("subtract: column '{}' not found on right", ln).into(),
+                            format!("cannot resolve: subtract: column '{}' not found on right", ln).into(),
                         )
                     })?
             };
@@ -996,7 +996,7 @@ pub fn intersect(
                     .cloned()
                     .ok_or_else(|| {
                         PolarsError::ColumnNotFound(
-                            format!("intersect: column '{}' not found on right", ln).into(),
+                            format!("cannot resolve: intersect: column '{}' not found on right", ln).into(),
                         )
                     })?
             } else {
@@ -1007,7 +1007,7 @@ pub fn intersect(
                     .cloned()
                     .ok_or_else(|| {
                         PolarsError::ColumnNotFound(
-                            format!("intersect: column '{}' not found on right", ln).into(),
+                            format!("cannot resolve: intersect: column '{}' not found on right", ln).into(),
                         )
                     })?
             };

--- a/crates/robin-sparkless-polars/src/error.rs
+++ b/crates/robin-sparkless-polars/src/error.rs
@@ -5,11 +5,19 @@ use polars::error::PolarsError;
 pub use robin_sparkless_core::EngineError;
 
 /// Map PolarsError to core EngineError for trait boundaries (core trait methods return core::EngineError).
+/// Column-not-found messages are normalized to include "cannot resolve" for PySpark parity (issue #1058).
 pub fn polars_to_core_error(e: PolarsError) -> robin_sparkless_core::EngineError {
     use robin_sparkless_core::EngineError as Core;
     let msg = e.to_string();
     match &e {
-        PolarsError::ColumnNotFound(_) => Core::NotFound(msg),
+        PolarsError::ColumnNotFound(_) => {
+            let normalized = if msg.to_lowercase().contains("cannot resolve") {
+                msg
+            } else {
+                format!("cannot resolve: {msg}")
+            };
+            Core::NotFound(normalized)
+        }
         PolarsError::InvalidOperation(_) => Core::User(msg),
         PolarsError::ComputeError(_) => {
             let lower = msg.to_lowercase();

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -20,6 +20,7 @@ use std::path::Path;
 use std::thread_local;
 
 /// Convert EngineError or PolarsError to Python exception (SparklessError or TypeError for known validation errors).
+/// Column-not-found messages are normalized to include "cannot resolve" for PySpark parity (issue #1058).
 fn to_py_err(e: impl std::fmt::Display) -> PyErr {
     let msg = e.to_string();
     if msg.contains("to_date requires StringType, TimestampType, or DateType input") {
@@ -35,6 +36,16 @@ fn to_py_err(e: impl std::fmt::Display) -> PyErr {
     if (msg.contains("Row ") || msg.contains("row ")) && msg.contains("expected type") {
         return pyo3::exceptions::PyTypeError::new_err(msg);
     }
+    // Ensure column-not-found errors contain "cannot resolve" (PySpark parity; Polars may emit "unable to find column").
+    let msg = if !msg.to_lowercase().contains("cannot resolve")
+        && (msg.contains("unable to find column")
+            || (msg.contains("not found") && msg.to_lowercase().contains("column"))
+            || msg.contains("valid columns"))
+    {
+        format!("cannot resolve: {msg}")
+    } else {
+        msg
+    };
     SparklessError::new_err(msg)
 }
 

--- a/tests/upstream_sparkless/tests/test_issue_158_dropped_column_error.py
+++ b/tests/upstream_sparkless/tests/test_issue_158_dropped_column_error.py
@@ -50,9 +50,9 @@ class TestIssue158DroppedColumnError:
         with pytest.raises(SparkColumnNotFoundError) as exc_info:
             df_transformed.select("impression_date")
 
-        # Verify the error message format (PySpark: "cannot resolve"; robin: "not found")
+        # Verify the error message format (PySpark parity: must contain "cannot resolve")
         error_msg = str(exc_info.value).lower()
-        assert "cannot resolve" in error_msg or "not found" in error_msg
+        assert "cannot resolve" in error_msg
         assert "impression_date" in error_msg
         assert "impression_id" in error_msg or "campaign_id" in error_msg
 
@@ -70,9 +70,9 @@ class TestIssue158DroppedColumnError:
         with pytest.raises(SparkColumnNotFoundError) as exc_info:
             df_dropped.select(F.col("col2")).collect()
 
-        # Verify the error message format (PySpark: "cannot resolve"; robin: "not found")
+        # Verify the error message format (PySpark parity: must contain "cannot resolve")
         error_msg = str(exc_info.value).lower()
-        assert "cannot resolve" in error_msg or "not found" in error_msg
+        assert "cannot resolve" in error_msg
         assert "col2" in error_msg
         assert "col1" in error_msg
 
@@ -91,9 +91,9 @@ class TestIssue158DroppedColumnError:
         with pytest.raises(SparkColumnNotFoundError) as exc_info:
             df_dropped.filter(F.col("col2").isNotNull())
 
-        # Verify the error message format (PySpark: "cannot resolve"; robin: "not found")
+        # Verify the error message format (PySpark parity: must contain "cannot resolve")
         error_msg = str(exc_info.value).lower()
-        assert "cannot resolve" in error_msg or "not found" in error_msg
+        assert "cannot resolve" in error_msg
         assert "col2" in error_msg
         assert "col1" in error_msg
 
@@ -111,8 +111,8 @@ class TestIssue158DroppedColumnError:
         with pytest.raises(SparkColumnNotFoundError) as exc_info:
             df_dropped.select("col2")
 
-        # Verify the error message format (PySpark: "cannot resolve"; robin: "not found")
+        # Verify the error message format (PySpark parity: must contain "cannot resolve")
         error_msg = str(exc_info.value).lower()
-        assert "cannot resolve" in error_msg or "not found" in error_msg
+        assert "cannot resolve" in error_msg
         assert "col2" in error_msg
         assert "col1" in error_msg


### PR DESCRIPTION
## Summary
Fixes [issue #1058](https://github.com/eddiethedean/robin-sparkless/issues/1058): tests expect substring `cannot resolve` in column-not-found errors; sparkless was emitting `not found: column ...` (or Polars’ `unable to find column`).

## Changes
- **Rust (robin-sparkless-polars):** All `ColumnNotFound` messages now include `cannot resolve`:
  - `dataframe/mod.rs`: trailing dot, get_column_dtype, struct field, resolve_struct_field_name
  - `dataframe/aggregations.rs`: grouped DataFrame and pivot column resolution, trailing dot
  - `dataframe/transformations.rs`: subtract/intersect column-not-found on right
- **Error conversion:** `polars_to_core_error` normalizes Polars `ColumnNotFound` messages to include `cannot resolve` when they don’t already (e.g. Polars’ `unable to find column`).
- **Python bindings:** `to_py_err` prepends `cannot resolve: ` for column-not-found-like messages (e.g. `unable to find column`, `valid columns`) so all paths show PySpark-style wording.
- **Tests:** `test_issue_158_dropped_column_error.py` now requires `cannot resolve` in the error message (strict PySpark parity) instead of accepting `not found` as a fallback.

## Testing
- `pytest tests/upstream_sparkless/tests/test_issue_158_dropped_column_error.py -v` — all 4 tests pass.
- `cargo test -p robin-sparkless-polars --lib` — 197 passed.