### PR TITLE
Fix #1263: withField tests (nested structs, type change, array field)

### DIFF
--- a/crates/robin-sparkless-polars/src/column.rs
+++ b/crates/robin-sparkless-polars/src/column.rs
@@ -2834,11 +2834,14 @@ impl Column {
                 let mut replaced = false;
                 for f in &mut new_fields {
                     if f.name.as_str() == field_name_schema {
-                        // When replacing, keep existing field's dtype so literals don't force String (#1066).
-                        let dtype = if f.dtype.is_known() {
+                        // When replacing, use value's dtype so type changes (e.g. int -> string) and
+                        // new complex types (e.g. array) are reflected in schema (Issue #1263).
+                        let dtype = if known_value_dtype.is_known() {
+                            known_value_dtype.clone()
+                        } else if f.dtype.is_known() {
                             f.dtype.clone()
                         } else {
-                            known_value_dtype.clone()
+                            DataType::String
                         };
                         *f = Field::new(PlSmallStr::from(f.name.as_str()), dtype);
                         replaced = true;

--- a/crates/robin-sparkless-polars/src/dataframe/mod.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/mod.rs
@@ -1115,6 +1115,7 @@ impl DataFrame {
         );
         let schema = StructType::from_polars_schema(&schema_override);
         // Resolve columns by name so order matches plan schema regardless of collected frame order.
+        // When cast fails (e.g. struct with List field vs plan String), use column as-is (Issue #1263).
         let columns_cast: Vec<_> = names
             .iter()
             .enumerate()
@@ -1126,27 +1127,28 @@ impl DataFrame {
                     )
                 })?;
                 let s = &collected.columns()[idx];
-                let dtype = effective_dtypes.get(col_idx).unwrap_or_else(|| s.dtype());
-                if dtype == s.dtype() {
-                    Ok(s.clone())
+                let dtype = effective_dtypes
+                    .get(col_idx)
+                    .unwrap_or_else(|| s.dtype())
+                    .clone();
+                if dtype == *s.dtype() {
+                    Ok((s.clone(), dtype))
                 } else {
-                    s.cast(dtype).map_err(|e| {
-                        PolarsError::ComputeError(
-                            format!("collect_as_json_rows_with_names cast: {e}").into(),
-                        )
-                    })
+                    match s.cast(&dtype) {
+                        Ok(casted) => Ok((casted, dtype)),
+                        Err(_) => Ok((s.clone(), s.dtype().clone())),
+                    }
                 }
             })
-            .collect::<Result<Vec<_>, _>>()?;
+            .collect::<Result<Vec<(polars::prelude::Column, DataType)>, PolarsError>>()?;
         let nrows = collected.height();
         let mut rows = Vec::with_capacity(nrows);
         for i in 0..nrows {
             let mut row = HashMap::with_capacity(names.len());
             for (col_idx, name) in names.iter().enumerate() {
-                let s = columns_cast
+                let (s, dtype) = columns_cast
                     .get(col_idx)
                     .ok_or_else(|| PolarsError::ComputeError("column index out of range".into()))?;
-                let dtype = effective_dtypes.get(col_idx).unwrap_or_else(|| s.dtype());
                 let av = s.get(i)?;
                 let jv = any_value_to_json(&av, dtype);
                 row.insert(name.clone(), jv);

--- a/crates/robin-sparkless-polars/src/udfs/rest.rs
+++ b/crates/robin-sparkless-polars/src/udfs/rest.rs
@@ -4942,6 +4942,26 @@ fn series_set_nulls_where(series: &Series, mask: &BooleanChunked) -> PolarsResul
             }
             series.clone()
         }
+        DataType::Struct(_) => {
+            // Preserve nested structs: mask each field recursively and rebuild (Issue #1263).
+            use polars::chunked_array::StructChunked;
+            let st = series
+                .struct_()
+                .map_err(|e| compute_err("with_field mask struct", e))?;
+            let len = st.len();
+            let fields_series = st.fields_as_series();
+            let masked_fields: Vec<Series> = fields_series
+                .iter()
+                .map(|s| series_set_nulls_where(s, mask).unwrap_or_else(|_| s.clone()))
+                .collect();
+            let out = StructChunked::from_series(name.as_str().into(), len, masked_fields.iter())
+                .map_err(|e| compute_err("with_field rebuild struct", e))?;
+            out.into_series()
+        }
+        DataType::List(_) => {
+            // Preserve list type: do not cast to String; clone so nulls are not masked per-element.
+            series.clone()
+        }
         _ => {
             // Try casting to String so literal/other string-like types get masked (PySpark #1066).
             if let Ok(casted) = series.cast(&DataType::String) {

--- a/tests/unit/dataframe/test_withfield.py
+++ b/tests/unit/dataframe/test_withfield.py
@@ -398,7 +398,6 @@ class TestWithField:
         rows = result_bool.collect()
         assert rows[0]["my_struct"]["bool_field"] is True
 
-    @pytest.mark.skip(reason="Issue #1263: unskip when fixing")
     def test_withfield_nested_struct(self, spark):
         """Test withField on nested struct columns."""
         nested_struct_type = StructType(
@@ -678,7 +677,6 @@ class TestWithField:
         assert rows[1]["my_struct"]["value_1"] == "20"
         assert rows[1]["my_struct"]["id_int"] == 2
 
-    @pytest.mark.skip(reason="Issue #1263: unskip when fixing")
     def test_withfield_replace_with_different_type(self, spark):
         """Test replacing a field with a different data type."""
         schema = StructType(
@@ -768,7 +766,6 @@ class TestWithField:
         assert rows[0]["my_struct"]["value_1"] == 1
         assert rows[0]["my_struct"]["null_field"] is None
 
-    @pytest.mark.skip(reason="Issue #1263: unskip when fixing")
     def test_withfield_with_array_field(self, spark):
         """Test withField adding a field that is an array."""
 
@@ -1108,7 +1105,6 @@ class TestWithField:
         assert struct["field3"] == 3
         assert struct["field4"] == "d"
 
-    @pytest.mark.skip(reason="Issue #1263: unskip when fixing")
     def test_withfield_nested_struct_field_access(self, spark):
         """Test withField using nested struct field access in expression."""
         nested_struct_type = StructType(
@@ -1169,7 +1165,6 @@ class TestWithField:
         assert rows[0]["my_struct"]["computed_from_nested"] == 10  # 5 * 2
         assert rows[1]["my_struct"]["computed_from_nested"] == 30  # 15 * 2
 
-    @pytest.mark.skip(reason="Issue #1263: unskip when fixing")
     def test_withfield_nested_struct_string_expression(self, spark):
         """Test withField using nested struct field in string expression."""
         nested_struct_type = StructType(
@@ -1233,7 +1228,6 @@ class TestWithField:
         combined2 = rows[1]["my_struct"]["combined_string"]
         assert combined2 == "prefix_data" or combined2 == "prefix_"
 
-    @pytest.mark.skip(reason="Issue #1263: unskip when fixing")
     def test_withfield_multiple_nested_structs(self, spark):
         """Test withField with multiple nested structs at same level."""
         nested1_type = StructType([StructField("n1_value", IntegerType(), True)])
@@ -1373,7 +1367,6 @@ class TestWithField:
         )
         assert rows[0]["my_struct"]["from_deep_nest"] == 40  # 4 * 10
 
-    @pytest.mark.skip(reason="Issue #1263: unskip when fixing")
     def test_withfield_nested_struct_with_null(self, spark):
         """Test withField with nested struct containing null values."""
         nested_struct_type = StructType(
@@ -1428,7 +1421,6 @@ class TestWithField:
         # Nested struct should still be None
         assert rows[1]["my_struct"]["nested"] is None
 
-    @pytest.mark.skip(reason="Issue #1263: unskip when fixing")
     def test_withfield_nested_struct_arithmetic(self, spark):
         """Test withField with arithmetic operations on nested struct fields."""
         nested_struct_type = StructType(


### PR DESCRIPTION
Fixes https://github.com/eddiethedean/robin-sparkless/issues/1263

**Changes**
- **Unskip** the 8 tests in `tests/unit/dataframe/test_withfield.py` that were skipped for Issue #1263. No other test changes.
- **Preserve nested structs in withField**: In `series_set_nulls_where`, add `DataType::Struct` and `DataType::List` branches so we no longer cast struct/list to string (which was dropping nested data).
- **Schema callback**: When replacing a field, use the value’s dtype (`known_value_dtype`) so replacing int with string (or adding an array field) is reflected in the plan schema.
- **Collect fallback**: When casting a column to the plan schema fails (e.g. struct with List field vs plan String), use the column as-is and its actual dtype for row serialization so `collect()` still succeeds.

All 8 previously failing tests now pass with `MOCK_SPARK_TEST_BACKEND=sparkless`; full `test_withfield.py` runs 35 passed, 3 skipped (other issues).