### PR TITLE
Fix #1238: implement df.rdd.flatMap and RDD actions (issue #408)

### DIFF
--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -2942,11 +2942,16 @@ fn resolve_join_keys_with_aliases(
     (left_key, right_key)
 }
 
-/// RDD-like wrapper for createDataFrame(df.rdd, schema) (issue #1147 / #361).
-/// Holds the source DataFrame; createDataFrame(rdd, schema) collects it to rows and builds a new DataFrame.
+/// RDD-like wrapper for createDataFrame(df.rdd, schema) (issue #1147 / #361) and df.rdd.flatMap (issue #408 / #1238).
+/// When from df.rdd: holds source_df and inner (DataFrame). When from flatMap/map/filter: holds elements (materialized list).
 #[pyclass]
 struct PyRDD {
-    inner: DataFrame,
+    /// When from df.rdd: the DataFrame as PyDataFrame for collect() to get Row objects.
+    source_df: Option<Py<PyDataFrame>>,
+    /// When from df.rdd: same DataFrame for _to_pylist (collect_as_json_rows).
+    inner: Option<DataFrame>,
+    /// When from flatMap/map/filter: materialized list of Python objects.
+    elements: Option<Vec<PyObject>>,
 }
 
 #[pymethods]
@@ -2960,8 +2965,45 @@ impl PyRDD {
         py: Python<'py>,
         preferred_names: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyList>> {
-        let (col_names, rows, _) = self
-            .inner
+        let Some(ref inner) = self.inner else {
+            // Materialized RDD (from flatMap/map): return list of single-key dicts for createDataFrame(rdd, schema).
+            let Some(ref elements) = self.elements else {
+                return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("RDD has no source"));
+            };
+            let (names, _use_preferred_keys): (Vec<String>, bool) = if let Some(arg) = preferred_names {
+                let lst_opt: Option<Bound<'py, PyList>> = if let Ok(lst) = arg.downcast::<PyList>() {
+                    Some(lst.clone())
+                } else if let Ok(tup) = arg.downcast::<pyo3::types::PyTuple>() {
+                    (tup.len() == 1)
+                        .then(|| tup.get_item(0).ok())
+                        .flatten()
+                        .and_then(|item| item.downcast_into::<PyList>().ok())
+                } else {
+                    None
+                };
+                if let Some(lst) = lst_opt {
+                    let n: Vec<String> = lst.iter().filter_map(|it| it.extract::<String>().ok()).collect();
+                    if n.is_empty() {
+                        (vec!["_1".to_string()], false)
+                    } else {
+                        (n, true)
+                    }
+                } else {
+                    (vec!["_1".to_string()], false)
+                }
+            } else {
+                (vec!["_1".to_string()], false)
+            };
+            let out = PyList::empty_bound(py);
+            let key = names.first().map(|s| s.as_str()).unwrap_or("_1");
+            for elem in elements {
+                let dict = PyDict::new_bound(py);
+                dict.set_item(key, elem.bind(py))?;
+                out.append(dict)?;
+            }
+            return Ok(out);
+        };
+        let (col_names, rows, _) = inner
             .collect_as_json_rows_with_names()
             .map_err(to_py_err)?;
         // call_method1(..., (py_names,)) passes a tuple to Python; unwrap single-element tuple.
@@ -2988,7 +3030,7 @@ impl PyRDD {
                 }
             } else {
                 (
-                    self.inner
+                    inner
                         .schema()
                         .ok()
                         .map(|s| s.fields().iter().map(|f| f.name.clone()).collect())
@@ -2998,7 +3040,7 @@ impl PyRDD {
             }
         } else {
             (
-                self.inner
+                inner
                     .schema()
                     .ok()
                     .map(|s| s.fields().iter().map(|f| f.name.clone()).collect())
@@ -3046,6 +3088,114 @@ impl PyRDD {
             }
         }
         Ok(out)
+    }
+
+    /// Collect elements (rows when from df.rdd, or materialized list).
+    fn collect_elements(&self, py: Python<'_>) -> PyResult<Vec<PyObject>> {
+        if let Some(ref elements) = self.elements {
+            return Ok(elements.iter().map(|o| o.clone_ref(py)).collect());
+        }
+        let Some(ref source_df) = self.source_df else {
+            return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("RDD has no source"));
+        };
+        let df = source_df.bind(py).downcast::<PyDataFrame>()?;
+        let list_obj = df.call_method0("collect")?;
+        let list = list_obj.downcast::<PyList>()?;
+        let mut vec = Vec::with_capacity(list.len());
+        for item in list.iter() {
+            vec.push(item.into_py(py));
+        }
+        Ok(vec)
+    }
+
+    #[pyo3(name = "flatMap")]
+    fn flat_map(slf: PyRef<Self>, py: Python<'_>, func: &Bound<'_, PyAny>) -> PyResult<PyRDD> {
+        let elements = slf.collect_elements(py)?;
+        let mut out: Vec<PyObject> = Vec::new();
+        for item in elements {
+            let item_bound = item.bind(py);
+            let result = func.call1((item_bound,))?;
+            for x in result.iter()? {
+                let x: Bound<'_, PyAny> = x?;
+                out.push(x.into_py(py));
+            }
+        }
+        Ok(PyRDD {
+            source_df: None,
+            inner: None,
+            elements: Some(out),
+        })
+    }
+
+    fn map(slf: PyRef<Self>, py: Python<'_>, func: &Bound<'_, PyAny>) -> PyResult<PyRDD> {
+        let elements = slf.collect_elements(py)?;
+        let mut out: Vec<PyObject> = Vec::with_capacity(elements.len());
+        for item in elements {
+            let item_bound = item.bind(py);
+            let mapped = func.call1((item_bound,))?;
+            out.push(mapped.into_py(py));
+        }
+        Ok(PyRDD {
+            source_df: None,
+            inner: None,
+            elements: Some(out),
+        })
+    }
+
+    fn filter(slf: PyRef<Self>, py: Python<'_>, func: &Bound<'_, PyAny>) -> PyResult<PyRDD> {
+        let elements = slf.collect_elements(py)?;
+        let mut out: Vec<PyObject> = Vec::new();
+        for item in elements {
+            let item_bound = item.bind(py);
+            let keep = func.call1((item_bound,))?.is_truthy()?;
+            if keep {
+                out.push(item);
+            }
+        }
+        Ok(PyRDD {
+            source_df: None,
+            inner: None,
+            elements: Some(out),
+        })
+    }
+
+    fn collect(&self, py: Python<'_>) -> PyResult<PyObject> {
+        let elements = self.collect_elements(py)?;
+        let list = PyList::new_bound(py, elements.iter().map(|o| o.bind(py)));
+        Ok(list.into_py(py))
+    }
+
+    fn count(&self, py: Python<'_>) -> PyResult<usize> {
+        self.collect_elements(py).map(|e| e.len())
+    }
+
+    fn take(&self, py: Python<'_>, n: usize) -> PyResult<PyObject> {
+        let elements = self.collect_elements(py)?;
+        let n = n.min(elements.len());
+        let list = PyList::new_bound(py, elements.iter().take(n).map(|o| o.bind(py)));
+        Ok(list.into_py(py))
+    }
+
+    fn first(&self, py: Python<'_>) -> PyResult<PyObject> {
+        let elements = self.collect_elements(py)?;
+        let first = elements.first().ok_or_else(|| {
+            PyErr::new::<pyo3::exceptions::PyValueError, _>("RDD is empty")
+        })?;
+        Ok(first.clone_ref(py))
+    }
+
+    fn reduce(&self, py: Python<'_>, func: &Bound<'_, PyAny>) -> PyResult<PyObject> {
+        let elements = self.collect_elements(py)?;
+        if elements.is_empty() {
+            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                "Cannot reduce empty RDD",
+            ));
+        }
+        let mut acc = elements[0].clone_ref(py);
+        for item in elements.iter().skip(1) {
+            acc = func.call1((acc.bind(py), item.bind(py)))?.into_py(py);
+        }
+        Ok(acc)
     }
 }
 
@@ -3804,8 +3954,14 @@ impl PyDataFrame {
 
     #[getter]
     fn rdd(slf: PyRef<Self>) -> PyRDD {
+        let inner = slf.inner.clone();
+        let py = slf.py();
+        let any = slf.into_py(py);
+        let source_df: Py<PyDataFrame> = any.downcast_bound(py).unwrap().clone().unbind();
         PyRDD {
-            inner: slf.inner.clone(),
+            source_df: Some(source_df),
+            inner: Some(inner),
+            elements: None,
         }
     }
 

--- a/tests/dataframe/test_issue_408_rdd_flatmap.py
+++ b/tests/dataframe/test_issue_408_rdd_flatmap.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import pytest
 
 
-@pytest.mark.skip(reason="Issue #1238: unskip when fixing")
 def test_rdd_flatmap_words(spark) -> None:
     """Reproduce issue #408: df.rdd.flatMap splits lines into words."""
     df = spark.createDataFrame(
@@ -23,7 +22,6 @@ def test_rdd_flatmap_words(spark) -> None:
     ]
 
 
-@pytest.mark.skip(reason="Issue #1238: unskip when fixing")
 def test_rdd_flatmap_empty_iterable(spark) -> None:
     """flatMap with func that sometimes returns empty iterable."""
     df = spark.createDataFrame([(1,), (0,), (2,)], ["x"])
@@ -31,7 +29,6 @@ def test_rdd_flatmap_empty_iterable(spark) -> None:
     assert rdd.collect() == [0, 0, 1]
 
 
-@pytest.mark.skip(reason="Issue #1238: unskip when fixing")
 def test_rdd_flatmap_then_map(spark) -> None:
     """flatMap then map (chaining)."""
     df = spark.createDataFrame([("a b",), ("c",)], ["line"])
@@ -39,7 +36,6 @@ def test_rdd_flatmap_then_map(spark) -> None:
     assert rdd.collect() == ["A", "B", "C"]
 
 
-@pytest.mark.skip(reason="Issue #1238: unskip when fixing")
 def test_rdd_flatmap_empty_rdd(spark) -> None:
     """flatMap on empty DataFrame yields empty RDD."""
     # PySpark cannot infer schema from empty list; use schema explicitly.
@@ -53,7 +49,6 @@ def test_rdd_flatmap_empty_rdd(spark) -> None:
     assert rdd.count() == 0
 
 
-@pytest.mark.skip(reason="Issue #1238: unskip when fixing")
 def test_rdd_flatmap_one_element_per_row(spark) -> None:
     """flatMap with each row mapping to a single-element iterable."""
     df = spark.createDataFrame([(1,), (2,), (3,)], ["x"])
@@ -61,7 +56,6 @@ def test_rdd_flatmap_one_element_per_row(spark) -> None:
     assert rdd.collect() == [10, 20, 30]
 
 
-@pytest.mark.skip(reason="Issue #1238: unskip when fixing")
 def test_rdd_flatmap_tuples_for_pair_ops(spark) -> None:
     """flatMap to (key, value) pairs (e.g. for word count style)."""
     df = spark.createDataFrame([("a b",), ("a c",)], ["line"])
@@ -70,7 +64,6 @@ def test_rdd_flatmap_tuples_for_pair_ops(spark) -> None:
     assert collected == [("a", 1), ("a", 1), ("b", 1), ("c", 1)]
 
 
-@pytest.mark.skip(reason="Issue #1238: unskip when fixing")
 def test_rdd_flatmap_then_filter(spark) -> None:
     """flatMap then filter."""
     df = spark.createDataFrame([("one",), ("two",), ("three",)], ["word"])
@@ -81,7 +74,6 @@ def test_rdd_flatmap_then_filter(spark) -> None:
     assert sorted(rdd.collect()) == ["ONE", "THREE", "TWO", "three"]
 
 
-@pytest.mark.skip(reason="Issue #1238: unskip when fixing")
 def test_rdd_flatmap_then_count_take_first(spark) -> None:
     """flatMap then count(), take(), first()."""
     df = spark.createDataFrame([("x y",), ("z",)], ["line"])
@@ -92,7 +84,6 @@ def test_rdd_flatmap_then_count_take_first(spark) -> None:
     assert rdd.first() == "x"
 
 
-@pytest.mark.skip(reason="Issue #1238: unskip when fixing")
 def test_rdd_flatmap_empty_string_split(spark) -> None:
     """flatMap with empty string split yields no elements for that row."""
     df = spark.createDataFrame([("a b",), ("",), ("c",)], ["line"])
@@ -100,7 +91,6 @@ def test_rdd_flatmap_empty_string_split(spark) -> None:
     assert rdd.collect() == ["a", "b", "c"]
 
 
-@pytest.mark.skip(reason="Issue #1238: unskip when fixing")
 def test_rdd_flatmap_then_reduce(spark) -> None:
     """flatMap then reduce (e.g. sum of all numbers)."""
     df = spark.createDataFrame([(1,), (2,), (3,)], ["x"])
@@ -109,7 +99,6 @@ def test_rdd_flatmap_then_reduce(spark) -> None:
     assert total == (1 + 2 + 2 + 3 + 3 + 4)  # 1,2,2,3,3,4
 
 
-@pytest.mark.skip(reason="Issue #1238: unskip when fixing")
 def test_rdd_flatmap_chain_double_flatmap(spark) -> None:
     """Chained flatMaps: split then each word -> [word, word.upper()]."""
     df = spark.createDataFrame([("ab cd",)], ["line"])
@@ -120,7 +109,6 @@ def test_rdd_flatmap_chain_double_flatmap(spark) -> None:
     assert sorted(rdd.collect()) == sorted(["ab", "AB", "cd", "CD"])
 
 
-@pytest.mark.skip(reason="Issue #1238: unskip when fixing")
 def test_rdd_flatmap_preserves_order(spark) -> None:
     """flatMap preserves order: row order then element order within each row."""
     df = spark.createDataFrame([("1",), ("2",), ("3",)], ["x"])


### PR DESCRIPTION
Fixes https://github.com/eddiethedean/robin-sparkless/issues/1238

**Summary**
- Unskips all 12 tests in `tests/dataframe/test_issue_408_rdd_flatmap.py`.
- Implements a minimal RDD-like API on `df.rdd`: `flatMap`, `map`, `filter`, `collect`, `count`, `take`, `first`, `reduce`, so that `df.rdd.flatMap(lambda row: ...).collect()` and chained transformations work (local, non-distributed).

**Changes (python/src/lib.rs)**
- **PyRDD** now has two representations: (1) dataframe-backed: `source_df` + `inner` (from `df.rdd`), (2) materialized: `elements` (after `flatMap`/`map`/`filter`).
- **flatMap(func)**: collects rows (or elements), calls `func(item)` for each, flattens iterable results into a new RDD.
- **map(func)**, **filter(func)**: same pattern; return new PyRDD with `elements`.
- **collect()**, **count()**, **take(n)**, **first()**, **reduce(func)**: operate on the current elements (collecting from DataFrame when needed).
- **_to_pylist** supports both states so `createDataFrame(rdd, schema)` still works for both dataframe-backed and materialized RDDs.
- **rdd** getter on PyDataFrame now passes `source_df` (Py\<PyDataFrame\>) and `inner` so RDD can collect rows via the existing Row-building logic.

**Testing**
- `tests/dataframe/test_issue_408_rdd_flatmap.py`: all 12 tests pass.
- `tests/dataframe/test_issue_361_createDataFrame_rdd.py`: all 5 tests pass (createDataFrame from df.rdd unchanged).