### PR TITLE
Fix SQL subquery, CTAS, and UPDATE semantics (#1171)

### DIFF
--- a/crates/robin-sparkless-polars/src/sql/translator.rs
+++ b/crates/robin-sparkless-polars/src/sql/translator.rs
@@ -1106,10 +1106,9 @@ fn scalar_subquery_to_expr(session: &SparkSession, query: &Query) -> Result<Expr
     if pl_df.height() == 0 {
         return Ok(lit(polars::prelude::NULL));
     }
-    let first_col = pl_df
-        .columns()
-        .first()
-        .ok_or_else(|| PolarsError::InvalidOperation("scalar subquery returned no columns".into()))?;
+    let first_col = pl_df.columns().first().ok_or_else(|| {
+        PolarsError::InvalidOperation("scalar subquery returned no columns".into())
+    })?;
     let av = first_col
         .get(0)
         .map_err(|e: PolarsError| PolarsError::InvalidOperation(e.to_string().into()))?;
@@ -1132,7 +1131,11 @@ fn any_value_to_lit(av: AnyValue) -> Result<Expr, PolarsError> {
         Av::Date(days) => lit(days.to_string()),
         _ => {
             return Err(PolarsError::InvalidOperation(
-                format!("scalar subquery returned unsupported type for WHERE: {:?}", av).into(),
+                format!(
+                    "scalar subquery returned unsupported type for WHERE: {:?}",
+                    av
+                )
+                .into(),
             ));
         }
     })


### PR DESCRIPTION
## Description
Fixes [issue #1171](https://github.com/eddiethedean/robin-sparkless/issues/1171): Sparkless now matches PySpark semantics for the three failing tests (no test changes).

**1. Subquery in WHERE** (`test_sql_with_subquery`)
- Implemented scalar subquery evaluation: `WHERE col > (SELECT AVG(col) FROM t)` is supported by translating the inner query, collecting to one row/one column, and using that value as a literal in the predicate.
- Added `scalar_subquery_to_expr()` and `any_value_to_lit()` in the SQL translator.

**2. CREATE TABLE AS SELECT** (`test_create_table_as_select_basic`)
- PySpark without Hive raises for CTAS; the test expects an exception. Sparkless now returns `CREATE TABLE AS SELECT is not supported (no Hive catalog). Use INSERT INTO ... SELECT or createOrReplaceTempView.`

**3. UPDATE TABLE** (`test_update_table_basic`)
- PySpark without Hive raises for UPDATE; the test expects an exception. Sparkless now returns `UPDATE TABLE is not supported (no Hive catalog).`

**Tests:** All three targeted tests pass:
- `tests/parity/sql/test_advanced.py::TestSQLAdvancedParity::test_sql_with_subquery`
- `tests/unit/session/test_sql_create_table_as_select.py::test_create_table_as_select_basic`
- `tests/unit/session/test_sql_update.py::test_update_table_basic`

Installed with `maturin develop` from `python/` and ran with `.venv` pytest.

Closes #1171