### PR TITLE
Fix #1249: missing bindings parity - Column.length() PySpark parity

### DIFF
--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -5614,10 +5614,11 @@ impl PyColumn {
         }
     }
 
-    fn length(&self) -> PyColumn {
-        PyColumn {
-            inner: self.inner.length(),
-        }
+    /// PySpark parity #1249: Column has .length attribute but it is not callable; use F.length(col) instead.
+    /// Returning self so that col.length() raises TypeError (column not callable).
+    #[getter]
+    fn length(slf: PyRef<Self>) -> PyRef<Self> {
+        slf
     }
 
     /// Split string by delimiter. PySpark split. limit=-1 means no limit.

--- a/tests/dataframe/test_missing_bindings_parity.py
+++ b/tests/dataframe/test_missing_bindings_parity.py
@@ -27,7 +27,6 @@ def _spark_and_df():
     # inferred from data (double for n, string for s/t), matching real PySpark.
     schema = ["s", "n", "t"]
     return spark, spark.createDataFrame(data, schema)
-@pytest.mark.skip(reason="Issue #1249: unskip when fixing")
 def test_length_module_and_method() -> None:
     _, df = _spark_and_df()
     out = df.select(F.length(F.col("s"))).collect()


### PR DESCRIPTION
Closes #1249

**Changes**
- Unskipped `test_length_module_and_method` in `tests/dataframe/test_missing_bindings_parity.py`.
- **PySpark parity:** In PySpark, `F.col('s').length()` raises `TypeError` (Column is not callable); only `F.length(F.col('s'))` is valid. Sparkless now matches: `PyColumn.length` is a getter that returns the column (self), so `col.length()` tries to call the column and raises `TypeError`. `F.length(col)` continues to work.

**Tests**
- `tests/dataframe/test_missing_bindings_parity.py`: all 6 tests pass.
- Full suite: 2679 passed, 138 skipped.