### PR TITLE
Fix #1139: functions.asc_nulls_last and null ordering

### DIFF
--- a/python/sparkless/sparkless/sql/functions.py
+++ b/python/sparkless/sparkless/sql/functions.py
@@ -249,6 +249,21 @@ def log10(c: ColumnOrName) -> _ColumnType:
     return _col_result(_native_fn("log10")(_as_col(c)))
 
 
+def asc_nulls_last(c: ColumnOrName) -> _ColumnType:
+    """Ascending sort order with nulls last (PySpark functions.asc_nulls_last)."""
+    return _as_col(c).asc_nulls_last()
+
+
+def desc_nulls_first(c: ColumnOrName) -> _ColumnType:
+    """Descending sort order with nulls first (PySpark functions.desc_nulls_first)."""
+    return _as_col(c).desc_nulls_first()
+
+
+def desc_nulls_last(c: ColumnOrName) -> _ColumnType:
+    """Descending sort order with nulls last (PySpark functions.desc_nulls_last)."""
+    return _as_col(c).desc_nulls_last()
+
+
 def greatest(*cols: ColumnOrName) -> _ColumnType:
     return _col_result(_native_fn("greatest")(tuple([_as_col(c) for c in cols])))
 

--- a/tests/dataframe/test_issue_327_orderby_ascending.py
+++ b/tests/dataframe/test_issue_327_orderby_ascending.py
@@ -222,7 +222,6 @@ class TestIssue327OrderByAscending:
         finally:
             spark.stop()
 
-    @pytest.mark.skip(reason="Issue #1139: unskip when fixing")
     def test_orderby_with_null_values(self):
         """Test orderBy with null values (explicit nulls last for PySpark)."""
         spark = SparkSession.builder.appName("issue-327").getOrCreate()
@@ -332,7 +331,6 @@ class TestIssue327OrderByAscending:
         finally:
             spark.stop()
 
-    @pytest.mark.skip(reason="Issue #1139: unskip when fixing")
     def test_orderby_mixed_nulls_and_values(self):
         """Test orderBy with mixed null and non-null values (explicit nulls last)."""
         spark = SparkSession.builder.appName("issue-327").getOrCreate()


### PR DESCRIPTION
## Summary
- Add PySpark-style function wrappers , , and  in , delegating to the existing Column methods.
- Unskip Issue #1139 orderBy null-ordering tests in  and get them passing under the robin backend.
- Preserve existing  sort-key helpers (/) while exposing the new null-ordering functions for DataFrame.orderBy.

## Test plan
- Created and activated a virtualenv: .
- Installed build/runtime deps: Requirement already satisfied: maturin in ./.venv/lib/python3.11/site-packages (1.12.6)
Requirement already satisfied: pyspark in ./.venv/lib/python3.11/site-packages (4.1.1)
Requirement already satisfied: py4j<0.10.9.10,>=0.10.9.7 in ./.venv/lib/python3.11/site-packages (from pyspark) (0.10.9.9).
- Built and installed sparkless native extension: Ignoring pytest: markers 'extra == "dev"' don't match your environment
Ignoring pandas: markers 'extra == "dev"' don't match your environment
Ignoring pytest-xdist: markers 'extra == "dev"' don't match your environment
Ignoring hypothesis: markers 'extra == "dev"' don't match your environment
Ignoring pytest-timeout: markers 'extra == "dev"' don't match your environment
Ignoring polars: markers 'extra == "dev"' don't match your environment
Ignoring pyspark: markers 'extra == "pyspark"' don't match your environment
Ignoring delta-spark: markers 'extra == "pyspark"' don't match your environment
✏️ Setting installed package as editable.
- Ran targeted tests for Issue #327 null ordering:
  - ============================= test session starts ==============================
platform darwin -- Python 3.11.14, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/odosmatthews/Documents/coding/robin-sparkless
configfile: pyproject.toml
plugins: xdist-3.8.0
created: 2/2 workers
2 workers [1 item]

.                                                                        [100%]
============================== 1 passed in 0.26s ===============================
  - ============================= test session starts ==============================
platform darwin -- Python 3.11.14, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/odosmatthews/Documents/coding/robin-sparkless
configfile: pyproject.toml
plugins: xdist-3.8.0
created: 2/2 workers
2 workers [1 item]

.                                                                        [100%]
============================== 1 passed in 0.25s ===============================.
