### PR TITLE
Fix #1231: unskip test_issue_375_flat_map tests

### DIFF
--- a/tests/dataframe/test_issue_375_flat_map.py
+++ b/tests/dataframe/test_issue_375_flat_map.py
@@ -1,10 +1,8 @@
 """Tests for #375: flatMap behavior (PySpark)."""
 
 from __future__ import annotations
-import pytest
 
 
-@pytest.mark.skip(reason="Issue #1231: unskip when fixing")
 def test_flat_map(spark) -> None:
     """PySpark: use RDD.flatMap for row expansion."""
     df = spark.createDataFrame([("a b",), ("c d e",)], ["word"])
@@ -12,7 +10,6 @@ def test_flat_map(spark) -> None:
     assert words == ["a", "b", "c", "d", "e"]
 
 
-@pytest.mark.skip(reason="Issue #1231: unskip when fixing")
 def test_flat_map_empty(spark) -> None:
     """PySpark: flatMap can return empty output."""
     df = spark.createDataFrame([(1,)], ["x"])


### PR DESCRIPTION
Unskips `test_flat_map` and `test_flat_map_empty` in `tests/dataframe/test_issue_375_flat_map.py`.

RDD.flatMap and collect were already implemented (PyRDD in python/src/lib.rs); no sparkless code changes required. Removed unused `pytest` import.

- Verified with `maturin develop` (from python/) and `.venv/bin/python -m pytest tests/dataframe/test_issue_375_flat_map.py -v` (both tests pass).

Closes #1231.