### PR TITLE
Fix #1142: createDataFrame verifySchema/samplingRatio kwargs

### DIFF
--- a/tests/dataframe/test_issue_372_create_data_frame.py
+++ b/tests/dataframe/test_issue_372_create_data_frame.py
@@ -229,7 +229,6 @@ def test_create_data_frame_dict_column_order_from_schema_not_insertion(spark) ->
 
 
 # ---- Many columns and unicode ----
-@pytest.mark.skip(reason="Issue #1142: unskip when fixing")
 def test_create_data_frame_many_columns(spark) -> None:
     """createDataFrame with many columns (e.g. 15) works."""
     n = 15
@@ -259,7 +258,6 @@ def test_create_data_frame_invalid_row_type_raises(spark) -> None:
         spark.createDataFrame(data)
 
 
-@pytest.mark.skip(reason="Issue #1142: unskip when fixing")
 def test_create_data_frame_mixed_dict_and_list_rows_raises(spark) -> None:
     """First row dict, second row list raises at execution time (shape mismatch)."""
     data = [{"a": 1}, (2,)]


### PR DESCRIPTION
Fixes #1142 ([issue](https://github.com/eddiethedean/robin-sparkless/issues/1142)).\n\n already accepts the PySpark-style keyword arguments  /  and passes them through to the Rust implementation. This PR simply **unskips** the remaining tests that were gated on this issue:\n- \n- \n\nNo test bodies or expectations were changed, and the full Python test suite passes (2752 passed, 66 skipped).