### PR TITLE
Fix #1213: join-different-case left-column test

### DIFF
--- a/tests/dataframe/test_issue_297_join_different_case_select.py
+++ b/tests/dataframe/test_issue_297_join_different_case_select.py
@@ -57,7 +57,6 @@ class TestIssue297JoinDifferentCaseSelect:
         finally:
             spark.stop()
 
-    @pytest.mark.skip(reason="Issue #1213: unskip when fixing")
     def test_join_different_case_select_left_column(self):
         """Test that selecting with different case picks the left DataFrame's column."""
         spark = SparkSession.builder.appName("issue-297").getOrCreate()


### PR DESCRIPTION
Fixes #1213.

- Unskip `TestIssue297JoinDifferentCaseSelect::test_join_different_case_select_left_column` in `tests/dataframe/test_issue_297_join_different_case_select.py`.
- No changes to test expectations or implementation; existing join/select behavior already passes the test file.\n\nAll 14 tests in this file pass locally.
