### PR TITLE
Fix #1102: Validation with datetime comparison (plan resolution)

### DIFF
--- a/crates/robin-sparkless-polars/src/dataframe/mod.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/mod.rs
@@ -361,6 +361,20 @@ impl DataFrame {
             Expr::Alias(inner, name) => (inner.as_ref().clone(), Some(name.clone())),
             _ => (expr.clone(), None),
         };
+        // #1102: Recursively coerce both sides of And/Or so (col("dt") >= "a") & (col("dt") <= "b")
+        // gets datetime-vs-string coercion in each comparison (plan sends string literals).
+        let expr_to_coerce = match &expr_to_coerce {
+            Expr::BinaryExpr { left, op, right } if matches!(op, Operator::And | Operator::Or) => {
+                let left_c = self.coerce_string_numeric_comparisons((**left).clone())?;
+                let right_c = self.coerce_string_numeric_comparisons((**right).clone())?;
+                Expr::BinaryExpr {
+                    left: Arc::new(left_c),
+                    op: *op,
+                    right: Arc::new(right_c),
+                }
+            }
+            _ => expr_to_coerce,
+        };
         fn wrap_expr_with_alias(
             expr: Expr,
             alias_name: Option<&polars::prelude::PlSmallStr>,

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -4318,6 +4318,17 @@ fn py_any_to_column(other: &Bound<'_, PyAny>) -> PyResult<Column> {
             return Ok(robin_sparkless::functions::lit_str(&format!("{:?}", vals)));
         }
     }
+    // datetime.date / datetime.datetime: convert to ISO string so plan gets string literal;
+    // backend coercion then casts to timestamp for col-vs-string comparison (#1102).
+    if let Ok(isoformat) = other.getattr("isoformat") {
+        if isoformat.is_callable() {
+            if let Ok(s) = isoformat.call0() {
+                if let Ok(iso) = s.extract::<String>() {
+                    return Ok(robin_sparkless::functions::lit_str(&iso));
+                }
+            }
+        }
+    }
     // Best effort: treat as string
     if let Ok(s) = other.str() {
         return Ok(robin_sparkless::functions::lit_str(&s.to_string()));


### PR DESCRIPTION
## Summary
Fixes https://github.com/eddiethedean/robin-sparkless/issues/1102

`filter((col("txn_date") >= start_date) & (col("txn_date") <= end_date))` with Python `datetime` `start_date`/`end_date` was failing with:
- **Python**: `TypeError: comparison rhs must be Column, int, float, str, bool, or None` (datetime not accepted)
- **Backend (when datetime was passed as string)**: `SparklessError: cannot compare 'date/datetime/time' to a string value` during plan resolution because coercion was not applied inside And/Or expressions.

## Changes

1. **`crates/robin-sparkless-polars/src/dataframe/mod.rs`**
   - In `coerce_string_numeric_comparisons`, after unwrapping `Alias`, if the expression is a logical `BinaryExpr` (`Operator::And` or `Operator::Or`), recursively coerce both sides. This ensures `(col >= "str") & (col <= "str")` has each comparison coerced (string literal → timestamp when column is datetime).

2. **`python/src/lib.rs`**
   - In `py_any_to_column`, accept `datetime.date` / `datetime.datetime` as comparison RHS by calling `isoformat()` and using `lit_str(iso)`, so the plan receives string literals and the backend coercion can cast them to timestamp.

## Tests
- `tests/upstream_sparkless/tests/test_issue_139_datetime_validation_compatibility.py::TestIssue139DatetimeValidationCompatibility::test_validation_with_datetime_comparison` **PASS**
- All 5 tests in `test_issue_139_datetime_validation_compatibility.py` pass.