### PR TITLE
fix(#1055): struct field dot notation in select (plan + select_items)

### DIFF
--- a/crates/robin-sparkless-polars/src/dataframe/transformations.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/transformations.rs
@@ -225,13 +225,12 @@ pub fn select_items(
     for item in items {
         match item {
             SelectItem::ColumnName(name) => {
-                // Dot notation (e.g. "Person.name") is struct field access; output column name is last segment (PySpark parity: row["name"]).
+                // #1055: Dot notation (e.g. "StructValue.E1") is struct field access. Preserve full name as output (PySpark: col("StructValue.E1") yields column "StructValue.E1").
                 if name.contains('.') {
                     let e = col(name);
                     let resolved = df.resolve_expr_column_names(e)?;
                     let coerced = df.coerce_string_numeric_comparisons(resolved)?;
-                    let last_part = name.split('.').next_back().unwrap_or(name);
-                    exprs.push(coerced.alias(last_part));
+                    exprs.push(coerced.alias(name));
                 } else {
                     let resolved = df.resolve_column_name(name)?;
                     exprs.push(col(resolved));

--- a/crates/robin-sparkless-polars/src/plan/mod.rs
+++ b/crates/robin-sparkless-polars/src/plan/mod.rs
@@ -377,11 +377,13 @@ fn apply_op(
                         let alias = alias_override.unwrap_or(s);
                         exprs.push(resolved.alias(alias));
                     } else {
+                        // #1055: col("StructValue.E1") / dot notation – resolve as expression so struct field access works.
+                        let col_expr = polars::prelude::col::<&str>(&*expr_str);
                         let resolved = df
-                            .resolve_column_name(expr_str)
+                            .resolve_expr_column_names(col_expr)
                             .map_err(PlanError::Session)?;
-                        // #1014, #1022: Preserve requested column name as output (e.g. "NaMe") so row keys match.
-                        exprs.push(polars::prelude::col(resolved).alias(name_str.as_str()));
+                        // #1014, #1022: Preserve requested column name as output (e.g. "NaMe", "StructValue.E1") so row keys match.
+                        exprs.push(resolved.alias(name_str.as_str()));
                     }
                 }
                 df.select_exprs(exprs).map_err(PlanError::Session)


### PR DESCRIPTION
## Fixes
- **#1055** (partial): Struct / withField / getField — struct field dot notation in select

## Changes

### Plan select
- When a select item is a **string** or `{col/column/name: "StructValue.E1"}`, the plan interpreter previously called `resolve_column_name("StructValue.E1")`, which fails because only top-level columns `["Name", "StructValue"]` exist.
- Now we build `col(expr_str)` and call `resolve_expr_column_names` so `"StructValue.E1"` is resolved as struct field access (col → struct_().field_by_name("E1")).

### select_items (direct API)
- For `SelectItem::ColumnName(name)` when `name` contains `.` (e.g. `"StructValue.E1"`), the output column name is now the **full** dotted name (PySpark: `col("StructValue.E1")` without alias yields column `"StructValue.E1"`).

## Tests
- 79 tests pass in the issue #1055–related suites (struct alias, withfield, getfield, column subscript).
- Remaining failures (27) are due to:
  - **withField**: schema reported as StringType after adding a new field; null struct should stay None (PySpark); withField + window (tracked in #1064).
  - **getField**: `getField(int)` for array index (TypeError: int not PyString); nested array / createDataFrame support.
  - **Column subscript / nested struct**: `field not found`, non-string key, coalesce behavior.

**Action:** This PR addresses the "cannot resolve StructValue.E1" / dot-notation path for **select**. Follow-up work for withField schema/null, getField(int), and nested struct is left for #1055 or a dedicated issue.