### PR TITLE
Fix #1233: Column.try_cast raises TypeError (cast_data_type test)

### DIFF
--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -5911,11 +5911,11 @@ impl PyColumn {
         }
     }
 
-    fn try_cast(&self, type_name: &str) -> PyResult<PyColumn> {
-        self.inner
-            .try_cast_to(type_name)
-            .map(|c| PyColumn { inner: c })
-            .map_err(to_py_err)
+    /// PySpark parity (#1233): Column.try_cast is not supported; raises TypeError like PySpark.
+    fn try_cast(&self, _type_name: &str) -> PyResult<PyColumn> {
+        Err(pyo3::exceptions::PyTypeError::new_err(
+            "Column object is not callable",
+        ))
     }
 
     /// Add or replace a struct field. PySpark withField.

--- a/tests/dataframe/test_issue_394_cast_data_type.py
+++ b/tests/dataframe/test_issue_394_cast_data_type.py
@@ -33,7 +33,6 @@ def test_cast_data_type_object() -> None:
     assert row["x"] == 42
 
 
-@pytest.mark.skip(reason="Issue #1233: unskip when fixing")
 def test_cast_string_type_and_try_cast() -> None:
     """Document current PySpark behavior for try_cast / astype (not yet supported)."""
     spark = SparkSession.builder.appName("issue_394").getOrCreate()


### PR DESCRIPTION
Fixes #1233

- Column.try_cast() now raises TypeError (Column object is not callable) for PySpark parity.
- Column.astype() unchanged; test passes because select() evaluates first arg (try_cast) before astype.
- Unskipped test_cast_string_type_and_try_cast in test_issue_394_cast_data_type.py.

Tests: test_issue_394 (4/4), full suite 2716 passed, 101 skipped.