### PR TITLE
Fix #1115: array type strictness and to_date

### DIFF
--- a/crates/robin-sparkless-polars/src/functions/rest.rs
+++ b/crates/robin-sparkless-polars/src/functions/rest.rs
@@ -2577,6 +2577,7 @@ pub fn isnotnull(column: &Column) -> Column {
 /// With no arguments, returns a column of empty arrays (one per row); PySpark parity.
 pub fn array(columns: &[&Column]) -> Result<crate::column::Column, PolarsError> {
     use polars::prelude::*;
+    use std::collections::HashSet;
     if columns.is_empty() {
         // PySpark F.array() with no args: one empty list per row (broadcast literal).
         // Use .first() so the single-row literal is treated as a scalar and broadcasts to frame height.
@@ -2587,6 +2588,8 @@ pub fn array(columns: &[&Column]) -> Result<crate::column::Column, PolarsError> 
         let expr = lit(list_series).first();
         return Ok(crate::column::Column::from_expr(expr, None));
     }
+    // Capture input column names so we can inspect their dtypes in the schema callback.
+    let input_names: Vec<String> = columns.iter().map(|c| c.name().to_string()).collect();
     // Build concat_list expression first, then wrap it in a validation layer that enforces
     // PySpark-style mixed-type rules using the input column dtypes at planning time.
     let exprs: Vec<Expr> = columns.iter().map(|c| c.expr().clone()).collect();
@@ -2594,34 +2597,55 @@ pub fn array(columns: &[&Column]) -> Result<crate::column::Column, PolarsError> 
         .map_err(|e| PolarsError::ComputeError(format!("array concat_list: {e}").into()))?;
     let expr = base.map(
         |s| Ok(s),
-        move |_schema, field| {
-            // field is the resulting list field; infer element dtype from it when possible.
-            let elem_dtype = match field.dtype() {
-                DataType::List(inner) => inner.as_ref().clone(),
-                other => other.clone(),
+        move |schema, field| {
+            // Derive categories from the input column dtypes. We ignore literals/expressions
+            // that don't appear in the schema so F.array(F.lit(...)) continues to work.
+            let mut cats: HashSet<&'static str> = HashSet::new();
+            for name in &input_names {
+                if let Some(f) = schema.get(name.as_str()) {
+                    let dt = f.data_type();
+                    let cat = match dt {
+                        DataType::Int8
+                        | DataType::Int16
+                        | DataType::Int32
+                        | DataType::Int64
+                        | DataType::UInt8
+                        | DataType::UInt16
+                        | DataType::UInt32
+                        | DataType::UInt64
+                        | DataType::Float32
+                        | DataType::Float64 => "numeric",
+                        DataType::String => "string",
+                        DataType::Boolean => "bool",
+                        DataType::Date => "date",
+                        DataType::Datetime(_, _) => "ts",
+                        _ => "other",
+                    };
+                    cats.insert(cat);
+                }
+            }
+            // If we couldn't resolve any input types (e.g. all literals/expressions), fall back
+            // to existing behavior and trust concat_list/Polars upcasting.
+            if cats.is_empty() {
+                return Ok(Field::new(field.name().clone(), field.dtype().clone()));
+            }
+            // Normalize categories: treat Null as absent (not inserted above), and allow
+            // specific combinations:
+            // - Single-category arrays: numeric, string, bool, date, ts
+            // - Date+timestamp together (temporal)
+            // Everything else is considered a mixed-type error (PySpark parity).
+            let mut cat_vec: Vec<&'static str> = cats.iter().copied().collect();
+            cat_vec.sort_unstable();
+            let allowed = match cat_vec.as_slice() {
+                ["bool"] => true,
+                ["date"] => true,
+                ["numeric"] => true,
+                ["string"] => true,
+                ["ts"] => true,
+                ["date", "ts"] => true,
+                _ => false,
             };
-            // Classify element dtype.
-            let is_numeric = matches!(
-                elem_dtype,
-                DataType::Int8
-                    | DataType::Int16
-                    | DataType::Int32
-                    | DataType::Int64
-                    | DataType::UInt8
-                    | DataType::UInt16
-                    | DataType::UInt32
-                    | DataType::UInt64
-                    | DataType::Float32
-                    | DataType::Float64
-            );
-            let is_string = matches!(elem_dtype, DataType::String);
-            let is_bool = matches!(elem_dtype, DataType::Boolean);
-            // PySpark 3.5/4.x: array() rejects clearly mixed element types such as
-            // string+int+bool. We approximate that by treating a boolean-typed array
-            // whose element dtype was inferred alongside strings as invalid. Numeric
-            // mixtures are allowed via upcasting, so we only reject the string+bool
-            // style combinations that surface as Boolean here.
-            if is_bool && !is_numeric && !is_string {
+            if !allowed {
                 return Err(PolarsError::ComputeError(
                     "array() does not support mixed element types".into(),
                 ));

--- a/crates/robin-sparkless-polars/src/functions/rest.rs
+++ b/crates/robin-sparkless-polars/src/functions/rest.rs
@@ -1892,7 +1892,16 @@ pub fn to_date(column: &Column, format: Option<&str>) -> Result<Column, String> 
                 false,
             ))
         },
-        move |_schema, _field| Ok(Field::new(out_name2.clone().into(), DataType::Date)),
+        move |_schema, field| {
+            match field.dtype() {
+                DataType::String | DataType::Date | DataType::Datetime(_, _) | DataType::Null => {
+                    Ok(Field::new(out_name2.clone().into(), DataType::Date))
+                }
+                _ => Err(polars::prelude::PolarsError::ComputeError(
+                    "to_date requires StringType, TimestampType, or DateType input".into(),
+                )),
+            }
+        },
     );
     Ok(Column::from_expr(expr.alias(&out_name), Some(out_name)))
 }
@@ -2578,9 +2587,48 @@ pub fn array(columns: &[&Column]) -> Result<crate::column::Column, PolarsError> 
         let expr = lit(list_series).first();
         return Ok(crate::column::Column::from_expr(expr, None));
     }
+    // Build concat_list expression first, then wrap it in a validation layer that enforces
+    // PySpark-style mixed-type rules using the input column dtypes at planning time.
     let exprs: Vec<Expr> = columns.iter().map(|c| c.expr().clone()).collect();
-    let expr = concat_list(exprs)
+    let base = concat_list(exprs)
         .map_err(|e| PolarsError::ComputeError(format!("array concat_list: {e}").into()))?;
+    let expr = base.map(
+        |s| Ok(s),
+        move |_schema, field| {
+            // field is the resulting list field; infer element dtype from it when possible.
+            let elem_dtype = match field.dtype() {
+                DataType::List(inner) => inner.as_ref().clone(),
+                other => other.clone(),
+            };
+            // Classify element dtype.
+            let is_numeric = matches!(
+                elem_dtype,
+                DataType::Int8
+                    | DataType::Int16
+                    | DataType::Int32
+                    | DataType::Int64
+                    | DataType::UInt8
+                    | DataType::UInt16
+                    | DataType::UInt32
+                    | DataType::UInt64
+                    | DataType::Float32
+                    | DataType::Float64
+            );
+            let is_string = matches!(elem_dtype, DataType::String);
+            let is_bool = matches!(elem_dtype, DataType::Boolean);
+            // PySpark 3.5/4.x: array() rejects clearly mixed element types such as
+            // string+int+bool. We approximate that by treating a boolean-typed array
+            // whose element dtype was inferred alongside strings as invalid. Numeric
+            // mixtures are allowed via upcasting, so we only reject the string+bool
+            // style combinations that surface as Boolean here.
+            if is_bool && !is_numeric && !is_string {
+                return Err(PolarsError::ComputeError(
+                    "array() does not support mixed element types".into(),
+                ));
+            }
+            Ok(Field::new(field.name().clone(), field.dtype().clone()))
+        },
+    );
     Ok(crate::column::Column::from_expr(expr, None))
 }
 

--- a/crates/robin-sparkless-polars/src/session/mod.rs
+++ b/crates/robin-sparkless-polars/src/session/mod.rs
@@ -787,6 +787,31 @@ fn json_value_to_series_single(
                 .cast(&DataType::Datetime(TimeUnit::Microseconds, None))?;
             Ok(s)
         }
+        // MapType element: map<key_type,value_type> where value is a JSON object.
+        (JsonValue::Object(obj), t) if parse_map_key_value_types(t).is_some() => {
+            let (key_type, value_type) =
+                parse_map_key_value_types(t).expect("guard ensures Some");
+            let key_dtype = json_type_str_to_polars(&key_type).ok_or_else(|| {
+                PolarsError::ComputeError(
+                    format!("map key type '{key_type}' not supported").into(),
+                )
+            })?;
+            let value_dtype = json_type_str_to_polars(&value_type).ok_or_else(|| {
+                PolarsError::ComputeError(
+                    format!("map value type '{value_type}' not supported").into(),
+                )
+            })?;
+            json_object_to_map_struct_series(obj, &key_type, &value_type, &key_dtype, &value_dtype, name)
+        }
+        // StructType element: struct<field1:type1,...> where value is JSON object/array.
+        (JsonValue::Object(_) | JsonValue::Array(_), t) if parse_struct_fields(t).is_some() => {
+            let fields = parse_struct_fields(t).expect("guard ensures Some");
+            // json_object_or_array_to_struct_series returns Option<Series>; None means null.
+            match json_object_or_array_to_struct_series(value, &fields, name)? {
+                Some(s) => Ok(s),
+                None => Ok(Series::new_null(name.into(), 1)),
+            }
+        }
         _ => Err(PolarsError::ComputeError(
             format!("json_value_to_series: unsupported {type_str} for {value:?}").into(),
         )),

--- a/python/sparkless/sparkless/sql/functions.py
+++ b/python/sparkless/sparkless/sql/functions.py
@@ -1245,6 +1245,10 @@ def concat_ws(separator, *cols):
 
 def array(*cols):
     """Create array column from columns (PySpark array)."""
+    # PySpark: F.array(()) is invalid and raises; empty tuple is typically a user error.
+    # Match that behavior so tests expecting an exception on F.array(()) pass.
+    if len(cols) == 1 and isinstance(cols[0], tuple) and len(cols[0]) == 0:
+        raise TypeError("array() does not accept an empty tuple argument")
     return _array(*[_as_col(c) for c in cols])
 
 
@@ -1362,7 +1366,10 @@ def size(column):
 def array_contains(column, value):
     """True if array contains value (PySpark array_contains). value can be column name, Column, or literal."""
     if isinstance(value, str):
-        v = col(value)
+        # PySpark treats bare strings as literals for the value parameter when the column is
+        # an array column, e.g. array_contains(col("tags"), "python"). For join conditions,
+        # callers should pass Column objects explicitly so we don't rely on name lookup here.
+        v = lit(value)
         return _array_contains(_as_col(column), v)
     if isinstance(value, _Column):  # Column argument, e.g. join condition
         # Implement via arrays_overlap(array_col, array(value_col)) so we avoid list.eval on named columns.

--- a/tests/dataframe/test_issue_367_array_empty.py
+++ b/tests/dataframe/test_issue_367_array_empty.py
@@ -116,7 +116,6 @@ class TestIssue367ArrayEmpty:
         for row in rows:
             assert row["arr"] == []
 
-    @pytest.mark.skip(reason="Issue #1115: unskip when fixing")
     def test_array_empty_tuple_raises_like_pyspark(self, spark):
         """F.array(()) raises in Sparkless (matches PySpark, which rejects tuple)."""
         from tests.fixtures.spark_imports import get_spark_imports

--- a/tests/dataframe/test_type_strictness.py
+++ b/tests/dataframe/test_type_strictness.py
@@ -91,7 +91,6 @@ class TestTypeStrictness:
         result = df.withColumn("parsed", F.to_timestamp(F.col("date_str")))
         assert result is not None
 
-    @pytest.mark.skip(reason="Issue #1115: unskip when fixing")
     def test_to_date_requires_string_or_date(self, spark):
         """to_date with IntegerType column must raise (PySpark: unsupported type)."""
         schema = StructType([StructField("date", IntegerType(), True)])

--- a/tests/unit/spark_types/test_array_type_robust.py
+++ b/tests/unit/spark_types/test_array_type_robust.py
@@ -108,7 +108,6 @@ class TestArrayTypeRobust:
         rows = df.collect()
         assert rows[0]["triple"] == [[[1, 2], [3, 4]], [[5, 6], [7, 8]]]
 
-    @pytest.mark.skip(reason="Issue #1115: unskip when fixing")
     def test_array_type_elementtype_with_map_type(self, spark):
         """Test ArrayType with elementType as MapType."""
         schema = StructType(
@@ -131,7 +130,6 @@ class TestArrayTypeRobust:
         assert rows[0]["map_array"][0]["key1"] == 1
         assert rows[0]["map_array"][1]["key3"] == 3
 
-    @pytest.mark.skip(reason="Issue #1115: unskip when fixing")
     def test_array_type_elementtype_with_struct_type(self, spark):
         """Test ArrayType with elementType as StructType."""
         element_struct = StructType(
@@ -272,7 +270,6 @@ class TestArrayTypeRobust:
         rows2 = result2.collect()
         assert rows2[0]["size"] == 5
 
-    @pytest.mark.skip(reason="Issue #1115: unskip when fixing")
     def test_array_type_elementtype_with_filter_operation(self, spark):
         """Test ArrayType with elementType in filter operations."""
         schema = StructType(

--- a/tests/unit/test_array_parameter_formats.py
+++ b/tests/unit/test_array_parameter_formats.py
@@ -116,7 +116,6 @@ class TestArrayParameterFormats:
         assert rows[1]["Array-Field-3"] == expected
         assert rows[1]["Array-Field-4"] == expected
 
-    @pytest.mark.skip(reason="Issue #1115: unskip when fixing")
     def test_array_with_mixed_types(self, spark):
         """Test array() with columns of different types."""
         df = spark.createDataFrame(
@@ -252,7 +251,6 @@ class TestArrayParameterFormats:
         assert len(rows) == 1
         assert rows[0]["flags"] == [True, False]
 
-    @pytest.mark.skip(reason="Issue #1115: unskip when fixing")
     def test_array_with_mixed_types_comprehensive(self, spark):
         """Test array() with comprehensive mixed type combinations."""
         df = spark.createDataFrame(
@@ -484,7 +482,6 @@ class TestArrayParameterFormats:
         assert len(rows) == 1
         assert rows[0]["numbers"] == [0, -5, 10]
 
-    @pytest.mark.skip(reason="Issue #1115: unskip when fixing")
     def test_array_all_formats_with_mixed_types(self, spark):
         """Test all array() parameter formats with mixed data types."""
         df = spark.createDataFrame(


### PR DESCRIPTION
## Summary
- Enforce input-type requirements for F.to_date to reject unsupported integer columns, matching PySpark.
- Tighten array() behavior in the Polars backend and Python F.array/F.array_contains wrappers to handle empty-tuple input, literal array_contains values, and ArrayType(elementType=MapType/StructType) JSON conversion.
- Unskip and get the group-11 strictness tests under tests/dataframe, tests/unit, and spark_types passing under the robin backend.

## Test plan
- Installed sparkless into .venv with: python -m venv .venv && source .venv/bin/activate && maturin develop
- Installed pyspark into .venv for PySpark-only example: pip install pyspark
- Ran full Python test suite under .venv with xdist: pytest tests -n 12
