### PR TITLE
Fix #1210: na.replace reject None as to_replace (PySpark parity)

### DIFF
--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -4611,6 +4611,12 @@ impl PyDataFrame {
         }
 
         let value = value.unwrap();
+        // PySpark: na.replace does not accept None as to_replace; use fillna for nulls (#1210).
+        if to_replace.is_none() {
+            return Err(to_py_err(
+                "na.replace does not accept None as to_replace; use fillna for nulls",
+            ));
+        }
         let old_expr = py_any_to_column(to_replace)?.into_expr();
         let new_expr = py_any_to_column(value)?.into_expr();
         self.inner
@@ -6293,15 +6299,11 @@ impl PyDataFrameNaFunctions {
 
         let value = value.unwrap();
 
-        // to_replace is None: replace null with value (fillna)
+        // PySpark: na.replace does not accept None as to_replace; use fillna for nulls (#1210).
         if to_replace.is_none() {
-            let value_col = py_any_to_column(value)?;
-            return df_ref
-                .inner
-                .na()
-                .fill(value_col.into_expr(), subset_refs)
-                .map(PyDataFrame::wrap)
-                .map_err(to_py_err);
+            return Err(to_py_err(
+                "na.replace does not accept None as to_replace; use fillna for nulls",
+            ));
         }
 
         // to_replace is list and value is list: replace each pair in order

--- a/tests/dataframe/test_issue_287_na_replace.py
+++ b/tests/dataframe/test_issue_287_na_replace.py
@@ -411,7 +411,6 @@ class TestIssue287NAReplace:
         finally:
             spark.stop()
 
-    @pytest.mark.skip(reason="Issue #1210: unskip when fixing")
     def test_na_replace_with_none_values(self):
         """PySpark na.replace does not accept None as to_replace; use fillna for nulls."""
         spark = SparkSession.builder.appName("issue-287").getOrCreate()


### PR DESCRIPTION
Fixes #1210

**Changes**
- **Unskip** `test_na_replace_with_none_values` in `tests/dataframe/test_issue_287_na_replace.py`.
- **python/src/lib.rs**: In both `PyDataFrame::replace` and the NA functions `replace`, raise an error when `to_replace` is `None` instead of treating it as fillna. Message: "na.replace does not accept None as to_replace; use fillna for nulls" (PySpark parity).

**Tests**
- `test_na_replace_with_none_values` — expects `df.na.replace(None, 0, subset=["Value"]).collect()` to raise; now passes.
- `test_na_replace_with_type_coercion` and `test_na_replace_with_mixed_types_in_column` — already passing; no code change.
- All 31 tests in `test_issue_287_na_replace.py` pass.