### PR TITLE
Fix filter IN/OR and NOT predicate handling (issue #1112)

### DIFF
--- a/crates/robin-sparkless-polars/src/column.rs
+++ b/crates/robin-sparkless-polars/src/column.rs
@@ -900,6 +900,13 @@ impl Column {
         Self::from_expr(expr, None)
     }
 
+    /// Logical NOT of a boolean expression column (PySpark `~` on boolean predicates).
+    /// Implemented as `expr == false` so it flows through expr_coerce_to_boolean like other comparisons.
+    pub fn logical_not(&self) -> Column {
+        let expr = self.expr().clone().eq(lit(false));
+        Self::from_expr(expr, None)
+    }
+
     /// Parse string to map (PySpark str_to_map). "k1:v1,k2:v2" -> map.
     pub fn str_to_map(&self, pair_delim: &str, key_value_delim: &str) -> Column {
         let pair_delim = pair_delim.to_string();

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -4631,7 +4631,9 @@ impl PyColumn {
 
     fn __invert__(&self) -> PyColumn {
         PyColumn {
-            inner: self.inner.bitwise_not(),
+            // For boolean expressions (e.g. ~(df.a == 20)), behave like logical NOT.
+            // Numeric bitwise NOT is exposed via F.bitwise_not(...) instead.
+            inner: self.inner.logical_not(),
         }
     }
 


### PR DESCRIPTION
Fixes #1112 by adding logical_not on Column and wiring PyColumn.__invert__ to use it; all referenced tests now pass.