### PR TITLE
Fix #1236: pow with Column exponent and bitwise NOT

### DIFF
--- a/crates/robin-sparkless-polars/src/column.rs
+++ b/crates/robin-sparkless-polars/src/column.rs
@@ -930,10 +930,21 @@ impl Column {
         Self::from_expr(expr, None)
     }
 
-    /// Logical NOT of a boolean expression column (PySpark `~` on boolean predicates).
-    /// Implemented as `expr == false` so it flows through expr_coerce_to_boolean like other comparisons.
+    /// Logical NOT of a boolean column (PySpark `~` on Column = boolean NOT).
+    /// Fails at execution time if column is not Boolean (#405, #1236); use F.expr("~x") for bitwise NOT on integers.
     pub fn logical_not(&self) -> Column {
-        let expr = self.expr().clone().eq(lit(false));
+        let expr = self.expr().clone().map(
+            move |col| expect_col(crate::udfs::apply_logical_not_boolean_only(col)),
+            |_schema, field| {
+                if field.dtype() == &DataType::Boolean {
+                    Ok(field.clone())
+                } else {
+                    Err(PolarsError::ComputeError(
+                        "logical NOT (~) requires boolean type".into(),
+                    ))
+                }
+            },
+        );
         Self::from_expr(expr, None)
     }
 

--- a/crates/robin-sparkless-polars/src/sql/translator.rs
+++ b/crates/robin-sparkless-polars/src/sql/translator.rs
@@ -1216,6 +1216,10 @@ fn sql_expr_to_polars(
             let e = sql_expr_to_polars(expr, session, df, having_agg_map, having_agg_list)?;
             match op {
                 sqlparser::ast::UnaryOperator::Not => Ok(e.not()),
+                sqlparser::ast::UnaryOperator::BitwiseNot => {
+                    let col = Column::from_expr(e, None);
+                    Ok(functions::bitwise_not(&col).expr().clone())
+                }
                 _ => Err(PolarsError::InvalidOperation(
                     format!("SQL: unsupported unary operator in WHERE: {:?}", op).into(),
                 )),

--- a/crates/robin-sparkless-polars/src/udfs/rest.rs
+++ b/crates/robin-sparkless-polars/src/udfs/rest.rs
@@ -1,6 +1,7 @@
 //! UDF implementations (string, array, map, encoding, date, math, bit, etc.).
 use super::compute_err;
 use chrono::{Datelike, TimeZone};
+use std::ops::Not;
 use chrono_tz::Tz;
 use polars::prelude::*;
 use regex::Regex;
@@ -5440,6 +5441,21 @@ fn parse_str_to_bool(s: &str, strict: bool) -> Option<bool> {
         _ if strict => None, // will error
         _ => None,
     }
+}
+
+/// Logical NOT for boolean columns only (PySpark: ~ on Column is boolean NOT).
+/// Fails with a clear error for numeric/integer columns; use F.expr("~x") for bitwise NOT (#405, #1236).
+pub fn apply_logical_not_boolean_only(column: Column) -> PolarsResult<Option<Column>> {
+    let name = column.field().into_owned().name;
+    let series = column.take_materialized_series();
+    if series.dtype() != &DataType::Boolean {
+        return Err(PolarsError::ComputeError(
+            "PySpark: '~' on Column is boolean NOT; cannot apply to numeric/integer columns. Use F.expr(\"~x\") for bitwise NOT.".into(),
+        ));
+    }
+    let ca = series.bool().map_err(|e| compute_err("logical_not", e))?;
+    let not_ca = ca.not();
+    Ok(Some(Column::new(name, not_ca.into_series())))
 }
 
 /// Apply string-to-boolean cast. Handles string columns; passes through boolean; numeric types

--- a/python/sparkless/sparkless/sql/functions.py
+++ b/python/sparkless/sparkless/sql/functions.py
@@ -189,8 +189,9 @@ def exp(c: ColumnOrName) -> _ColumnType:
     return _col_result(_native_fn("exp")(_as_col(c)))
 
 
-def pow(col1: ColumnOrName, col2: Union[int, float]) -> _ColumnType:
-    return _col_result(_native_fn("pow")(_as_col(col1), int(col2)))
+def pow(col1: ColumnOrName, col2: Union[int, float, _ColumnType]) -> _ColumnType:
+    """Power: col1 ** col2. col2 can be int, float, or Column (e.g. F.lit(2))."""
+    return _col_result(_native_fn("pow")(_as_col(col1), col2))
 
 
 power = pow

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -7648,6 +7648,11 @@ fn exp(column: &PyColumn) -> PyColumn {
 
 #[pyfunction]
 fn pow(column: &PyColumn, exp: &Bound<'_, PyAny>) -> PyResult<PyColumn> {
+    if let Ok(exp_col) = exp.downcast::<PyColumn>() {
+        return Ok(PyColumn {
+            inner: column.inner.pow_with(&exp_col.borrow().inner),
+        });
+    }
     if let Ok(exp_i) = exp.extract::<i64>() {
         return Ok(PyColumn {
             inner: functions::pow(&column.inner, exp_i),
@@ -7665,7 +7670,7 @@ fn pow(column: &PyColumn, exp: &Bound<'_, PyAny>) -> PyResult<PyColumn> {
         });
     }
     Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
-        "pow exponent must be int or float",
+        "pow exponent must be int, float, or Column",
     ))
 }
 

--- a/tests/dataframe/test_issue_405_pow_bitwise.py
+++ b/tests/dataframe/test_issue_405_pow_bitwise.py
@@ -10,7 +10,6 @@ F = _imports.F
 import pytest
 
 
-@pytest.mark.skip(reason="Issue #1236: unskip when fixing")
 def test_pow_column_literal(spark) -> None:
     """col("x") ** 2 and pow(col("x"), 2) give squared values."""
     df = spark.createDataFrame([(3,), (5,)], ["x"])
@@ -26,7 +25,6 @@ def test_pow_column_literal(spark) -> None:
     assert rows2[1]["sq"] == 25
 
 
-@pytest.mark.skip(reason="Issue #1236: unskip when fixing")
 def test_bitwise_not(spark) -> None:
     """PySpark: `~col` is boolean NOT; use SQL `~` for bitwise."""
     df = spark.createDataFrame([(0,), (1,), (5,)], ["x"])


### PR DESCRIPTION
Fixes #1236

**Changes:**
- **pow()**: Accept `Column` as second argument so `F.pow(col, F.lit(2))` and `col ** 2` work (Python + native).
- **logical_not (`~col`)**: Require boolean column; raise on int for PySpark parity (use `F.expr("~x")` for bitwise NOT).
- **F.expr("~x")**: Implement bitwise NOT in SQL translator so `~x` in expressions returns bitwise NOT.

Tests in `tests/dataframe/test_issue_405_pow_bitwise.py` are unskipped and pass:
- `test_pow_column_literal`
- `test_bitwise_not`