### PR TITLE
Fix #1185: select() with tuple of column names

### DIFF
--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -3391,6 +3391,16 @@ impl PyDataFrame {
             ))
         }
 
+        if cols.len() == 1 {
+            // PySpark: df.select(("a", "b")) is invalid – a tuple of names is not accepted.
+            // Only lists/tuples nested inside are allowed when they contain valid column refs.
+            if let Ok(_tup) = cols.get_item(0)?.downcast::<PyTuple>() {
+                return Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+                    "select() with a single tuple of column names is not supported; use a list instead (e.g. select(['a', 'b']))",
+                ));
+            }
+        }
+
         let mut raw: Vec<ItemOrExprStr> = Vec::with_capacity(cols.len());
         let mut name_boxes: Vec<Box<str>> = Vec::new();
         for item in cols.iter() {

--- a/tests/dataframe/test_issue_202_select_with_list.py
+++ b/tests/dataframe/test_issue_202_select_with_list.py
@@ -66,7 +66,6 @@ class TestIssue202SelectWithList:
         assert rows[2].name == "Charlie"
         assert rows[2].dept == "IT"
 
-    @pytest.mark.skip(reason="Issue #1185: unskip when fixing")
     def test_select_with_tuple_of_column_names_raises(self, spark):
         """
         PySpark select() does not accept a tuple of column names; it raises.


### PR DESCRIPTION
Fixes #1185 ([issue](https://github.com/eddiethedean/robin-sparkless/issues/1185)).\n\n**Behavioral change**\n- Update DataFrame.select implementation to detect the PySpark-invalid pattern of passing a *single tuple of column names* (e.g. `df.select(("name", "salary"))`) and raise a clear `TypeError`, matching PySpark behavior.\n- Lists or nested lists/tuples of valid column references remain supported (e.g. `df.select(["name", "salary"])`).\n\n**Tests**\n- Unskip `test_select_with_tuple_of_column_names_raises` in `tests/dataframe/test_issue_202_select_with_list.py`.\n- No test expectations were modified; after the change, all 5 tests in this file pass under sparkless.