### PR TITLE
Fix #1204: isnan on string and numeric columns

### DIFF
--- a/crates/robin-sparkless-polars/src/udfs/rest.rs
+++ b/crates/robin-sparkless-polars/src/udfs/rest.rs
@@ -131,10 +131,17 @@ pub fn apply_isnan_pyspark_parity(column: Column) -> PolarsResult<Option<Column>
     let name = column.field().into_owned().name;
     let series = column.take_materialized_series();
     let out = match series.dtype() {
-        DataType::Float32 | DataType::Float64 => series
-            .is_nan()
-            .map_err(|e| compute_err("isnan", e))?
-            .into_series(),
+        DataType::Float32 | DataType::Float64 => {
+            // For numeric columns, PySpark treats only real NaN values as True; None/null is False.
+            let bool_ca = series
+                .is_nan()
+                .map_err(|e| compute_err("isnan", e))?;
+            let out = BooleanChunked::from_iter_options(
+                name.as_str().into(),
+                bool_ca.into_iter().map(|opt_b| Some(opt_b.unwrap_or(false))),
+            );
+            out.into_series()
+        }
         // PySpark special case: string "NaN" is treated as NaN (true), all other strings false.
         // This also covers our JSON serialization path where float NaN becomes the string "nan".
         DataType::String => {

--- a/tests/dataframe/test_issue_263_isnan_string.py
+++ b/tests/dataframe/test_issue_263_isnan_string.py
@@ -39,7 +39,6 @@ class TestIssue263IsnanString:
         result = df.filter(F.isnan(F.col("Value")))
         assert result.collect() == []
 
-    @pytest.mark.skip(reason="Issue #1204: unskip when fixing")
     def test_isnan_on_numeric_column_true_only_for_nan(self, spark):
         df = spark.createDataFrame(
             [
@@ -72,7 +71,6 @@ class TestIssue263IsnanString:
         assert rows[0]["none"] is False
         assert rows[0]["nan"] == math.isnan(float("nan"))
 
-    @pytest.mark.skip(reason="Issue #1204: unskip when fixing")
     def test_isnan_on_string_and_numeric_columns_in_select(self, spark):
         """Ensure isnan() behaves correctly on both string and numeric columns."""
         df = spark.createDataFrame(


### PR DESCRIPTION
Fixes #1204 ([issue](https://github.com/eddiethedean/robin-sparkless/issues/1204)).\n\n**Behavioral fixes**\n- For numeric columns, `F.isnan` now treats only real NaN values as True and returns False for None/null (PySpark parity).\n- For string columns, keep the existing PySpark-like behavior: case-insensitive "NaN" is True; all other strings and None are False.\n\n**Tests**\n- Unskip `test_isnan_on_numeric_column_true_only_for_nan` and `test_isnan_on_string_and_numeric_columns_in_select` in `tests/dataframe/test_issue_263_isnan_string.py`.\n- Test expectations remain unchanged; all 5 isnan tests in this file now pass under sparkless (one additional PySpark-parity test remains skip-if-pyspark-only).