### PR TITLE
Fix #1209: count(column) counts non-null values (PySpark parity)

### DIFF
--- a/crates/robin-sparkless-polars/src/functions/rest.rs
+++ b/crates/robin-sparkless-polars/src/functions/rest.rs
@@ -7,17 +7,19 @@ use crate::column::Column;
 use polars::prelude::*;
 
 /// Count aggregation (PySpark LongType; cast to Int64 for schema parity #734).
-/// Use len() so we count all rows (including nulls), matching test_arithmetic_with_nulls
-/// and row["count(Value)"] semantics. When the input is "*", output name is "count(1)" for parity.
+/// count(column): count non-null values in that column (PySpark parity, #1209).
+/// count(*): use len() to count all rows per group.
 /// Carries source column for running-window conversion when orderBy is present (#1218).
 pub fn count(col: &Column) -> Column {
     use polars::prelude::len;
 
-    let expr = len().cast(DataType::Int64);
-    let name = if col.name() == "*" {
-        "count(1)".to_string()
+    let (expr, name) = if col.name() == "*" {
+        (len().cast(DataType::Int64), "count(1)".to_string())
     } else {
-        format!("count({})", col.name())
+        (
+            col.expr().clone().count().cast(DataType::Int64),
+            format!("count({})", col.name()),
+        )
     };
     let mut c = Column::from_expr(expr, Some(name));
     c.source_for_running_count = Some(col.name().to_string());

--- a/tests/dataframe/test_issue_286_aggregate_function_arithmetic.py
+++ b/tests/dataframe/test_issue_286_aggregate_function_arithmetic.py
@@ -270,7 +270,6 @@ class TestIssue286AggregateFunctionArithmetic:
         finally:
             spark.stop()
 
-    @pytest.mark.skip(reason="Issue #1209: unskip when fixing")
     def test_arithmetic_with_nulls(self):
         """Test arithmetic operations when aggregate results might be None."""
         spark = SparkSession.builder.appName("issue-286").getOrCreate()


### PR DESCRIPTION
Fixes #1209

**Changes**
- **Unskip** `test_arithmetic_with_nulls` in `tests/dataframe/test_issue_286_aggregate_function_arithmetic.py`.
- **crates/robin-sparkless-polars/src/functions/rest.rs**: For `count(column)` use `col.expr().count()` (count non-null values per group). For `count(*)` keep `len()` (count all rows). Matches PySpark: `count("Value")` excludes nulls.

**Test**
- `test_arithmetic_with_nulls`: Alice has two nulls → count(Value)=0, count+1=1; Bob has one value → count+1=2. All 26 tests in `test_issue_286_aggregate_function_arithmetic.py` pass.