### PR TITLE
Fix #1239: SparkSession.builder not callable (PySpark parity #412)

### DIFF
--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -537,10 +537,8 @@ impl PySparkSessionBuilder {
         }
     }
 
-    /// PySpark: SparkSession.builder() returns the builder; allow () for compatibility.
-    fn __call__(slf: PyRef<Self>, py: Python<'_>) -> Py<PyAny> {
-        slf.into_py(py)
-    }
+    /// PySpark parity (#412, #1239): Builder is not callable; SparkSession.builder.appName(...) works,
+    /// builder() raises TypeError. We do not implement __call__ so that builder() raises as in PySpark.
 
     fn app_name<'a>(mut slf: PyRefMut<'a, Self>, name: &str) -> PyRefMut<'a, Self> {
         let old = std::mem::replace(&mut slf.inner, SparkSessionBuilder::new());
@@ -756,9 +754,7 @@ impl PySparkSession {
         Ok(obj)
     }
 
-    /// PySpark: SparkSession.builder returns a builder instance.
-    /// We expose it as a class attribute so both `SparkSession.builder.appName(...)`
-    /// and `SparkSession.builder().appName(...)` work (the builder itself is callable).
+    /// PySpark: SparkSession.builder returns a builder instance (not callable; builder() raises TypeError).
     #[classattr]
     fn builder(_py: Python<'_>) -> PySparkSessionBuilder {
         PySparkSessionBuilder {

--- a/tests/dataframe/test_issue_412_builder_callable.py
+++ b/tests/dataframe/test_issue_412_builder_callable.py
@@ -16,7 +16,6 @@ SparkSession = _imports.SparkSession
 class TestIssue412BuilderCallable:
     """Regression tests for SparkSession.builder() callable form (issue #412)."""
 
-    @pytest.mark.skip(reason="Issue #1239: unskip when fixing")
     def test_builder_callable_returns_self(self) -> None:
         """builder is a non-callable Builder object (PySpark parity)."""
         builder = SparkSession.builder
@@ -27,7 +26,6 @@ class TestIssue412BuilderCallable:
         with pytest.raises(TypeError):
             builder()
 
-    @pytest.mark.skip(reason="Issue #1239: unskip when fixing")
     def test_builder_callable_full_chain(self) -> None:
         """SparkSession.builder() callable form raises TypeError (PySpark parity)."""
         builder = SparkSession.builder
@@ -39,7 +37,6 @@ class TestIssue412BuilderCallable:
             # In PySpark this raises \"'Builder' object is not callable\".
             builder().appName("my_app").getOrCreate()
 
-    @pytest.mark.skip(reason="Issue #1239: unskip when fixing")
     def test_builder_property_and_call_equivalent(self) -> None:
         """Property-style builder works; callable form raises TypeError (PySpark parity)."""
         builder = SparkSession.builder


### PR DESCRIPTION
Fixes https://github.com/eddiethedean/robin-sparkless/issues/1239

**Summary**
- Unskips the three tests in `tests/dataframe/test_issue_412_builder_callable.py`.
- Makes `SparkSession.builder` **non-callable** so that `builder()` raises `TypeError` (PySpark parity: "'Builder' object is not callable").
- `SparkSession.builder.appName("x").getOrCreate()` continues to work.

**Changes**
- **python/src/lib.rs**: Removed `__call__` from `PySparkSessionBuilder`. Updated classattr comment. Added a short doc comment that Builder is not callable per #412/#1239.

**Testing**
- `test_issue_412_builder_callable.py`: all 3 tests pass.
- `test_issue_410_builder_callable.py` and `test_issue_373_builder_option.py` still pass (they use `getattr(builder, "__call__", lambda: builder)()` so they work with or without `__call__`).