### PR TITLE
Fix failing tests: tests/dataframe/test_issue_421_join_column_names.py (#1242)

### DIFF
--- a/crates/robin-sparkless-polars/src/dataframe/joins.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/joins.rs
@@ -70,6 +70,36 @@ pub fn try_extract_join_eq_columns_all(expr: &Expr) -> Vec<(String, String)> {
     pairs
 }
 
+/// Returns true if the expression is only AND and Eq (column refs). When true, a key-based join
+/// already enforces the condition, so we must not filter after the join (left/right/outer would
+/// otherwise lose unmatched rows). Used for PySpark parity (#1242).
+pub fn expr_contains_only_join_key_equalities(expr: &Expr) -> bool {
+    use polars::prelude::Expr as PlExpr;
+    fn only_join_equalities(e: &Expr) -> bool {
+        let mut current = e;
+        while let PlExpr::Alias(inner, _) = current {
+            current = inner.as_ref();
+        }
+        match current {
+            PlExpr::BinaryExpr {
+                left,
+                op: Operator::Eq | Operator::EqValidity,
+                right,
+            } => {
+                expr_to_column_name(left.as_ref()).is_some()
+                    && expr_to_column_name(right.as_ref()).is_some()
+            }
+            PlExpr::BinaryExpr {
+                left,
+                op: Operator::And,
+                right,
+            } => only_join_equalities(left.as_ref()) && only_join_equalities(right.as_ref()),
+            _ => false,
+        }
+    }
+    only_join_equalities(expr)
+}
+
 /// Join type for DataFrame joins (PySpark-compatible)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum JoinType {
@@ -550,7 +580,10 @@ pub fn join(
 
 #[cfg(test)]
 mod tests {
-    use super::{JoinType, join, try_extract_join_eq_columns, try_extract_join_eq_columns_all};
+    use super::{
+        expr_contains_only_join_key_equalities, join, try_extract_join_eq_columns,
+        try_extract_join_eq_columns_all, JoinType,
+    };
     use crate::functions::col;
     use crate::{DataFrame, SparkSession};
     use std::collections::HashMap;
@@ -586,6 +619,24 @@ mod tests {
         let expr = eq_expr.into_expr(); // adds Alias(..., "<expr>")
         let out = try_extract_join_eq_columns(&expr);
         assert_eq!(out, Some(("a".to_string(), "b".to_string())));
+    }
+
+    #[test]
+    fn expr_contains_only_join_key_equalities_simple_and_compound() {
+        // Only key equalities -> true (so we skip post-join filter for left/right/outer #1242).
+        let eq_expr = col("Key").eq(col("Name").into_expr()).into_expr();
+        assert!(expr_contains_only_join_key_equalities(&eq_expr));
+        let and_expr = col("a")
+            .eq(col("b").into_expr())
+            .and_(&col("c").eq(col("d").into_expr()))
+            .into_expr();
+        assert!(expr_contains_only_join_key_equalities(&and_expr));
+        // Compound (equality + other) -> false so we still apply filter (#380).
+        let gt_expr = col("a")
+            .eq(col("b").into_expr())
+            .and_(&col("x").gt(col("y").into_expr()))
+            .into_expr();
+        assert!(!expr_contains_only_join_key_equalities(&gt_expr));
     }
 
     fn left_df() -> DataFrame {

--- a/crates/robin-sparkless-polars/src/dataframe/mod.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/mod.rs
@@ -7,7 +7,10 @@ mod transformations;
 
 pub(crate) use aggregations::disambiguate_agg_output_names;
 pub use aggregations::{CubeRollupData, GroupedData, PivotedGroupedData};
-pub use joins::{JoinType, join, try_extract_join_eq_columns, try_extract_join_eq_columns_all};
+pub use joins::{
+    expr_contains_only_join_key_equalities, join, JoinType, try_extract_join_eq_columns,
+    try_extract_join_eq_columns_all,
+};
 pub use stats::DataFrameStat;
 pub(crate) use transformations::literal_value_to_serde_value;
 pub use transformations::{

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -9,7 +9,7 @@ use pyo3::create_exception;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyList, PyTuple};
 use robin_sparkless::dataframe::{
-    try_extract_join_eq_columns_all, JoinType, PivotedGroupedData, SaveMode, WriteFormat, WriteMode,
+    expr_contains_only_join_key_equalities, try_extract_join_eq_columns_all, JoinType, PivotedGroupedData, SaveMode, WriteFormat, WriteMode,
 };
 use robin_sparkless::functions::{self, asc_from_name, SortOrder, ThenBuilder, WhenBuilder};
 use robin_sparkless::{
@@ -4124,11 +4124,16 @@ impl PyDataFrame {
                             .inner
                             .join_with_keys(&other.inner, left_refs, right_refs, join_type)
                             .map_err(to_py_err)?;
-                        // When the original expression was a compound condition (e.g. key equality AND filter),
-                        // reapply the full predicate after the key-based join so additional conditions are honored
-                        // (issue #380: join with compound condition).
-                        let filtered = joined.filter(expr).map_err(to_py_err)?;
-                        return Ok(PyDataFrame::wrap(filtered));
+                        // When the expression is only key equalities, the join already enforces them;
+                        // do not filter afterward or left/right/outer would lose unmatched rows (#1242).
+                        // When the expression is compound (e.g. key equality AND filter), reapply the
+                        // full predicate after the key-based join (issue #380).
+                        let result = if expr_contains_only_join_key_equalities(&expr) {
+                            joined
+                        } else {
+                            joined.filter(expr).map_err(to_py_err)?
+                        };
+                        return Ok(PyDataFrame::wrap(result));
                     }
                 }
                 // Non-eq expression: cross + filter (ambiguous duplicate column names may apply).

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -45,7 +45,7 @@ pub struct PivotedGroupedData(pub(crate) PolarsPivotedGroupedData);
 /// Re-export for API compatibility.
 pub use robin_sparkless_polars::dataframe::{
     GroupBySpec, JoinType, SaveMode, SelectItem, WriteFormat, WriteMode,
-    try_extract_join_eq_columns, try_extract_join_eq_columns_all,
+    expr_contains_only_join_key_equalities, try_extract_join_eq_columns, try_extract_join_eq_columns_all,
 };
 
 /// Root-owned DataFrameStat; delegates to the Polars backend.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ pub use robin_sparkless_polars::{
 pub use dataframe::{
     CubeRollupData, DataFrame, DataFrameNa, DataFrameStat, DataFrameWriter, GroupBySpec,
     GroupedData, JoinType, PivotedGroupedData, SaveMode, SelectItem, WriteFormat, WriteMode,
-    try_extract_join_eq_columns, try_extract_join_eq_columns_all,
+    expr_contains_only_join_key_equalities, try_extract_join_eq_columns, try_extract_join_eq_columns_all,
 };
 pub use session::{DataFrameReader, SparkSession, SparkSessionBuilder};
 

--- a/tests/dataframe/test_issue_421_join_column_names.py
+++ b/tests/dataframe/test_issue_421_join_column_names.py
@@ -69,7 +69,6 @@ class TestIssue421JoinColumnNames:
         alice_row = next(r for r in rows if _val(r, "Name") == "Alice")
         assert _val(alice_row, "Key") == "Alice"
 
-    @pytest.mark.skip(reason="Issue #1242: unskip when fixing")
     def test_join_different_column_names_left_no_match(self, spark):
         """Left join: left row with no right match yields nulls in right columns."""
         df1 = spark.createDataFrame(
@@ -98,7 +97,6 @@ class TestIssue421JoinColumnNames:
         assert _val(rows[0], "id_l") == 1 and _val(rows[0], "y") == 100
         assert _val(rows[1], "id_l") == 2 and _val(rows[1], "y") == 200
 
-    @pytest.mark.skip(reason="Issue #1242: unskip when fixing")
     def test_join_different_column_names_right(self, spark):
         """Right join with F.col() on different column names."""
         df1 = spark.createDataFrame([{"a": 1, "x": 10}])  # only id 1
@@ -115,7 +113,6 @@ class TestIssue421JoinColumnNames:
         assert _val(r2, "x") is None
         assert _val(r2, "y") == 200
 
-    @pytest.mark.skip(reason="Issue #1242: unskip when fixing")
     def test_join_different_column_names_outer(self, spark):
         """Full outer join with F.col() on different column names."""
         df1 = spark.createDataFrame(


### PR DESCRIPTION
## Description
Fixes #1242

- **Unskipped** the three tests:
  - `test_join_different_column_names_left_no_match`
  - `test_join_different_column_names_right`
  - `test_join_different_column_names_outer`
- **Cause:** For condition joins with `F.col("Key") == F.col("Name")`, we perform a key-based join (correct) but then applied `filter(expr)` to the result. For left/right/outer joins, unmatched rows have nulls in the right (or left) key column, so `Key == Name` evaluates to null and those rows were dropped—effectively turning the join into an inner join.
- **Fix:** When the join condition is only key equalities (no extra predicates), skip the post-join filter so left/right/outer preserve unmatched rows. When the condition is compound (e.g. key equality AND a filter), we still apply the filter (issue #380 behavior preserved).
- Added `expr_contains_only_join_key_equalities()` in the joins module and a unit test.

Tests: `pytest tests/dataframe/test_issue_421_join_column_names.py -v` (10 passed), `cargo test -p robin-sparkless-polars join` (17 passed).