### PR TITLE
Fix #1103: date_column_vs_string_column_filter result keeps string column as string

### DIFF
--- a/crates/robin-sparkless-polars/src/session/mod.rs
+++ b/crates/robin-sparkless-polars/src/session/mod.rs
@@ -1705,23 +1705,12 @@ impl SparkSession {
                     Some("double".to_string())
                 }
             }
-            JsonValue::String(s) => {
-                // #1084: Only infer date when string strictly matches YYYY-MM-DD (e.g. 10 chars,
-                // two-digit month/day) so "2024-01-2" stays string and comparisons remain lexicographic.
-                let s = s.trim();
-                if s.len() == 10
-                    && s.as_bytes().get(4) == Some(&b'-')
-                    && s.as_bytes().get(7) == Some(&b'-')
-                    && chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d").is_ok()
-                {
-                    Some("date".to_string())
-                } else if chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.f").is_ok()
-                    || chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S").is_ok()
-                {
-                    Some("timestamp".to_string())
-                } else {
-                    Some("string".to_string())
-                }
+            JsonValue::String(_) => {
+                // #1103: Keep string columns as string in createDataFrame so that e.g.
+                // filter(date_col > string_col) only casts the string in the predicate and the
+                // result row still has the string column as string (PySpark parity). Do not infer
+                // date/timestamp from date-like strings; user can pass explicit schema if needed.
+                Some("string".to_string())
             }
             JsonValue::Array(_) => Some("array".to_string()),
             JsonValue::Object(_) => None, // struct type is inferred in infer_schema_from_json_rows from object keys

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1968,6 +1968,16 @@ fn infer_type_from_py_value(v: &Bound<'_, PyAny>) -> String {
     if v.downcast::<PyBytes>().is_ok() {
         return "binary".to_string();
     }
+    // #1103: Preserve date/timestamp from Python so createDataFrame([{"d": date(2026,1,1), "s": "2025-06-15"}])
+    // infers d as date and s as string; string column stays string in filter result.
+    if let Ok(dt) = v.getattr("isoformat") {
+        if dt.is_callable() {
+            if v.getattr("hour").is_ok() {
+                return "timestamp".to_string();
+            }
+            return "date".to_string();
+        }
+    }
     "string".to_string()
 }
 


### PR DESCRIPTION
## Summary
Fixes https://github.com/eddiethedean/robin-sparkless/issues/1103

`df.filter(F.col("date_timestamp") > F.col("date_string"))` was returning `result[0]["date_string"]` as `datetime.date(2025, 6, 15)` instead of the string `"2025-06-15"`. The string column should remain string in the result; only the predicate should use coercion (cast string to date for comparison).

## Root cause
1. **Schema inference** was inferring `date_string` as `date` from values like `"2025-06-15"` (YYYY-MM-DD), so the column was created as Date and the result row had that type.
2. For **dict rows** without explicit schema, we now infer from **Python types**: `datetime.date` → date, `datetime.datetime` → timestamp, `str` → string, so `date_timestamp` (from `date(2026,1,1)`) is date and `date_string` (from `"2025-06-15"`) stays string.

## Changes

1. **`crates/robin-sparkless-polars/src/session/mod.rs`**
   - In `infer_dtype_from_json_value`, for `JsonValue::String` always return `"string"`. Do not infer date/timestamp from date-like strings so that string columns stay string when schema is refined from JSON rows.

2. **`python/src/lib.rs`**
   - In `infer_type_from_py_value`, detect `datetime.date` and `datetime.datetime` (via `isoformat` + `hour`) and return `"date"` / `"timestamp"` so createDataFrame dict rows get correct types from Python values.

## Tests
- `test_issue_259_datetime_string_comparison::test_date_column_vs_string_column_filter` **PASS** (`result[0]["date_string"] == "2025-06-15"`, `result[0]["date_timestamp"] == date(2026, 1, 1)`)
- All 13 tests in `test_issue_259_datetime_string_comparison.py` pass
- 130 tests in infer schema parity, cast/datetime, and datetime validation compatibility pass