### PR TITLE
Make withColumnRenamed non-existent columns a no-op (fix #1074)

### DIFF
--- a/crates/robin-sparkless-polars/src/dataframe/transformations.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/transformations.rs
@@ -923,11 +923,17 @@ pub fn with_column_renamed(
     new_name: &str,
     case_sensitive: bool,
 ) -> Result<DataFrame, PolarsError> {
-    let resolved = df.resolve_column_name(old_name)?;
-    let lf = df
-        .lazy_frame()
-        .rename([resolved.as_str()], [new_name], true);
-    Ok(super::DataFrame::from_lazy_with_options(lf, case_sensitive))
+    match df.resolve_column_name(old_name) {
+        Ok(resolved) => {
+            let lf = df
+                .lazy_frame()
+                .rename([resolved.as_str()], [new_name], true);
+            Ok(super::DataFrame::from_lazy_with_options(lf, case_sensitive))
+        }
+        // PySpark parity: renaming a non-existent column is a no-op.
+        Err(PolarsError::ColumnNotFound(_)) => Ok(df.clone()),
+        Err(e) => Err(e),
+    }
 }
 
 /// Replace values in a column: where column == old_value, use new_value. PySpark replace (single column).
@@ -1627,14 +1633,25 @@ pub fn with_columns_renamed(
     renames: &[(String, String)],
     case_sensitive: bool,
 ) -> Result<DataFrame, PolarsError> {
-    let mut mapping = Vec::new();
-    for (old_name, new_name) in renames {
-        let resolved = df.resolve_column_name(old_name)?;
-        mapping.push((resolved, new_name.clone()));
-    }
+    // Apply renames one by one; skip columns that do not exist (no-op for missing),
+    // matching PySpark withColumnsRenamed behavior for non-existent columns.
     let mut lf = df.lazy_frame();
-    for (old, new) in mapping {
-        lf = lf.rename([old.as_str()], [new.as_str()], true);
+    let mut applied_any = false;
+    for (old_name, new_name) in renames {
+        match df.resolve_column_name(old_name) {
+            Ok(resolved) => {
+                lf = lf.rename([resolved.as_str()], [new_name.as_str()], true);
+                applied_any = true;
+            }
+            Err(PolarsError::ColumnNotFound(_)) => {
+                // Non-existent column: leave DataFrame unchanged for this entry.
+                continue;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    if !applied_any {
+        return Ok(df.clone());
     }
     Ok(super::DataFrame::from_lazy_with_options(lf, case_sensitive))
 }

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -3236,9 +3236,11 @@ impl PyDataFrame {
         for (i, item) in flat.iter().enumerate() {
             let asc = asc_vec.get(i).copied().unwrap_or(true);
             if let Ok(ps) = item.downcast::<PySortOrder>() {
+                // Explicit SortOrder (e.g. col("x").desc()), use as-is.
                 sort_orders.push(ps.borrow().inner.clone());
                 all_strings = false;
             } else if let Ok(pc) = item.downcast::<PyColumn>() {
+                // Bare Column: apply ascending/descending from asc_vec.
                 let so = if asc {
                     pc.borrow().inner.asc_nulls_last()
                 } else {
@@ -3246,10 +3248,26 @@ impl PyDataFrame {
                 };
                 sort_orders.push(so);
                 all_strings = false;
+            } else if let (Ok(name_attr), Ok(asc_attr)) =
+                (item.getattr("name"), item.getattr("ascending"))
+            {
+                // Sort-key object from sparkless.sql.functions.desc/asc: has .name and .ascending.
+                let name: String = name_attr.extract()?;
+                let ascending_flag: bool = asc_attr.extract()?;
+                let col = Column::new(name.clone());
+                let so = if ascending_flag {
+                    functions::asc(&col)
+                } else {
+                    functions::desc(&col)
+                };
+                sort_orders.push(so);
+                all_strings = false;
             } else if let Ok(s) = item.extract::<String>() {
+                // Plain column name string.
                 sort_orders.push(asc_from_name(&s));
                 names_only.push(s);
             } else {
+                // Fallback: give up on mixed types; try pure string path below.
                 sort_orders.clear();
                 names_only.clear();
                 all_strings = false;


### PR DESCRIPTION
## Summary

- Update the Rust DataFrame transformations so `withColumnRenamed` and `withColumnsRenamed` **treat non-existent columns as a no-op**, matching PySpark: missing columns are silently skipped instead of raising a `SparklessError`.
- Extend the Python `DataFrame.orderBy` implementation to accept sort-key objects from `sparkless.sql.functions.desc/asc`, so patterns like `df.orderBy(F.desc("salary"))` work as they do in PySpark.
- Together these changes fix all the `withColumnRenamed` / `withColumnsRenamed` tests in [issue #1074](https://github.com/eddiethedean/robin-sparkless/issues/1074).

## Test plan

- .venv/bin/python -m pytest -v tests/upstream_sparkless/tests/test_issue_295_withColumnRenamed_nonexistent.py
