### PR TITLE
Fix #1178: groupBy/rollup/cube with tuple of column names

### DIFF
--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -3998,6 +3998,25 @@ impl PyDataFrame {
 
     #[pyo3(signature = (*cols))]
     fn rollup(&self, cols: &Bound<'_, PyTuple>) -> PyResult<PyCubeRollupData> {
+        // PySpark: rollup(("a", "b")) is invalid – a bare tuple of column-name
+        // strings is not accepted. It raises PySparkTypeError[NOT_COLUMN_OR_STR].
+        if cols.len() == 1 {
+            let item0 = cols.get_item(0)?;
+            if let Ok(tup) = item0.downcast::<PyTuple>() {
+                let mut all_strings = true;
+                for sub in tup.iter() {
+                    if sub.extract::<String>().is_err() {
+                        all_strings = false;
+                        break;
+                    }
+                }
+                if all_strings {
+                    return Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+                        "Argument `col` should be a Column or str (NOT_COLUMN_OR_STR: tuple is not allowed; use a list of columns instead)",
+                    ));
+                }
+            }
+        }
         let names = py_tuple_or_single_to_vec_string(cols)?;
         let refs: Vec<&str> = names.iter().map(|s| s.as_str()).collect();
         self.inner
@@ -4042,6 +4061,25 @@ impl PyDataFrame {
 
     #[pyo3(signature = (*cols))]
     fn cube(&self, cols: &Bound<'_, PyTuple>) -> PyResult<PyCubeRollupData> {
+        // PySpark: cube(("a", "b")) is invalid – a bare tuple of column-name
+        // strings is not accepted. It raises PySparkTypeError[NOT_COLUMN_OR_STR].
+        if cols.len() == 1 {
+            let item0 = cols.get_item(0)?;
+            if let Ok(tup) = item0.downcast::<PyTuple>() {
+                let mut all_strings = true;
+                for sub in tup.iter() {
+                    if sub.extract::<String>().is_err() {
+                        all_strings = false;
+                        break;
+                    }
+                }
+                if all_strings {
+                    return Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+                        "Argument `col` should be a Column or str (NOT_COLUMN_OR_STR: tuple is not allowed; use a list of columns instead)",
+                    ));
+                }
+            }
+        }
         let names = py_tuple_or_single_to_vec_string(cols)?;
         let refs: Vec<&str> = names.iter().map(|s| s.as_str()).collect();
         self.inner
@@ -4062,6 +4100,30 @@ impl PyDataFrame {
 
     #[pyo3(name = "groupBy", signature = (*cols))]
     fn group_by_camel(&self, cols: &Bound<'_, PyTuple>) -> PyResult<PyGroupedData> {
+        // PySpark: groupBy(("a", "b")) is invalid – a bare tuple of column-name
+        // strings is not accepted and raises NOT_COLUMN_OR_STR. Lists (["a","b"])
+        // and tuples/lists of Columns are allowed.
+        if cols.len() == 1 {
+            let item0 = cols.get_item(0)?;
+            if let Ok(tup) = item0.downcast::<PyTuple>() {
+                let mut all_strings = true;
+                for sub in tup.iter() {
+                    if sub.downcast::<PyColumn>().is_ok() || sub.downcast::<PyExprStr>().is_ok() {
+                        all_strings = false;
+                        break;
+                    }
+                    if sub.extract::<String>().is_err() {
+                        all_strings = false;
+                        break;
+                    }
+                }
+                if all_strings {
+                    return Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+                        "Argument `col` should be a Column or str (NOT_COLUMN_OR_STR: tuple is not allowed; use a list of columns instead)",
+                    ));
+                }
+            }
+        }
         let mut specs: Vec<GroupBySpec> = Vec::with_capacity(cols.len());
         for item in cols.iter() {
             for spec in py_group_by_specs(&item)? {

--- a/tests/dataframe/test_groupby_rollup_cube_with_list.py
+++ b/tests/dataframe/test_groupby_rollup_cube_with_list.py
@@ -46,7 +46,6 @@ def test_groupBy_with_list(sample_df):
     assert {"dept": "HR", "year": 2024, "count": 1} in counts
 
 
-@pytest.mark.skip(reason="Issue #1178: unskip when fixing")
 def test_groupBy_with_tuple(sample_df):
     """Test that groupBy() with a tuple of column names raises a clear error (PySpark parity)."""
     with pytest.raises(Exception) as exc_info:
@@ -97,7 +96,6 @@ def test_rollup_with_list(sample_df):
     assert "count" in result.columns
 
 
-@pytest.mark.skip(reason="Issue #1178: unskip when fixing")
 def test_rollup_with_tuple(sample_df):
     """Test that rollup() with a tuple of column names raises a clear error (PySpark parity)."""
     with pytest.raises(Exception) as exc_info:
@@ -133,7 +131,6 @@ def test_cube_with_list(sample_df):
     assert "count" in result.columns
 
 
-@pytest.mark.skip(reason="Issue #1178: unskip when fixing")
 def test_cube_with_tuple(sample_df):
     """Test that cube() with a tuple of column names raises a clear error (PySpark parity)."""
     with pytest.raises(Exception) as exc_info:


### PR DESCRIPTION
Fixes #1178 ([issue](https://github.com/eddiethedean/robin-sparkless/issues/1178)).

**Behavioral changes**
- Update DataFrame.groupBy, DataFrame.rollup, and DataFrame.cube so that calling them with a *single tuple of column-name strings* (e.g. df.groupBy(("dept", "year"))) raises a TypeError containing NOT_COLUMN_OR_STR, matching PySpark’s behavior.
- Lists (e.g. df.groupBy(["dept", "year"])) and nested lists/tuples of Column or expression objects (e.g. df.select(F.posexplode(...)), F.json_tuple(...)) remain supported and are still flattened as before.

**Tests**
- Unskip test_groupBy_with_tuple, test_rollup_with_tuple, and test_cube_with_tuple in tests/dataframe/test_groupby_rollup_cube_with_list.py without changing any assertions.
- All 10 tests in this file now pass, and the full Python test suite passes (2752 passed, 66 skipped).