### PR TITLE
fix(#1056): date_trunc format mapping and empty Window.orderBy() error

### DIFF
--- a/crates/robin-sparkless-polars/src/column.rs
+++ b/crates/robin-sparkless-polars/src/column.rs
@@ -44,6 +44,22 @@ fn like_pattern_to_regex(pattern: &str, escape_char: Option<char>) -> String {
     format!("^{out}$")
 }
 
+/// Map PySpark date_trunc/trunc format (year, month, day, hour, etc.) to Polars duration string (1y, 1mo, 1d, 1h).
+/// Polars dt.truncate expects a leading integer; PySpark uses unit names without a number.
+fn pyspark_trunc_format_to_polars_duration(format: &str) -> String {
+    match format.to_lowercase().as_str() {
+        "year" | "years" => "1y".to_string(),
+        "month" | "months" => "1mo".to_string(),
+        "week" | "weeks" | "wk" => "1w".to_string(),
+        "day" | "days" => "1d".to_string(),
+        "hour" | "hours" => "1h".to_string(),
+        "minute" | "minutes" | "min" => "1m".to_string(),
+        "second" | "seconds" | "sec" => "1s".to_string(),
+        "quarter" | "quarters" | "q" => "1q".to_string(),
+        _ => format.to_string(), // already Polars-style (e.g. 1d) or pass through
+    }
+}
+
 /// Deferred random column: when added via with_column, we generate a full-length series in one go (PySpark-like).
 #[derive(Debug, Clone, Copy)]
 pub enum DeferredRandom {
@@ -2177,13 +2193,23 @@ impl Column {
         Self::from_expr(expr, None)
     }
 
-    /// Truncate date/datetime to unit (e.g. "mo", "wk", "day"). PySpark trunc.
+    /// Truncate date/datetime to unit. PySpark date_trunc/trunc use "year", "month", "day", "hour";
+    /// Polars dt.truncate expects duration strings like "1y", "1mo", "1d", "1h". We map PySpark names.
+    /// Uses a UDF path so string columns (e.g. from createDataFrame with Python datetime) are coerced to datetime then truncated.
     pub fn trunc(&self, format: &str) -> Column {
         use polars::prelude::*;
-        Self::from_expr(
-            self.expr().clone().dt().truncate(lit(format.to_string())),
-            None,
-        )
+        let polars_duration = pyspark_trunc_format_to_polars_duration(format);
+        let duration = polars_duration.clone();
+        let expr = self.expr().clone().map(
+            move |c| expect_col(crate::udfs::apply_date_trunc(c, &duration)),
+            |_schema, field| {
+                Ok(Field::new(
+                    field.name().clone(),
+                    DataType::Datetime(TimeUnit::Microseconds, None),
+                ))
+            },
+        );
+        Self::from_expr(expr, Some(self.name().to_string()))
     }
 
     /// Add n months to date/datetime column (PySpark add_months). Month-aware.

--- a/crates/robin-sparkless-polars/src/udfs/rest.rs
+++ b/crates/robin-sparkless-polars/src/udfs/rest.rs
@@ -3853,6 +3853,79 @@ pub fn apply_second(column: Column) -> PolarsResult<Option<Column>> {
     Ok(Some(Column::new(name, out)))
 }
 
+/// date_trunc/trunc: coerce to datetime (including from string) then truncate by duration (1y, 1mo, 1d, 1h, etc.).
+pub fn apply_date_trunc(column: Column, polars_duration: &str) -> PolarsResult<Option<Column>> {
+    use chrono::{Datelike, NaiveDateTime, TimeZone, Timelike};
+    use polars::datatypes::TimeUnit;
+    let name = column.field().into_owned().name;
+    let series = column.take_materialized_series();
+    let dt_series = series_to_datetime_micros(&series)?;
+    let ca = dt_series.datetime().map_err(|e| compute_err("date_trunc", e))?;
+    let truncate_by = match polars_duration.to_lowercase().as_str() {
+        "1y" => 0,
+        "1mo" => 1,
+        "1w" => 2,
+        "1d" => 3,
+        "1h" => 4,
+        "1m" => 5,
+        "1s" => 6,
+        _ => {
+            return Err(PolarsError::ComputeError(
+                format!("date_trunc: unsupported duration {:?}", polars_duration).into(),
+            ))
+        }
+    };
+    let results: Vec<Option<i64>> = ca
+        .phys
+        .iter()
+        .map(|opt: Option<i64>| {
+            opt.and_then(|t_us| {
+                let dt = match chrono::Utc.timestamp_micros(t_us) {
+                    chrono::LocalResult::Single(d) => d,
+                    _ => return None,
+                };
+                let ndt = dt.naive_utc();
+                let (y, mo, d, h, min, s) = (
+                    ndt.year(),
+                    ndt.month(),
+                    ndt.day(),
+                    ndt.hour(),
+                    ndt.minute(),
+                    ndt.second(),
+                );
+                let (tr_y, tr_mo, tr_d, tr_h, tr_min, tr_s) = match truncate_by {
+                    0 => (y, 1, 1, 0, 0, 0),
+                    1 => (y, mo, 1, 0, 0, 0),
+                    2 => {
+                        let w = ndt.date().week(chrono::Weekday::Mon);
+                        let start = w.first_day();
+                        (start.year(), start.month(), start.day(), 0, 0, 0)
+                    }
+                    3 => (y, mo, d, 0, 0, 0),
+                    4 => (y, mo, d, h, 0, 0),
+                    5 => (y, mo, d, h, min, 0),
+                    6 => (y, mo, d, h, min, s),
+                    _ => (y, mo, d, h, min, s),
+                };
+                let truncated = NaiveDateTime::parse_from_str(
+                    &format!(
+                        "{:04}-{:02}-{:02} {:02}:{:02}:{:02}",
+                        tr_y, tr_mo, tr_d, tr_h, tr_min, tr_s
+                    ),
+                    "%Y-%m-%d %H:%M:%S",
+                )
+                .ok()?;
+                Some(chrono::Utc.from_utc_datetime(&truncated).timestamp_micros())
+            })
+        })
+        .collect();
+    let chunked = Int64Chunked::from_iter_options(name.as_str().into(), results.into_iter());
+    let out = chunked
+        .into_series()
+        .cast(&DataType::Datetime(TimeUnit::Microseconds, None))?;
+    Ok(Some(Column::new(name, out)))
+}
+
 /// make_date(year, month, day) - three columns to date.
 pub fn apply_make_date(columns: &mut [Column]) -> PolarsResult<Option<Column>> {
     use chrono::NaiveDate;

--- a/python/sparkless/sparkless/sql/functions.py
+++ b/python/sparkless/sparkless/sql/functions.py
@@ -1596,7 +1596,9 @@ def _window_spec_to_partition_order(window, require_order=True):
     partition_by = list(getattr(window, "_partition_by", []) or [])
     order_keys = list(getattr(window, "_order_by", []) or [])
     if not order_keys and require_order:
-        raise PySparkValueError("window function .over() requires Window.orderBy(...)")
+        raise ValueError(
+            "At least one column must be specified for orderBy(...) in window function .over()"
+        )
     partition_names = [
         _col_name(c) if not isinstance(c, str) else c for c in partition_by
     ]


### PR DESCRIPTION
## Fixes
- **#1056** (partial): Window functions — date_trunc and empty orderBy

## Changes

### date_trunc
- **Format mapping:** PySpark uses `year`, `month`, `day`, `hour`, etc. Polars `dt.truncate()` expects duration strings (`1y`, `1mo`, `1d`, `1h`). Added `pyspark_trunc_format_to_polars_duration()` in `column.rs` and use it in `Column::trunc()` so `date_trunc("month", col("d"))` works (fixes "expected leading integer in the duration string found 'm'").
- **String/date columns:** `createDataFrame` can produce string columns for datetimes. Added `apply_date_trunc` UDF in `udfs/rest.rs` to coerce to datetime then truncate by unit (chrono), and route `trunc()` through this UDF so all column types are supported.

### Window.orderBy()
- **Empty orderBy:** When `.over()` is used with `Window.orderBy([])`, raise `ValueError("At least one column must be specified for orderBy(...) in window function .over()")` so parity test `test_window_orderby_list_empty_list_error` passes.

## Tests
- `test_date_trunc_robust.py`, `test_date_trunc_polars_backend.py`: all pass.
- `test_issue_335_window_orderby_list.py::test_window_orderby_list_empty_list_error`: pass.
- Remaining failures in #1056 (rowsBetween/rangeBetween frame, lag/lead ordering, row_number over desc, withField+window) are out of scope for this PR.