### PR TITLE
Fix #1255: aggregate cast parity and preserve user aliases

### DIFF
--- a/crates/robin-sparkless-polars/src/dataframe/aggregations.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/aggregations.rs
@@ -10,9 +10,9 @@ use polars_plan::dsl::AggExpr;
 use std::collections::HashMap;
 
 /// PySpark-style name for Cast expressions in agg (e.g. "CAST(avg(value) AS STRING)").
-/// Issue #1255: aggregate cast column names must match PySpark format for parity tests.
+/// Returns (cast_name, inner_name) so callers can keep user aliases (issue #1255).
 /// Unwrap outer Alias(es) so we detect Cast when expr is Alias(Alias(Cast(...), _), _) or Alias(Cast(...), _).
-fn pyspark_style_cast_agg_name(expr: &Expr) -> Option<String> {
+fn pyspark_style_cast_agg_name(expr: &Expr) -> Option<(String, String)> {
     let mut top: &Expr = expr;
     while let Expr::Alias(e, _) = top {
         top = e.as_ref();
@@ -42,24 +42,43 @@ fn pyspark_style_cast_agg_name(expr: &Expr) -> Option<String> {
         Some(DataType::Boolean) => "BOOLEAN",
         _ => return None,
     };
-    Some(format!("CAST({inner_name} AS {type_str})"))
+    let cast_name = format!("CAST({inner_name} AS {type_str})");
+    Some((cast_name, inner_name))
 }
 
 /// Disambiguate duplicate output names in aggregation expressions (PySpark parity: issue #368).
 /// When multiple aggs produce the same name (e.g. sum("value"), avg("value") both "value"),
 /// suffix with _1, _2, ... so Polars does not error.
-/// For Cast expressions, use PySpark-style name "CAST(agg(col) AS TYPE)" (issue #1255).
+/// For Cast expressions without a user alias, use PySpark-style name "CAST(agg(col) AS TYPE)" (issue #1255).
+/// When the user set an explicit alias (e.g. .alias("TotalScore")), keep it (never overwrite).
 pub(crate) fn disambiguate_agg_output_names(aggregations: Vec<Expr>) -> Vec<Expr> {
     let mut name_count: HashMap<String, u32> = HashMap::new();
     aggregations
         .into_iter()
         .map(|e| {
-            let base_name = pyspark_style_cast_agg_name(&e)
-                .unwrap_or_else(|| {
-                    polars_plan::utils::expr_output_name(&e)
-                        .map(|s| s.to_string())
-                        .unwrap_or_else(|_| "_".to_string())
-                });
+            // If top-level is Alias(_, name), use it unless it's the default (same as Cast inner);
+            // then use CAST name for parity tests (issue #1255). User alias like "TotalScore" is preserved (#332).
+            let (base_name, used_cast_name): (String, bool) = if let Expr::Alias(_, name) = &e {
+                let user_name = name.to_string();
+                match pyspark_style_cast_agg_name(&e) {
+                    Some((cast_name, inner_name)) if user_name == inner_name => (cast_name, true),
+                    _ => (user_name, false),
+                }
+            } else {
+                let current_name = polars_plan::utils::expr_output_name(&e)
+                    .map(|s| s.to_string())
+                    .unwrap_or_else(|_| "_".to_string());
+                match pyspark_style_cast_agg_name(&e) {
+                    Some((cast_name, inner_name)) => {
+                        if current_name == inner_name {
+                            (cast_name, true)
+                        } else {
+                            (current_name, false)
+                        }
+                    }
+                    None => (current_name, false),
+                }
+            };
             let count = name_count.entry(base_name.clone()).or_insert(0);
             *count += 1;
             let final_name = if *count == 1 {
@@ -67,8 +86,7 @@ pub(crate) fn disambiguate_agg_output_names(aggregations: Vec<Expr>) -> Vec<Expr
             } else {
                 format!("{}_{}", base_name, *count - 1)
             };
-            // Always alias Cast exprs so schema shows PySpark-style name (issue #1255).
-            let needs_alias = pyspark_style_cast_agg_name(&e).is_some() || *count > 1;
+            let needs_alias = used_cast_name || *count > 1;
             if needs_alias {
                 e.alias(final_name.as_str())
             } else {

--- a/crates/robin-sparkless-polars/src/functions/rest.rs
+++ b/crates/robin-sparkless-polars/src/functions/rest.rs
@@ -1441,14 +1441,12 @@ fn cast_impl(column: &Column, type_name: &str, strict: bool) -> Result<Column, S
     if dtype == DataType::Int32 || dtype == DataType::Int64 {
         // Use strict_cast when expr is not a plain column (e.g. aggregate) so we get a Cast node
         // and PySpark-style column name "CAST(sum(value) AS INT)" in groupby agg (issue #1255).
+        // Do not add an inner alias here so that user .alias("TotalScore") becomes the single
+        // top-level Alias and is preserved by disambiguate_agg_output_names (#332).
         // PySpark parity (#1048): for plain string columns, cast returns NULL for invalid strings.
         let is_plain_column = matches!(column.expr(), Expr::Column(_));
         if !is_plain_column {
-            let expr = column
-                .expr()
-                .clone()
-                .strict_cast(dtype)
-                .alias(&base_name);
+            let expr = column.expr().clone().strict_cast(dtype);
             return Ok(Column::from_expr(expr, Some(base_name)));
         }
         let target = dtype.clone();

--- a/crates/robin-sparkless-polars/src/plan/mod.rs
+++ b/crates/robin-sparkless-polars/src/plan/mod.rs
@@ -684,6 +684,15 @@ fn parse_aggs(aggs: &[Value], df: &DataFrame) -> Result<Vec<polars::prelude::Exp
         let obj = a
             .as_object()
             .ok_or_else(|| PlanError::InvalidPlan("each agg must be an object".into()))?;
+        // Full expression tree (e.g. cast+alias from Sparkless); issue #1255 / #332.
+        if let Some(expr_val) = obj.get("expr") {
+            let expr = expr_from_value(expr_val).map_err(PlanError::Expr)?;
+            let resolved = df
+                .resolve_expr_column_names(expr)
+                .map_err(PlanError::Session)?;
+            out.push(resolved);
+            continue;
+        }
         // Sparkless may send "func" instead of "agg" (e.g. groupby_first_last; fixes #828–#838).
         let agg = obj
             .get("agg")
@@ -754,6 +763,16 @@ fn parse_aggs(aggs: &[Value], df: &DataFrame) -> Result<Vec<polars::prelude::Exp
             _ => return Err(PlanError::InvalidPlan(format!("unsupported agg: {agg}"))),
         };
         let mut expr = col_expr.into_expr();
+        // Optional cast (e.g. {"agg": "sum", "column": "Score", "alias": "TotalScore", "cast": "int"}); #1255, #332.
+        if let Some(cast_type) = obj
+            .get("cast")
+            .or_else(|| obj.get("cast_type"))
+            .and_then(Value::as_str)
+        {
+            let dtype =
+                crate::functions::parse_type_name(cast_type).map_err(PlanError::InvalidPlan)?;
+            expr = expr.strict_cast(dtype);
+        }
         // #672, #791: PySpark-style result column names (e.g. avg(Value)) when plan does not set alias.
         // #777: Deduplicate aliases so multiple count() etc. get count, count_1, count_2, ...
         // Accept "name" as fallback for "alias" (Sparkless may send either).

--- a/tests/parity/functions/test_aggregate_cast_parity.py
+++ b/tests/parity/functions/test_aggregate_cast_parity.py
@@ -1,7 +1,6 @@
 """PySpark parity test for aggregate function cast (Issue #265)."""
 
 from tests.fixtures.parity_base import ParityTestBase
-import pytest
 from tests.fixtures.spark_imports import get_spark_imports
 
 

--- a/tests/unit/dataframe/test_casewhen_windowfunction_cast.py
+++ b/tests/unit/dataframe/test_casewhen_windowfunction_cast.py
@@ -8,8 +8,6 @@ These tests work with both sparkless (mock) and PySpark backends.
 Set MOCK_SPARK_TEST_BACKEND=pyspark to run with real PySpark.
 """
 
-import pytest
-
 from tests.fixtures.spark_imports import get_spark_imports
 
 # Get imports based on backend


### PR DESCRIPTION
Fixes #1255. Unskips parity tests; preserves user aliases (e.g. .alias("TotalScore")); plan expr/cast support; clippy/ruff fixes.