### PR TITLE
Fix #1222: GroupedData.pivot column order and null in values

### DIFF
--- a/crates/robin-sparkless-polars/src/dataframe/aggregations.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/aggregations.rs
@@ -1042,6 +1042,8 @@ impl PivotedGroupedData {
         let lf = self.lf.clone().group_by(by).agg(agg_exprs);
         let mut pl_df = lf.collect()?;
         pl_df = reorder_groupby_columns(&mut pl_df, &self.grouping_cols)?;
+        // PySpark: when values= was provided, column order follows values list (#1222).
+        pl_df = reorder_pivot_columns(&pl_df, &self.grouping_cols, &pivot_vals)?;
         Ok(super::DataFrame::from_polars_with_options(
             pl_df,
             self.case_sensitive,
@@ -1109,6 +1111,7 @@ impl PivotedGroupedData {
         let lf = self.lf.clone().group_by(by).agg(agg_exprs);
         let mut pl_df = lf.collect()?;
         pl_df = reorder_groupby_columns(&mut pl_df, &self.grouping_cols)?;
+        pl_df = reorder_pivot_columns(&pl_df, &self.grouping_cols, &pivot_vals)?;
         Ok(super::DataFrame::from_polars_with_options(
             pl_df,
             self.case_sensitive,
@@ -1484,6 +1487,35 @@ fn null_series_for_dtype(name: &str, n: usize, dtype: &DataType) -> Result<Serie
         _ => Series::new(name, vec![None::<i64>; n]).cast(dtype)?,
     };
     Ok(s)
+}
+
+/// After pivot, ensure columns are grouping_cols then pivot_vals order (PySpark: when values= provided, column order follows values list; #1222).
+fn reorder_pivot_columns(
+    pl_df: &PlDataFrame,
+    grouping_cols: &[String],
+    pivot_vals: &[String],
+) -> Result<PlDataFrame, PolarsError> {
+    let all_cols: std::collections::HashSet<String> = pl_df
+        .get_column_names()
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    let mut order: Vec<&str> = Vec::new();
+    for gc in grouping_cols {
+        if all_cols.contains(gc) {
+            order.push(gc);
+        }
+    }
+    for pv in pivot_vals {
+        if all_cols.contains(pv) {
+            order.push(pv);
+        }
+    }
+    if order.len() == all_cols.len() {
+        pl_df.select(order)
+    } else {
+        Ok(pl_df.clone())
+    }
 }
 
 /// Reorder columns after groupBy to match PySpark order: grouping columns first, then aggregations

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -3837,6 +3837,7 @@ impl PyDataFrame {
             }
             let py_row = row_cls.call((), Some(&kwargs))?;
             py_row.setattr("_fields", output_names.clone())?;
+            py_row.setattr("__fields__", output_names.clone())?;
             py_row.setattr("_schema", py_schema.clone_ref(py))?;
             // PySpark parity: Row has _data_dict for dict-like access in tests (e.g. "full_name" in result[0].__dict__["_data_dict"]).
             py_row.setattr("_data_dict", kwargs.clone())?;
@@ -6524,10 +6525,24 @@ impl PyGroupedData {
     }
 
     #[pyo3(signature = (pivot_col, values=None))]
-    fn pivot(&self, pivot_col: &str, values: Option<Vec<String>>) -> PyPivotedGroupedData {
-        PyPivotedGroupedData {
-            inner: self.inner.pivot(pivot_col, values),
-        }
+    fn pivot(&self, pivot_col: &str, values: Option<&Bound<'_, PyAny>>) -> PyResult<PyPivotedGroupedData> {
+        let rust_values = if let Some(seq) = values {
+            let mut v = Vec::new();
+            for item in seq.iter()? {
+                let item = item?;
+                if item.is_none() {
+                    v.push("null".to_string());
+                } else {
+                    v.push(item.extract::<String>()?);
+                }
+            }
+            Some(v)
+        } else {
+            None
+        };
+        Ok(PyPivotedGroupedData {
+            inner: self.inner.pivot(pivot_col, rust_values),
+        })
     }
 }
 

--- a/tests/dataframe/test_issue_359_groupeddata_pivot.py
+++ b/tests/dataframe/test_issue_359_groupeddata_pivot.py
@@ -59,7 +59,6 @@ def test_group_by_pivot_with_values(spark) -> None:
     assert rows[0]["C"] is None
 
 
-@pytest.mark.skip(reason="Issue #1222: unskip when fixing")
 def test_group_by_pivot_column_order_from_values(spark) -> None:
     """PySpark: when values= is provided, column order follows the values list."""
     df = spark.createDataFrame(
@@ -94,7 +93,6 @@ def test_group_by_pivot_numeric_pivot_column(spark) -> None:
     assert by_k[2]["10"] == 150 and by_k[2]["20"] is None
 
 
-@pytest.mark.skip(reason="Issue #1222: unskip when fixing")
 def test_group_by_pivot_null_in_pivot_column(spark) -> None:
     """PySpark: null in pivot_col becomes a column named 'null'."""
     df = spark.createDataFrame([("A", 1, 10), (None, 1, 20)], ["r", "k", "v"])


### PR DESCRIPTION
Fixes https://github.com/eddiethedean/robin-sparkless/issues/1222

- **Column order**: When `values=` is provided to `pivot()`, result columns now follow the values list order (PySpark parity). Added `reorder_pivot_columns()` and use it after pivot agg/count.
- **Null in values**: Python `pivot(pivot_col, values=["A", None])` now accepts `None` in the list; it is mapped to `"null"` so the pivot column null becomes a column named `"null"`.
- **Row `__fields__`**: `collect()` now sets `__fields__` on each Row so tests that use `getattr(row, "__fields__", [])` get the column names (e.g. `test_group_by_pivot_column_order_from_values`).
- **Tests**: Unskipped `test_group_by_pivot_column_order_from_values` and `test_group_by_pivot_null_in_pivot_column` (no other test changes).

Installed with `maturin develop --release` from `python/` and ran `pytest tests/dataframe/test_issue_359_groupeddata_pivot.py` — all 8 tests pass.