### PR TITLE
Fix #1057: SparkContext.version property and pow() int/float exponent

### DIFF
--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -784,6 +784,8 @@ impl PySparkContext {
             .unwrap_or_else(|| "sparkless".to_string()))
     }
 
+    /// PySpark parity: version is a property (read-only string), not a method.
+    #[getter]
     fn version(&self) -> String {
         env!("CARGO_PKG_VERSION").to_string()
     }
@@ -6032,10 +6034,26 @@ fn exp(column: &PyColumn) -> PyColumn {
 }
 
 #[pyfunction]
-fn pow(column: &PyColumn, exp: i64) -> PyColumn {
-    PyColumn {
-        inner: functions::pow(&column.inner, exp),
+fn pow(column: &PyColumn, exp: &Bound<'_, PyAny>) -> PyResult<PyColumn> {
+    if let Ok(exp_i) = exp.extract::<i64>() {
+        return Ok(PyColumn {
+            inner: functions::pow(&column.inner, exp_i),
+        });
     }
+    if let Ok(exp_i) = exp.extract::<i32>() {
+        return Ok(PyColumn {
+            inner: functions::pow(&column.inner, exp_i as i64),
+        });
+    }
+    if let Ok(exp_f) = exp.extract::<f64>() {
+        let lit_col = functions::lit_f64(exp_f);
+        return Ok(PyColumn {
+            inner: column.inner.pow_with(&lit_col),
+        });
+    }
+    Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+        "pow exponent must be int or float",
+    ))
 }
 
 #[pyfunction]

--- a/tests/python/test_issue_387_spark_context.py
+++ b/tests/python/test_issue_387_spark_context.py
@@ -19,9 +19,9 @@ def test_spark_context_exists() -> None:
 
 
 def test_spark_context_version() -> None:
-    """SparkContext.version() returns a string."""
+    """SparkContext.version is a string property (PySpark parity)."""
     spark = _spark()
     ctx = spark.sparkContext
-    v = ctx.version()
+    v = ctx.version  # property, not method (PySpark: sc.version)
     assert isinstance(v, str)
     assert len(v) >= 1


### PR DESCRIPTION
## Summary
Addresses [issue #1057](https://github.com/eddiethedean/robin-sparkless/issues/1057) (Pow / coalesce / head / SparkContext / union). This PR implements the two remaining parity items that required code changes; the others already pass.

## Changes

### 1. SparkContext.version (PySpark parity)
- **Before:** `version()` was a method → `spark.sparkContext.version` returned a method object (TypeError if used as string).
- **After:** `version` is a **property** (getter) so `spark.sparkContext.version` returns the version string, matching [PySpark](https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.SparkContext.version.html).
- Test `test_issue_387_spark_context.py::test_spark_context_version` updated to use `ctx.version` (property) instead of `ctx.version()`.

### 2. pow(column, exp) — int or float exponent
- **Before:** Native `pow(column, exp: i64)` only accepted integer exponent from Python.
- **After:** `pow(column, exp)` accepts `int` or `float`. Integer exponents use `functions::pow`; float exponents use `Column::pow_with` with `lit_f64(exp)` so `pow(col("x"), 2.0)` and fractional exponents work from Python/sparkless.

## Tests
All 11 tests referenced in the issue pass:
- `tests/python/test_issue_405_pow_bitwise.py` (2)
- `tests/python/test_issue_407_coalesce_variadic.py` (2)
- `tests/python/test_issue_413_head.py` (2)
- `tests/python/test_issue_387_spark_context.py` (2)
- `tests/python/test_issue_385_union_dataframe_like.py` (3)

(Head, coalesce, and union were already implemented and passing; no code changes needed for those.)