### PR TITLE
fix(datetime): partial fix for #1084 – filters, validation, hour/minute/second, string comparison

### DIFF
--- a/crates/robin-sparkless-polars/src/dataframe/mod.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/mod.rs
@@ -638,6 +638,28 @@ impl DataFrame {
                             });
                         }
                     }
+                    // #1084: Fallback: cast string literal to timestamp so datetime col vs string
+                    // literal works when schema is lazy or unknown (e.g. Python datetime.isoformat()).
+                    use polars::datatypes::TimeUnit;
+                    let dt = DataType::Datetime(TimeUnit::Microseconds, None);
+                    let (left_ty, right_ty) = if left_is_col {
+                        (dt.clone(), DataType::String)
+                    } else {
+                        (DataType::String, dt)
+                    };
+                    if let Ok((new_l, new_r)) = coerce_for_pyspark_comparison(
+                        (*left).clone(),
+                        (*right).clone(),
+                        &left_ty,
+                        &right_ty,
+                        &op,
+                    ) {
+                        return Ok(Expr::BinaryExpr {
+                            left: Arc::new(new_l),
+                            op,
+                            right: Arc::new(new_r),
+                        });
+                    }
                     return Ok(Expr::BinaryExpr { left, op, right });
                 } else {
                     // Leave other comparison forms (col-col, lit-lit, non-numeric) unchanged.

--- a/crates/robin-sparkless-polars/src/plan/expr.rs
+++ b/crates/robin-sparkless-polars/src/plan/expr.rs
@@ -111,9 +111,23 @@ pub fn expr_from_value(v: &Value) -> Result<Expr, PlanExprError> {
                         "le" => CompareOp::LtEq,
                         _ => unreachable!(),
                     };
+                    // #1084: When one side is a column (no type at plan time) and the other is a
+                    // string literal, skip coercion here so the DataFrame-level coerce_string_numeric_comparisons
+                    // (in filter()) can cast the string literal to date/datetime using the actual schema.
                     let (lt, rt) = match (&l_ty, &r_ty) {
                         (Some(lt), Some(rt)) => (lt.clone(), rt.clone()),
                         (Some(lt), None) => (lt.clone(), DataType::String),
+                        (None, Some(rt)) if *rt == DataType::String => {
+                            return Ok(match op {
+                                "eq" => l.eq(r),
+                                "ne" => l.neq(r),
+                                "gt" => l.gt(r),
+                                "ge" => l.gt_eq(r),
+                                "lt" => l.lt(r),
+                                "le" => l.lt_eq(r),
+                                _ => unreachable!(),
+                            });
+                        }
                         (None, Some(rt)) => (DataType::String, rt.clone()),
                         (None, None) => {
                             // No type info; skip coercion (may error at runtime).

--- a/crates/robin-sparkless-polars/src/session/mod.rs
+++ b/crates/robin-sparkless-polars/src/session/mod.rs
@@ -1706,7 +1706,14 @@ impl SparkSession {
                 }
             }
             JsonValue::String(s) => {
-                if chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d").is_ok() {
+                // #1084: Only infer date when string strictly matches YYYY-MM-DD (e.g. 10 chars,
+                // two-digit month/day) so "2024-01-2" stays string and comparisons remain lexicographic.
+                let s = s.trim();
+                if s.len() == 10
+                    && s.as_bytes().get(4) == Some(&b'-')
+                    && s.as_bytes().get(7) == Some(&b'-')
+                    && chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d").is_ok()
+                {
                     Some("date".to_string())
                 } else if chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.f").is_ok()
                     || chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S").is_ok()
@@ -1802,9 +1809,11 @@ impl SparkSession {
         Some(format!("struct<{}>", inner))
     }
 
-    /// Infer schema (name, dtype_str) from JSON rows by scanning the first non-null value per column.
+    /// Infer schema (name, dtype_str) from JSON rows by scanning values per column.
     /// Used by createDataFrame(data, schema=None) when schema is omitted or only column names given.
-    /// When the first non-null value is a JSON object, infers struct<k1:string,k2:string,...> (PR13 / struct parity).
+    /// When the first non-null value is a JSON object, infers struct (PR13 / struct parity).
+    /// #1084: If any value in a column infers as string (e.g. "2024-01-2" with single-digit day),
+    /// use string for the column so date-like strings stay string and comparisons remain lexicographic.
     pub fn infer_schema_from_json_rows(
         rows: &[Vec<JsonValue>],
         names: &[String],
@@ -1817,6 +1826,8 @@ impl SparkSession {
             .map(|n| (n.clone(), "string".to_string()))
             .collect();
         for (col_idx, (_, dtype_str)) in schema.iter_mut().enumerate() {
+            let mut first_non_string: Option<String> = None;
+            let mut has_string = false;
             for row in rows {
                 let v = row.get(col_idx).unwrap_or(&JsonValue::Null);
                 if let JsonValue::Object(_) = v {
@@ -1826,9 +1837,17 @@ impl SparkSession {
                     break;
                 }
                 if let Some(dtype) = Self::infer_dtype_from_json_value(v) {
-                    *dtype_str = dtype;
-                    break;
+                    if dtype == "string" {
+                        has_string = true;
+                        break;
+                    }
+                    first_non_string.get_or_insert(dtype);
                 }
+            }
+            if has_string {
+                *dtype_str = "string".to_string();
+            } else if let Some(d) = first_non_string {
+                *dtype_str = d;
             }
         }
         schema

--- a/crates/robin-sparkless-polars/src/type_coercion.rs
+++ b/crates/robin-sparkless-polars/src/type_coercion.rs
@@ -267,7 +267,14 @@ pub fn coerce_for_pyspark_comparison(
     }
 
     // Date/datetime vs string: cast string side to the temporal type (PySpark implicit cast).
+    // #1084: For literals use direct cast so filter(col("dt") >= "2024-01-12 00:00:00") works
+    // when the plan sends string literals; try_cast uses map() which may not handle literals.
     fn wrap_try_to_temporal(expr: Expr, target: &DataType) -> Result<Expr, PolarsError> {
+        if matches!(target, DataType::Date | DataType::Datetime(_, _)) {
+            if matches!(&expr, Expr::Literal(_)) {
+                return Ok(expr.cast(target.clone()));
+            }
+        }
         let col = Column::from_expr(expr, None);
         let type_name = match target {
             DataType::Date => "date",

--- a/crates/robin-sparkless-polars/src/udfs/rest.rs
+++ b/crates/robin-sparkless-polars/src/udfs/rest.rs
@@ -3919,23 +3919,85 @@ pub fn apply_to_timestamp_format(
     }
 }
 
-/// Coerce series to Datetime(Microseconds) for date-part extraction (#403). String parsed as "%Y-%m-%d %H:%M:%S".
+/// Parse a single timestamp string with multiple formats (#1084). Returns micros since epoch (UTC).
+pub(crate) fn parse_timestamp_string_flexible(s: &str) -> Option<i64> {
+    use chrono::{NaiveDate, NaiveDateTime};
+    let s = s.trim();
+    // Strip trailing timezone for naive parse (e.g. +0000, -0500, Z)
+    let s_no_tz = s
+        .strip_suffix('Z')
+        .or_else(|| s.strip_suffix("z"))
+        .unwrap_or(s);
+    let s_no_tz = if s_no_tz.len() >= 5 {
+        let rest = &s_no_tz[s_no_tz.len() - 5..];
+        if (rest.starts_with('+') || rest.starts_with('-'))
+            && rest[1..].chars().all(|c| c.is_ascii_digit())
+        {
+            &s_no_tz[..s_no_tz.len() - 5]
+        } else if s_no_tz.len() >= 6 {
+            let rest = &s_no_tz[s_no_tz.len() - 6..];
+            if (rest.starts_with('+') || rest.starts_with('-'))
+                && !rest.contains(':')
+                && rest[1..].chars().all(|c| c.is_ascii_digit())
+            {
+                &s_no_tz[..s_no_tz.len() - 6]
+            } else {
+                s_no_tz
+            }
+        } else {
+            s_no_tz
+        }
+    } else {
+        s_no_tz
+    };
+    // Try formats with fractional seconds by parsing the part before '.' and optional subsecs
+    if let Some(dot) = s_no_tz.find('.') {
+        let base = &s_no_tz[..dot];
+        let subsec = &s_no_tz[dot + 1..];
+        let subsec_digits: String = subsec.chars().take_while(|c| c.is_ascii_digit()).collect();
+        if let Ok(ndt) = NaiveDateTime::parse_from_str(base, "%Y-%m-%dT%H:%M:%S")
+            .or_else(|_| NaiveDateTime::parse_from_str(base, "%Y-%m-%d %H:%M:%S"))
+        {
+            let micros = if subsec_digits.is_empty() {
+                0_i64
+            } else {
+                let frac = subsec_digits.parse::<u32>().unwrap_or(0) as i64;
+                let digits = subsec_digits.len();
+                (if digits <= 6 {
+                    frac * 10_i64.pow((6 - digits) as u32)
+                } else {
+                    frac / 10_i64.pow((digits - 6) as u32)
+                })
+                .min(999_999)
+            };
+            let ndt = ndt + chrono::TimeDelta::microseconds(micros);
+            return Some(ndt.and_utc().timestamp_micros());
+        }
+    }
+    const FORMATS: &[&str] = &["%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M:%S", "%Y-%m-%d"];
+    for fmt in FORMATS {
+        if let Ok(ndt) = NaiveDateTime::parse_from_str(s_no_tz, fmt) {
+            return Some(ndt.and_utc().timestamp_micros());
+        }
+    }
+    if let Ok(d) = NaiveDate::parse_from_str(s_no_tz, "%Y-%m-%d") {
+        let ndt = d.and_hms_opt(0, 0, 0).unwrap();
+        return Some(ndt.and_utc().timestamp_micros());
+    }
+    None
+}
+
+/// Coerce series to Datetime(Microseconds) for date-part extraction (#403, #1084).
+/// String parsed with multiple formats (ISO with T, space, timezone stripped, date-only).
 fn series_to_datetime_micros(series: &Series) -> PolarsResult<Series> {
-    use chrono::NaiveDateTime;
     use polars::datatypes::TimeUnit;
     if series.dtype() == &DataType::String {
         let name = series.name().as_str().into();
         let ca = series.str().map_err(|e| compute_err("date on string", e))?;
-        const FMT: &str = "%Y-%m-%d %H:%M:%S";
         let out = Int64Chunked::from_iter_options(
             name,
-            ca.into_iter().map(|opt_s| {
-                opt_s.and_then(|s| {
-                    NaiveDateTime::parse_from_str(s.trim(), FMT)
-                        .ok()
-                        .map(|ndt| ndt.and_utc().timestamp_micros())
-                })
-            }),
+            ca.into_iter()
+                .map(|opt_s| opt_s.and_then(parse_timestamp_string_flexible)),
         );
         out.into_series()
             .cast(&DataType::Datetime(TimeUnit::Microseconds, None))
@@ -5456,4 +5518,19 @@ pub fn apply_to_timestamp_ntz_format(
         .cast(&DataType::Datetime(TimeUnit::Microseconds, None))?;
     let _ = strict;
     Ok(Some(Column::new(name, out_series)))
+}
+
+#[cfg(test)]
+mod tests_parse_timestamp {
+    use super::parse_timestamp_string_flexible;
+
+    #[test]
+    fn test_parse_iso_with_tz() {
+        let s = "2023-02-07T04:00:01.730+0000";
+        let micros = parse_timestamp_string_flexible(s);
+        assert!(micros.is_some(), "expected Some for {s:?}");
+        let t = micros.unwrap();
+        let hour = (t / 1_000_000 / 3600) % 24;
+        assert_eq!(hour, 4, "hour should be 4 for {s:?}");
+    }
 }


### PR DESCRIPTION
## Summary
Addresses [issue #1084](https://github.com/eddiethedean/robin-sparkless/issues/1084) (Datetime/timestamp: filters, validation, hour/minute/second, string comparison).

## Changes
- **Schema inference**: If any value in a column infers as string (e.g. `2024-01-2` with single-digit day), infer the column as string so date-like strings stay string and comparisons remain lexicographic. Fixes `test_string_values_that_look_like_dates_but_both_sides_string`.
- **Hour/minute/second from string timestamps**: Add `parse_timestamp_string_flexible` and use it in `series_to_datetime_micros` so `apply_hour`/`apply_minute`/`apply_second` work on string timestamps (e.g. `2023-02-07T04:00:01.730+0000`). Fixes 6/7 `test_issue_294` tests.
- **Plan expr**: When one side is a column (no type at plan time) and the other is a string literal, skip plan-level coercion so the DataFrame-level `coerce_string_numeric_comparisons` can cast the string to date/datetime using the actual schema.
- **Type coercion**: For date/datetime vs string literal, use direct cast on literals in `wrap_try_to_temporal` so `filter(col('dt') >= '2024-01-12')` works when the plan sends string literals.

## Tests fixed (7 of 12 from issue)
- `test_string_values_that_look_like_dates_but_both_sides_string` ✅
- 6× `test_issue_294_hour_minute_second_string_timestamps` ✅ (all except `test_hour_minute_second_with_filter`)

## Remaining failures (5)
- `test_to_timestamp_with_filter_isnotnull`, `test_to_timestamp_with_multiple_filters`: filter after `withColumn(to_timestamp)` returns 0 rows.
- `test_validation_with_datetime_comparison`: plan resolution path still compares datetime to string before backend coercion.
- `test_date_column_vs_string_column_filter`: result has `date_string` as date not string.
- `test_hour_minute_second_with_filter`: `F.col('hour') >= 12` returns 0 rows.

These are left for follow-up work.

Closes #1084 (partial).