### PR TITLE
Fix window frame ntile and last() parity (fix #1064)

### DIFF
--- a/crates/robin-sparkless-polars/src/column.rs
+++ b/crates/robin-sparkless-polars/src/column.rs
@@ -2590,10 +2590,12 @@ impl Column {
         let n_expr = lit(n as f64);
         let rank_f = rank_expr.cast(DataType::Float64);
         let count_f = count_expr.cast(DataType::Float64);
-        // Avoid division by zero when partition is empty: use bucket 1
-        let bucket = when(count_f.clone().eq(lit(0.0)))
-            .then(lit(1.0))
-            .otherwise((rank_f * n_expr / count_f).ceil());
+        // Avoid division by zero when partition is empty: use bucket 1.
+        // PySpark parity: ntile(n) uses floor((rank - 1) * n / count) + 1 so that
+        // the first buckets get the extra rows when count % n != 0.
+        let bucket = when(count_f.clone().eq(lit(0.0))).then(lit(1.0)).otherwise(
+            ((rank_f.clone() - lit(1.0)) * n_expr.clone() / count_f.clone()).floor() + lit(1.0),
+        );
         let clamped = bucket.clip(lit(1.0), lit(n as f64));
         Self::from_expr(clamped.cast(DataType::Int32), None)
     }

--- a/python/sparkless/sparkless/sql/functions.py
+++ b/python/sparkless/sparkless/sql/functions.py
@@ -377,7 +377,16 @@ def first(col_or_name: ColumnOrName, ignorenulls: bool = False) -> _ColumnType:
     return _col_result(_native_fn("first")(_as_col(col_or_name), ignorenulls))
 
 
-last = _ni("last")
+def last(col_or_name: ColumnOrName, ignorenulls: bool = False) -> _ColumnType:
+    """Last value aggregate/window function (PySpark last).
+
+    GroupBy: use in df.groupBy().agg(F.last("col")) – implemented via last_value semantics.
+    Window: use with .over(Window.partitionBy(...).orderBy(...)) and optional frame; when
+    orderBy is present, default RANGE UNBOUNDED PRECEDING..CURRENT ROW makes last() == current row.
+    """
+    # For window usage, reuse last_value() expression helper so
+    # F.last(\"salary\").over(window_spec) matches last_value semantics.
+    return _col_result(last_value(col_or_name))
 
 
 def collect_list(col_or_name: ColumnOrName) -> _ColumnType:


### PR DESCRIPTION
## Summary

- Implement `F.last()` as a real aggregate/window function by delegating to the existing `last_value` window expression, so `F.last(col).over(Window...)` and `groupBy().agg(F.last(...))` behave like PySpark.
- Fix `ntile` window semantics in the Rust backend to use `floor((rank - 1) * n / count) + 1`, matching PySpark’s bucket distribution (first buckets get extra rows when count % n != 0).
- Confirmed that all window tests from [issue #1064](https://github.com/eddiethedean/robin-sparkless/issues/1064) now pass, including:
  - `tests/python/test_issue_377_window_rows_range_between.py`
  - `tests/upstream_sparkless/tests/test_issue_335_window_orderby_list.py`
  - `tests/upstream_sparkless/tests/test_issue_398_withfield_window.py`
  - `tests/upstream_sparkless/tests/parity/dataframe/test_window.py` (ntile/last_value parity)

## Test plan

- .venv/bin/python -m pytest -v tests/python/test_issue_377_window_rows_range_between.py
- .venv/bin/python -m pytest -v tests/upstream_sparkless/tests/test_issue_335_window_orderby_list.py
- .venv/bin/python -m pytest -v tests/upstream_sparkless/tests/test_issue_398_withfield_window.py
- .venv/bin/python -m pytest -v tests/upstream_sparkless/tests/parity/dataframe/test_window.py
