### PR TITLE
Fix #1274: Collect String schema semantics – infer numeric, unskip tests

### DIFF
--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -2120,59 +2120,9 @@ fn python_data_and_schema(
             .collect();
         schema = refined;
     }
-    // #1149: PySpark createDataFrame(list_of_dicts, [col names]) infers first column as Long/Double
-    // and later numeric columns as String. Apply only for dict rows; list/tuple rows keep normal inference.
-    // #1267/#357: Only apply when the first column actually inferred as numeric; otherwise keep
-    // first column as string (e.g. dept="A", salary=100 with ["dept","salary"]).
-    if schema_was_inferred
-        && schema_names_only
-        && matches!(row_kind, Some("dict"))
-        && !schema.is_empty()
-    {
-        let inferred: Vec<String> = (0..schema.len())
-            .map(|i| {
-                rows.iter()
-                    .filter_map(|r| r.get(i))
-                    .find(|v| !matches!(v, JsonValue::Null))
-                    .map(infer_type_from_json_value)
-                    .unwrap_or_else(|| "string".to_string())
-            })
-            .collect();
-        let first_inferred_numeric = inferred
-            .first()
-            .map(|t| t.eq_ignore_ascii_case("long") || t.eq_ignore_ascii_case("double"))
-            .unwrap_or(false);
-        let first_is_long = schema.len() == 2
-            && first_inferred_numeric
-            && inferred
-                .get(1)
-                .map(|t| t.eq_ignore_ascii_case("long"))
-                .unwrap_or(false);
-        // Second column in 2-col schema becomes String; in 3+ cols only double becomes String (long stays).
-        let two_cols = schema.len() == 2;
-        schema = schema
-            .into_iter()
-            .enumerate()
-            .map(|(i, (name, _))| {
-                let t = inferred.get(i).map(|s| s.as_str()).unwrap_or("string");
-                let typ = match i {
-                    0 => {
-                        if first_is_long {
-                            "long".to_string()
-                        } else if first_inferred_numeric {
-                            "double".to_string()
-                        } else {
-                            t.to_string()
-                        }
-                    }
-                    _ if t.eq_ignore_ascii_case("double") => "string".to_string(),
-                    _ if two_cols && i == 1 => "string".to_string(),
-                    _ => t.to_string(),
-                };
-                (name, typ)
-            })
-            .collect();
-    }
+    // #1274: Do not force later columns to String for names-only dict rows. Use inferred types
+    // for all columns so collect() returns numeric when data is numeric (PySpark-aligned semantics:
+    // when schema says String, Row returns string; infer numeric so schema is not String).
     Ok((rows, schema, schema_was_inferred))
 }
 

--- a/tests/dataframe/test_dataframe_parity.py
+++ b/tests/dataframe/test_dataframe_parity.py
@@ -49,9 +49,6 @@ def test_filter_salary_gt_60000(spark) -> None:
     assert_rows_equal(rows, expected, order_matters=False)
 
 
-@pytest.mark.skip(
-    reason="Issue #1274: unskip when fixing collect String schema semantics"
-)
 def test_filter_and_operator(spark) -> None:
     """Ported from Sparkless test_filter_with_and_operator: (a > 1) & (b > 1)."""
     data = [{"a": 1, "b": 2}, {"a": 2, "b": 3}, {"a": 3, "b": 1}]

--- a/tests/dataframe/test_doc_examples.py
+++ b/tests/dataframe/test_doc_examples.py
@@ -54,9 +54,6 @@ def test_user_guide_na_fill_drop(spark) -> None:
     assert len(dropped.collect()) == 2
 
 
-@pytest.mark.skip(
-    reason="Issue #1274: unskip when fixing collect String schema semantics"
-)
 def test_user_guide_create_dataframe_from_rows(spark) -> None:
     """USER_GUIDE: _create_dataframe_from_rows."""
     schema = ["id", "name", "score"]

--- a/tests/dataframe/test_issue_176_pyspark_parity.py
+++ b/tests/dataframe/test_issue_176_pyspark_parity.py
@@ -141,9 +141,6 @@ def test_select_expression_and_column_name_pyspark_parity() -> None:
     assert_rows_equal(actual, EXPECTED_SELECT_EXPR_AND_COLUMN, order_matters=True)
 
 
-@pytest.mark.skip(
-    reason="Issue #1274: unskip when fixing collect String schema semantics"
-)
 def test_select_list_of_column_names_still_works() -> None:
     """select(['a','b']) continues to work (backward compatibility)."""
 
@@ -156,9 +153,6 @@ def test_select_list_of_column_names_still_works() -> None:
     assert [r.asDict() for r in rows] == [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
 
 
-@pytest.mark.skip(
-    reason="Issue #1274: unskip when fixing collect String schema semantics"
-)
 def test_select_varargs_column_names_still_works() -> None:
     """select('a', 'b') continues to work (backward compatibility)."""
 

--- a/tests/dataframe/test_issue_257_order_by_accepts_sort_order.py
+++ b/tests/dataframe/test_issue_257_order_by_accepts_sort_order.py
@@ -32,9 +32,6 @@ def test_order_by_single_desc_nulls_last(spark) -> None:
     assert values == ["D", "C", "B", "A", None]
 
 
-@pytest.mark.skip(
-    reason="Issue #1274: unskip when fixing collect String schema semantics"
-)
 def test_order_by_list_of_sort_orders(spark) -> None:
     """df.order_by([col("a").asc(), col("b").desc_nulls_last()]) works."""
     data = [{"a": 1, "b": 10}, {"a": 1, "b": 20}, {"a": 2, "b": 5}]

--- a/tests/dataframe/test_issue_274_join_key_coercion.py
+++ b/tests/dataframe/test_issue_274_join_key_coercion.py
@@ -7,12 +7,7 @@ Robin previously raised: RuntimeError: datatypes of join keys don't match.
 
 from __future__ import annotations
 
-import pytest
 
-
-@pytest.mark.skip(
-    reason="Issue #1274: unskip when fixing collect String schema semantics"
-)
 def test_join_str_key_left_int_key_right(spark) -> None:
     """Join on 'id': left id is str, right id is int; keys are coerced to common type."""
     df1 = spark.createDataFrame(

--- a/tests/dataframe/test_issue_353_join_on_accept_column.py
+++ b/tests/dataframe/test_issue_353_join_on_accept_column.py
@@ -6,17 +6,12 @@ PySpark's DataFrame.join(other, on=...) accepts on as a Column or list of column
 
 from __future__ import annotations
 
-import pytest
-
 from tests.fixtures.spark_imports import get_spark_imports
 
 _imports = get_spark_imports()
 F = _imports.F
 
 
-@pytest.mark.skip(
-    reason="Issue #1274: unskip when fixing collect String schema semantics"
-)
 def test_join_on_column(spark) -> None:
     """left.join(right, col(\"id\")) works (PySpark parity)."""
     left = spark.createDataFrame([{"id": 1, "v": 10}], ["id", "v"])
@@ -49,9 +44,6 @@ def test_join_on_list_of_columns(spark) -> None:
     )
 
 
-@pytest.mark.skip(
-    reason="Issue #1274: unskip when fixing collect String schema semantics"
-)
 def test_join_on_str_still_works(spark) -> None:
     """join(right, "id") and join(right, ["id"]) still work."""
     left = spark.createDataFrame([{"id": 1, "v": 10}], ["id", "v"])

--- a/tests/dataframe/test_issue_360_na_replace.py
+++ b/tests/dataframe/test_issue_360_na_replace.py
@@ -36,9 +36,6 @@ def test_na_replace_without_subset(spark) -> None:
     assert rows[1]["a"] == "y" and rows[1]["b"] == "y"
 
 
-@pytest.mark.skip(
-    reason="Issue #1274: unskip when fixing collect String schema semantics"
-)
 def test_na_replace_subset_one_column(spark) -> None:
     """na.replace with subset only touches specified columns."""
     create_df = getattr(spark, "create_dataframe_from_rows", spark.createDataFrame)

--- a/tests/dataframe/test_issue_381_agg_multiple_global.py
+++ b/tests/dataframe/test_issue_381_agg_multiple_global.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
-
 from tests.fixtures.spark_imports import get_spark_imports
 
 _imports = get_spark_imports()
@@ -34,9 +32,6 @@ def test_agg_single_expr_unchanged(spark) -> None:
     assert list(rows[0].asDict().values()) == [3]
 
 
-@pytest.mark.skip(
-    reason="Issue #1274: unskip when fixing collect String schema semantics"
-)
 def test_agg_list_unchanged(spark) -> None:
     """df.agg([expr1, expr2]) still works."""
     df = spark.createDataFrame([{"a": 1, "b": 10}], schema=["a", "b"])


### PR DESCRIPTION
Fixes #1274

**Summary**
- **Inference:** Removed the #1149 override that forced the second column (and `double` columns) to String for `createDataFrame(list_of_dicts, [col names])}`. All columns now keep their inferred type (long/double for numeric data), so when the schema is numeric, `collect()` returns numeric values (PySpark-aligned: when schema says String, Row returns string; infer numeric so schema is not String for numeric data).
- **Tests:** Unskipped the 10 tests listed in the issue. No other test logic or expectations were changed. Removed unused `pytest` imports where the only use was the skip decorator.

**Verification**
- `make check-full` passes (format, clippy, audit, deny, Rust tests, ruff, mypy).