### PR TITLE
fix: struct field dot notation col("struct_col.field") and select("struct_col.field") (#1076)

### DIFF
--- a/crates/robin-sparkless-polars/src/dataframe/mod.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/mod.rs
@@ -108,6 +108,17 @@ impl DataFrame {
         }
     }
 
+    /// Create a DataFrame from an eager Polars DataFrame without converting to Lazy.
+    /// Used by create_dataframe_from_rows so schema (including struct types) is immediately
+    /// available for dotted column resolution (e.g. select("StructValue.e1")) (#1076).
+    pub(crate) fn from_eager_with_options(df: PlDataFrame, case_sensitive: bool) -> Self {
+        DataFrame {
+            inner: DataFrameInner::Eager(Arc::new(df)),
+            case_sensitive,
+            alias: None,
+        }
+    }
+
     /// Create a DataFrame from a LazyFrame (no materialization).
     pub fn from_lazy(lf: LazyFrame) -> Self {
         DataFrame {

--- a/crates/robin-sparkless-polars/src/dataframe/transformations.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/transformations.rs
@@ -290,13 +290,15 @@ pub fn select_items(
     for item in items {
         match item {
             SelectItem::ColumnName(name) => {
-                // #1055: Dot notation (e.g. "StructValue.E1") is struct field access. Preserve full name as output (PySpark: col("StructValue.E1") yields column "StructValue.E1").
+                // #1055, #1076: Dot notation (e.g. "StructValue.e1") is struct field access.
+                // PySpark: select("StructValue.e1") yields output column "e1" (last segment), not full dotted name.
                 if name.contains('.') {
                     let e = col(name);
                     let resolved = df.resolve_expr_column_names(e)?;
                     let coerced = df.coerce_string_numeric_comparisons(resolved)?;
                     let safe = struct_field_safe_alias(name);
-                    rename_after.push((safe.clone(), name.to_string()));
+                    let last_segment = name.split('.').next_back().unwrap_or(name);
+                    rename_after.push((safe.clone(), last_segment.to_string()));
                     exprs.push(coerced.alias(safe));
                 } else {
                     let resolved = df.resolve_column_name(name)?;
@@ -325,7 +327,8 @@ pub fn select_items(
                 let coerced = df.coerce_string_numeric_comparisons(resolved)?;
                 if let Some(name) = name_for_alias {
                     let safe = struct_field_safe_alias(&name);
-                    rename_after.push((safe.clone(), name));
+                    let last_segment = name.split('.').next_back().unwrap_or(&name).to_string();
+                    rename_after.push((safe.clone(), last_segment));
                     exprs.push(coerced.alias(safe));
                 } else {
                     exprs.push(coerced);

--- a/crates/robin-sparkless-polars/src/session/mod.rs
+++ b/crates/robin-sparkless-polars/src/session/mod.rs
@@ -1989,7 +1989,7 @@ impl SparkSession {
 
         if schema.is_empty() {
             if rows.is_empty() {
-                return Ok(DataFrame::from_polars_with_options(
+                return Ok(DataFrame::from_eager_with_options(
                     PlDataFrame::new(0, vec![])?,
                     self.is_case_sensitive(),
                 ));
@@ -2440,7 +2440,8 @@ impl SparkSession {
         }
 
         let pl_df = PlDataFrame::new_infer_height(cols.iter().map(|s| s.clone().into()).collect())?;
-        Ok(DataFrame::from_polars_with_options(
+        // Keep eager so schema (including struct types) is available for dotted select (#1076).
+        Ok(DataFrame::from_eager_with_options(
             pl_df,
             self.is_case_sensitive(),
         ))


### PR DESCRIPTION
## Summary
Fixes #1076: PySpark-style `col("StructValue.e1")` and `select("StructValue.e1")` when the column is a struct with field `e1`. Robin-sparkless previously failed with `KeyError: 'e1'` when collecting.

## Changes
1. **Output column name**: For struct field select, use the **last segment** as the output column name (e.g. `"e1"` for `select("StructValue.e1")`), matching PySpark. Previously the full dotted name was used.
2. **Schema availability**: Keep DataFrames created from `create_dataframe_from_rows` as **Eager** so the schema (including struct types) is available for dotted column resolution. Previously they were converted to Lazy and `collect_schema()` did not expose struct dtypes in the resolution path.

## Tests
All three tests referenced in the issue now pass:
- `tests/python/test_issue_397_struct_field_dot_notation.py::test_select_struct_field_dot_notation_string`
- `tests/python/test_issue_397_struct_field_dot_notation.py::test_select_struct_field_dot_notation_col`
- `tests/python/test_issue_397_struct_field_dot_notation.py::test_select_struct_field_multiple_dots`