### PR TITLE
Fix #1143: posexplode two-name alias and posexplode_outer

### DIFF
--- a/python/sparkless/sparkless/__init__.py
+++ b/python/sparkless/sparkless/__init__.py
@@ -168,11 +168,12 @@ class _PosexplodeResult(tuple):
         """Alias the two output columns.
 
         PySpark: posexplode(col).alias("pos", "val") – two-name alias.
+        PySpark: posexplode(col).alias() – keeps default names "pos" and "col".
         Sparkless extension: posexplode(col).alias("Value1") – second name defaults to "col".
         """
-        if not names:
-            raise ValueError("alias() requires at least one name")
-        if len(names) == 1:
+        if len(names) == 0:
+            pos_name, val_name = "pos", "col"
+        elif len(names) == 1:
             pos_name = names[0]
             val_name = "col"
         elif len(names) == 2:

--- a/tests/dataframe/test_issue_366_alias_posexplode.py
+++ b/tests/dataframe/test_issue_366_alias_posexplode.py
@@ -24,7 +24,6 @@ class TestIssue366AliasPosexplode:
         process_id = os.getpid()
         return f"{test_name}_{process_id}_{thread_id}"
 
-    @pytest.mark.skip(reason="Issue #366: unskip when fixing posexplode alias")
     def test_posexplode_alias_two_names_select(self, spark):
         """Select with posexplode().alias('Value1', 'Value2') names both columns (PySpark API)."""
         df = spark.createDataFrame(
@@ -44,7 +43,6 @@ class TestIssue366AliasPosexplode:
         assert by_name["Alice"] == [(0, 10), (1, 20)]
         assert by_name["Bob"] == [(0, 30), (1, 40)]
 
-    @pytest.mark.skip(reason="Issue #366: unskip when fixing posexplode alias")
     def test_posexplode_alias_two_names_no_type_error(self, spark):
         """posexplode().alias('pos', 'val') must not raise TypeError (PySpark API)."""
         df = spark.createDataFrame([{"x": [1, 2], "y": "ok"}])
@@ -63,7 +61,6 @@ class TestIssue366AliasPosexplode:
         assert rows[0]["id"] == 1
         assert rows[0]["idx"] == 0 and rows[0]["elem"] == 42
 
-    @pytest.mark.skip(reason="Issue #366: unskip when fixing posexplode alias")
     def test_posexplode_alias_two_names_empty_array(self, spark):
         """Row with empty array yields 0 rows; row with values explodes."""
         df = spark.createDataFrame([{"id": 1, "arr": []}, {"id": 2, "arr": [10, 20]}])
@@ -76,7 +73,6 @@ class TestIssue366AliasPosexplode:
         assert 2 in by_id
         assert by_id[2] == [(0, 10), (1, 20)]
 
-    @pytest.mark.skip(reason="Issue #366: unskip when fixing posexplode alias")
     def test_posexplode_outer_alias_two_names(self, spark):
         """posexplode_outer with two-name alias; null array row produces one row."""
         df = spark.createDataFrame(
@@ -93,7 +89,6 @@ class TestIssue366AliasPosexplode:
         assert (0, 10) in by_id[1] and (1, 20) in by_id[1]
         assert 2 in by_id
 
-    @pytest.mark.skip(reason="Issue #366: unskip when fixing posexplode alias")
     def test_posexplode_alias_select_two_names(self, spark):
         """Select with posexplode().alias('Value1', 'col') runs (PySpark requires 2 aliases)."""
         df = spark.createDataFrame(
@@ -108,7 +103,6 @@ class TestIssue366AliasPosexplode:
         keys = list(rows[0].asDict().keys()) if rows else []
         assert "Name" in keys and "Value1" in keys
 
-    @pytest.mark.skip(reason="Issue #366: unskip when fixing posexplode alias")
     def test_alias_empty_raises(self, spark):
         """alias() with no arguments works (PySpark behavior: keeps default names)."""
         df = spark.createDataFrame([{"Values": [1, 2]}])

--- a/tests/dataframe/test_issue_429_posexplode_no_alias.py
+++ b/tests/dataframe/test_issue_429_posexplode_no_alias.py
@@ -15,11 +15,6 @@ from tests.fixtures.spark_backend import BackendType
 from tests.fixtures.spark_imports import get_spark_imports
 
 
-pytestmark = pytest.mark.skip(
-    reason="Issue #1143: unskip when fixing posexplode alias and posexplode_outer"
-)
-
-
 def test_posexplode_without_alias_no_type_error(spark, spark_backend):
     """posexplode() without alias must not raise TypeError (#429). Uses session fixture."""
     F_backend = get_spark_imports(spark_backend).F


### PR DESCRIPTION
Fixes #1143

**Changes:**
- **Python:** Allow `posexplode(col).alias()` with no arguments (PySpark behavior: keep default names `pos` and `col`). Previously raised `ValueError: alias() requires at least one name`.
- **Tests:** Unskip all tests in `test_issue_366_alias_posexplode.py` and remove module-level skip in `test_issue_429_posexplode_no_alias.py`. No test logic changed.

Two-name alias (`posexplode(col).alias("pos", "val")`) and `posexplode_outer` were already implemented in Rust and Python; the only missing behavior was `alias()` with zero arguments.

All 17 tests in these two files pass.