### PR TITLE
Fix #1243: posexplode/posexplode_outer alias execution

### DIFF
--- a/crates/robin-sparkless-polars/src/dataframe/transformations.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/transformations.rs
@@ -32,6 +32,27 @@ fn expr_refs_column(expr: &Expr, column_name: &str) -> bool {
     expr_referenced_columns(expr).contains(column_name)
 }
 
+/// If the expression contains an Explode node, return its input and options (for posexplode detection).
+fn find_explode_in_expr(expr: &Expr) -> Option<(Arc<Expr>, polars::prelude::ExplodeOptions)> {
+    if let Expr::Explode { input, options } = expr {
+        return Some((input.clone(), *options));
+    }
+    if let Expr::Alias(inner, _) = expr {
+        return find_explode_in_expr(inner.as_ref());
+    }
+    // Recurse into common wrappers so we find Explode inside StructField etc.
+    let out = RefCell::new(None);
+    let _ = expr.clone().try_map_expr(|e| {
+        if out.borrow().is_none() {
+            if let Expr::Explode { input, options } = &e {
+                out.borrow_mut().replace((input.clone(), *options));
+            }
+        }
+        Ok(e)
+    });
+    out.into_inner()
+}
+
 /// Replace a pure literal expr with a column-referencing expr so Polars produces correct row count.
 /// Polars lit() in select-only or empty-df contexts yields 1 row; we need N rows (or 0 for empty).
 fn expand_pure_literal_to_rows(expr: Expr, first_col: Option<&str>) -> Result<Expr, PolarsError> {
@@ -115,10 +136,64 @@ pub fn select_with_exprs(
         .map(|e| expand_pure_literal_to_rows(e.clone(), first_col).unwrap_or(e))
         .collect();
 
+    // Detect posexplode: two exprs that each contain Explode(list.eval(...)) with same single list column (#1243).
+    type PosexplodeTarget = (
+        PlSmallStr,
+        polars::prelude::ExplodeOptions,
+        [(PlSmallStr, usize); 2], // (alias_pos, idx_pos), (alias_col, idx_col)
+    );
+    let posexplode_target: Option<PosexplodeTarget> = {
+        let mut by_col: HashMap<
+            String,
+            Vec<(polars::prelude::ExplodeOptions, String, usize)>,
+        > = HashMap::new();
+        for (i, e) in exprs.iter().enumerate() {
+            let (inner, alias_name) = match e {
+                Expr::Alias(inner, name) => (inner.as_ref(), name.as_str().to_string()),
+                _ => continue,
+            };
+            if let Some((input, options)) = find_explode_in_expr(inner) {
+                let refs = expr_referenced_columns(input.as_ref());
+                // List.eval uses col("") for element context; only consider columns that exist in the frame.
+                let frame_refs: Vec<String> = refs
+                    .intersection(&df_columns)
+                    .cloned()
+                    .collect();
+                if frame_refs.len() == 1 {
+                    let list_col = frame_refs.into_iter().next().unwrap();
+                    by_col
+                        .entry(list_col.clone())
+                        .or_default()
+                        .push((options, alias_name, i));
+                }
+            }
+        }
+        by_col
+            .into_iter()
+            .find(|(_, v)| v.len() == 2)
+            .map(|(list_col, mut v)| {
+                v.sort_by_key(|(_, _, i)| *i);
+                let list_col = PlSmallStr::from(list_col.as_str());
+                let options = v[0].0;
+                (
+                    list_col,
+                    options,
+                    [
+                        (PlSmallStr::from(v[0].1.as_str()), v[0].2),
+                        (PlSmallStr::from(v[1].1.as_str()), v[1].2),
+                    ],
+                )
+            })
+    };
+
     // Detect simple explode expressions (e.g. F.explode(col(\"scores\")).alias(\"score\"))
     // and rewrite to use LazyFrame.explode. When alias != source column, add a copy then explode
     // so the original list column is preserved (PySpark select(Name, Value, explode(Value).alias("ExplodedValue"))).
     // Python Column.into_expr() does expr.alias(name), so explode(col).alias("x") becomes Alias(Alias(Explode(...), "x"), "x"); peel one more Alias.
+    let posexplode_pe_col = posexplode_target
+        .as_ref()
+        .map(|(lc, _, _)| format!("__pe_{}", lc.as_str()));
+
     type ExplodeTarget = (
         PlSmallStr,
         Option<PlSmallStr>,
@@ -127,7 +202,23 @@ pub fn select_with_exprs(
     let mut explode_target: Option<ExplodeTarget> = None;
     let exprs: Vec<Expr> = exprs
         .into_iter()
-        .map(|e| match e {
+        .enumerate()
+        .map(|(i, e)| {
+            if let (Some(pt), Some(pe_col)) = (&posexplode_target, &posexplode_pe_col) {
+                if i == pt.2[0].1 {
+                    return col(pe_col.as_str())
+                        .struct_()
+                        .field_by_name("pos")
+                        .alias(pt.2[0].0.as_str());
+                }
+                if i == pt.2[1].1 {
+                    return col(pe_col.as_str())
+                        .struct_()
+                        .field_by_name("col")
+                        .alias(pt.2[1].0.as_str());
+                }
+            }
+            match e {
             Expr::Alias(inner, name) => {
                 let inner_ref = inner.as_ref();
                 let (explode_input, options): (Option<Arc<Expr>>, polars::prelude::ExplodeOptions) =
@@ -189,6 +280,7 @@ pub fn select_with_exprs(
                 }
             }
             other => other,
+        }
         })
         .collect();
     let mut name_count: HashMap<String, u32> = HashMap::new();
@@ -218,7 +310,7 @@ pub fn select_with_exprs(
     // When every expression references no column from the frame, Polars select yields 1 row.
     // Cross-join with a single key column to get N rows (PySpark parity).
     let mut lf = df.lazy_frame();
-    let had_explode = explode_target.is_some();
+    let had_explode = explode_target.is_some() || posexplode_target.is_some();
 
     // If we saw an explode expression on a single column, apply frame-level explode first so
     // non-exploded columns are replicated correctly (PySpark explode parity).
@@ -239,6 +331,22 @@ pub fn select_with_exprs(
             };
             lf = lf.explode(selector, options);
         }
+    }
+    // Posexplode: add list-of-structs column and explode so non-exploded columns replicate (#1243).
+    if let Some((list_col, options, _)) = &posexplode_target {
+        let pe_col = format!("__pe_{}", list_col.as_str());
+        use polars::prelude::as_struct;
+        let pos_inner = (col("").cum_count(false) - lit(1i64)).alias("pos");
+        let val_inner = col("").alias("col");
+        let list_struct = col(list_col.as_str())
+            .list()
+            .eval(as_struct(vec![pos_inner, val_inner]));
+        lf = lf.with_column(list_struct.alias(pe_col.as_str()));
+        let selector = Selector::ByName {
+            names: Arc::from([PlSmallStr::from(pe_col.as_str())]),
+            strict: true,
+        };
+        lf = lf.explode(selector, *options);
     }
     // When we applied explode, the frame was already expanded; rewritten exprs may reference only
     // the new column (e.g. "x"), so we must not use the no-col-refs cross_join path (it would

--- a/python/sparkless/sparkless/__init__.py
+++ b/python/sparkless/sparkless/__init__.py
@@ -201,6 +201,14 @@ def posexplode(col_or_name):
     return _PosexplodeResult(pos_col, val_col)
 
 
+def posexplode_outer(col_or_name):
+    """Explode array with position; null/empty yields one row (PySpark posexplode_outer)."""
+    if isinstance(col_or_name, str):
+        col_or_name = column(col_or_name)
+    pos_col, val_col = _mod.posexplode_outer(col_or_name)
+    return _PosexplodeResult(pos_col, val_col)
+
+
 to_timestamp = _mod.to_timestamp
 to_date = _mod.to_date
 current_date = _mod.current_date

--- a/python/sparkless/sparkless/sql/functions.py
+++ b/python/sparkless/sparkless/sql/functions.py
@@ -20,6 +20,7 @@ from sparkless import (
     least as _least,
     array_distinct as _array_distinct,
     posexplode as _posexplode,
+    posexplode_outer as _posexplode_outer,
     upper,
     lower,
     substring,
@@ -347,7 +348,9 @@ def posexplode(col_or_name: ColumnOrName) -> _ColumnType:
     return _col_result(_native_fn("posexplode")(_as_col(col_or_name)))
 
 
-posexplode_outer = _ni("posexplode_outer")
+def posexplode_outer(col_or_name: ColumnOrName) -> _ColumnType:
+    """Explode array with position; null/empty yields one row (PySpark posexplode_outer)."""
+    return _col_result(_posexplode_outer(col_or_name))
 
 
 def flatten(col_or_name: ColumnOrName) -> _ColumnType:

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -7260,6 +7260,12 @@ fn posexplode(column: &PyColumn) -> (PyColumn, PyColumn) {
 }
 
 #[pyfunction]
+fn posexplode_outer(column: &PyColumn) -> (PyColumn, PyColumn) {
+    let (pos, val) = functions::posexplode_outer(&column.inner);
+    (PyColumn { inner: pos }, PyColumn { inner: val })
+}
+
+#[pyfunction]
 fn regexp_like(column: &PyColumn, pattern: &str) -> PyColumn {
     PyColumn {
         inner: functions::regexp_like(&column.inner, pattern),
@@ -8209,6 +8215,7 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(least, m)?)?;
     m.add_function(wrap_pyfunction!(array_distinct, m)?)?;
     m.add_function(wrap_pyfunction!(posexplode, m)?)?;
+    m.add_function(wrap_pyfunction!(posexplode_outer, m)?)?;
     m.add_function(wrap_pyfunction!(to_timestamp, m)?)?;
     m.add_function(wrap_pyfunction!(to_date, m)?)?;
     m.add_function(wrap_pyfunction!(current_date, m)?)?;

--- a/tests/dataframe/test_issue_430_posexplode_alias_execution.py
+++ b/tests/dataframe/test_issue_430_posexplode_alias_execution.py
@@ -16,7 +16,6 @@ import pytest
 from tests.fixtures.spark_imports import get_spark_imports
 
 
-@pytest.mark.skip(reason="Issue #1243: unskip when fixing")
 def test_posexplode_alias_two_names_returns_exploded_rows(spark, spark_backend):
     """posexplode().alias('Value1', 'Value2') must return 4 rows with correct values (#430)."""
     F_backend = get_spark_imports(spark_backend).F
@@ -45,7 +44,6 @@ def test_posexplode_alias_two_names_returns_exploded_rows(spark, spark_backend):
     assert by_name["Bob"] == [(0, 30), (1, 40)]
 
 
-@pytest.mark.skip(reason="Issue #1243: unskip when fixing")
 def test_posexplode_alias_no_none_values(spark, spark_backend):
     """posexplode().alias() must not return None in exploded columns (#430)."""
     F_backend = get_spark_imports(spark_backend).F
@@ -64,7 +62,6 @@ def test_posexplode_alias_no_none_values(spark, spark_backend):
     assert [(r["pos"], r["val"]) for r in rows] == [(0, 1), (1, 2), (2, 3)]
 
 
-@pytest.mark.skip(reason="Issue #1243: unskip when fixing")
 def test_posexplode_alias_chained_filter_orderby(spark, spark_backend):
     """posexplode().alias() in chained select/filter/orderBy/limit returns correct rows."""
     F_backend = get_spark_imports(spark_backend).F
@@ -130,7 +127,6 @@ def test_posexplode_alias_single_element(spark, spark_backend):
     assert rows[0]["pos"] is not None and rows[0]["val"] is not None
 
 
-@pytest.mark.skip(reason="Issue #1243: unskip when fixing")
 def test_posexplode_alias_mixed_columns(spark, spark_backend):
     """select(a, posexplode(arr).alias(...), b) preserves column order."""
     F_backend = get_spark_imports(spark_backend).F
@@ -145,7 +141,6 @@ def test_posexplode_alias_mixed_columns(spark, spark_backend):
         assert rows[1]["pos"] == 1 and rows[1]["val"] == 2
 
 
-@pytest.mark.skip(reason="Issue #1243: unskip when fixing")
 def test_posexplode_outer_alias_returns_exploded_rows(spark, spark_backend):
     """posexplode_outer().alias() returns exploded rows; null array yields one row."""
     F_backend = get_spark_imports(spark_backend).F
@@ -165,7 +160,6 @@ def test_posexplode_outer_alias_returns_exploded_rows(spark, spark_backend):
         assert 2 in by_id
 
 
-@pytest.mark.skip(reason="Issue #1243: unskip when fixing")
 def test_posexplode_alias_string_array(spark, spark_backend):
     """posexplode on string array returns correct values."""
     F_backend = get_spark_imports(spark_backend).F
@@ -186,7 +180,6 @@ def test_posexplode_alias_column_object(spark, spark_backend):
     assert [(r["idx"], r["elem"]) for r in rows] == [(0, 100), (1, 200)]
 
 
-@pytest.mark.skip(reason="Issue #1243: unskip when fixing")
 def test_posexplode_alias_show_no_none(spark, spark_backend):
     """Regression: show() on posexplode result must not display None for exploded cols."""
     F_backend = get_spark_imports(spark_backend).F


### PR DESCRIPTION
Closes #1243

**Summary**
- Unskipped the seven tests in `tests/dataframe/test_issue_430_posexplode_alias_execution.py` (no other test changes).
- Fixed sparkless so `select(..., F.posexplode("col").alias("pos", "val"), ...)` and `F.posexplode_outer(...).alias(...)` produce the correct number of rows with non-exploded columns replicated (PySpark semantics).

**Changes**
1. **`crates/robin-sparkless-polars/src/dataframe/transformations.rs`**
   - In `select_with_exprs`, detect when two exprs are posexplode outputs (each contains `Explode(list.eval(...))` with the same single list column; filter refs to frame columns so `col("")` from list.eval is ignored).
   - When detected: add a temp list-of-structs column, apply frame-level explode, rewrite the two exprs to struct field access on that column so `select(Name, posexplode(Values).alias(Value1, Value2))` yields 4 rows with Name replicated.
   - `had_explode` now includes posexplode so cross-join path is not used.

2. **Python**
   - Expose `posexplode_outer` in the native lib (returns `(PyColumn, PyColumn)` like `posexplode`).
   - Add `posexplode_outer` in `__init__.py` and `sql.functions` using `_PosexplodeResult` so `F.posexplode_outer("arr").alias("pos", "val")` works.

**Testing**
- `maturin develop --manifest-path python/Cargo.toml` then `.venv/bin/python -m pytest tests/dataframe/test_issue_430_posexplode_alias_execution.py -v`: **10 passed**.