### PR TITLE
Fix #1189: DataFrame.sort tuple input raises NOT_COLUMN_OR_STR

### DIFF
--- a/python/sparkless/sparkless/__init__.py
+++ b/python/sparkless/sparkless/__init__.py
@@ -275,6 +275,29 @@ GroupedData = _GroupedData
 DataFrameReader = _DataFrameReader
 DataFrameWriter = _DataFrameWriter
 
+# Keep a reference to the native DataFrame.sort implementation so we can wrap it
+# without causing recursion when calling via the Python alias.
+_native_dataframe_sort = _DataFrame.sort
+
+
+def _dataframe_sort(self, *cols, ascending=None):
+    """PySpark-compatible DataFrame.sort wrapper.
+
+    PySpark treats a bare tuple of columns passed to sort/orderBy as invalid and raises
+    PySparkTypeError[NOT_COLUMN_OR_STR]. Lists (including df.columns) are accepted.
+    """
+    if len(cols) == 1 and isinstance(cols[0], tuple):
+        # Match PySpark error text used in tests (Issue #1189).
+        raise TypeError(
+            "Argument `col` should be a Column or str (NOT_COLUMN_OR_STR: tuple is not allowed; use a list of columns instead)"
+        )
+    # Delegate everything else to the native implementation (handles lists, *cols, Column, SortOrder, etc.).
+    return _native_dataframe_sort(self, *cols, ascending=ascending)
+
+
+# Attach wrapper so tests calling df.sort(...) go through the PySpark-compatible logic.
+setattr(DataFrame, "sort", _dataframe_sort)
+
 
 # PySpark-style: from sparkless import F, functions, StringType, ...
 def __getattr__(name):

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -4038,17 +4038,22 @@ impl PyDataFrame {
         cols: &Bound<'_, PyTuple>,
         ascending: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<PyDataFrame> {
-        // Flatten: single item may be list/tuple of columns
+        // Flatten: single item may be a list of columns.
+        // IMPORTANT: We intentionally do NOT flatten tuples here.
+        // In PySpark, a bare tuple passed to sort/orderBy (e.g. df.sort(("a", "b")))
+        // raises PySparkTypeError[NOT_COLUMN_OR_STR] instead of being treated like a list.
+        // To match that behavior, tuples are treated as invalid inputs below rather than
+        // silently flattened.
         let mut flat: Vec<Bound<'_, PyAny>> = Vec::new();
         for item in cols.iter() {
             if let Ok(list) = item.downcast::<PyList>() {
                 for sub in list.iter() {
                     flat.push(sub.clone());
                 }
-            } else if let Ok(tup) = item.downcast::<PyTuple>() {
-                for sub in tup.iter() {
-                    flat.push(sub.clone());
-                }
+            } else if item.downcast::<PyTuple>().is_ok() {
+                return Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+                    "Argument `col` should be a Column or str (NOT_COLUMN_OR_STR: tuple is not allowed; use a list of columns instead)",
+                ));
             } else {
                 flat.push(item.clone());
             }

--- a/tests/dataframe/test_issue_214_sort_with_list.py
+++ b/tests/dataframe/test_issue_214_sort_with_list.py
@@ -81,8 +81,6 @@ def test_sort_with_explicit_column_list(spark):
     rows = result.collect()
     assert len(rows) == 3
 
-
-@pytest.mark.skip(reason="Issue #1189: unskip when fixing")
 def test_sort_with_tuple(spark):
     """Tuple input to sort() raises clear error in PySpark (NOT_COLUMN_OR_STR)."""
     df = spark.createDataFrame(


### PR DESCRIPTION
## Summary

- Unskip  in  for issue #1189.
- Add a PySpark-compatible  wrapper so a bare tuple of column names (e.g. ) raises a clear NOT_COLUMN_OR_STR-style error, while list inputs and  still work.
- Keep the native Rust sort/orderBy behavior for all valid inputs; only tuple column lists are rejected.

## Testing

- ============================= test session starts ==============================
platform darwin -- Python 3.10.18, pytest-8.4.2, pluggy-1.6.0 -- /Users/odosmatthews/Documents/coding/robin-sparkless/.venv/bin/python
cachedir: .pytest_cache
hypothesis profile 'ci' -> database=None, deadline=None, print_blob=True, derandomize=True, suppress_health_check=(HealthCheck.too_slow,)
rootdir: /Users/odosmatthews/Documents/coding/robin-sparkless
configfile: pyproject.toml
plugins: xdist-3.8.0, timeout-2.4.0, hypothesis-6.151.9
collecting ... collected 4 items

tests/dataframe/test_issue_214_sort_with_list.py::test_sort_with_list_of_column_names PASSED [ 25%]
tests/dataframe/test_issue_214_sort_with_list.py::test_sort_with_df_columns PASSED [ 50%]
tests/dataframe/test_issue_214_sort_with_list.py::test_sort_with_explicit_column_list PASSED [ 75%]
tests/dataframe/test_issue_214_sort_with_list.py::test_sort_with_tuple PASSED [100%]

============================== 4 passed in 0.14s ===============================
- ============================= test session starts ==============================
platform darwin -- Python 3.10.18, pytest-8.4.2, pluggy-1.6.0
rootdir: /Users/odosmatthews/Documents/coding/robin-sparkless
configfile: pyproject.toml
plugins: xdist-3.8.0, timeout-2.4.0, hypothesis-6.151.9
created: 10/10 workers
10 workers [2818 items]

........ss.....................................s........................ [  2%]
........................................................................ [  5%]
...................s................s...............s...........sssss... [  7%]
................................s....................................... [ 10%]
....s..........................................................s........ [ 12%]
......s.............s............................................s...s.. [ 15%]
...s......................s.s.s....................sss...ss............. [ 17%]
........................................................................ [ 20%]
........................................................................ [ 22%]
....................................s.......s........................... [ 25%]
...s...............s...........................................s........ [ 28%]
........................s............................................... [ 30%]
........................................................................ [ 33%]
........................................................................ [ 35%]
........................................................................ [ 38%]
...s.................................................................... [ 40%]
........................................................................ [ 43%]
................................................s....................s.. [ 45%]
..................................................................s..... [ 48%]
..s..................................................................... [ 51%]
........................................................................ [ 53%]
............................s..........s................................ [ 56%]
........................................................................ [ 58%]
.................................................s...................... [ 61%]
........................................................................ [ 63%]
.........ssss.s......................................................... [ 66%]
........................................................................ [ 68%]
........................................................................ [ 71%]
........................................................................ [ 74%]
........................................................................ [ 76%]
........................................................................ [ 79%]
......................................................................ss [ 81%]
..............s..................................................s.s.... [ 84%]
.....................................................................s.. [ 86%]
.......................................................................s [ 89%]
.s...............ss........s....s....................................... [ 91%]
........................s..............s................................ [ 94%]
........................................................................ [ 97%]
........................................................................ [ 99%]
.....sss..                                                               [100%]
====================== 2755 passed, 63 skipped in 32.46s =======================
