### PR TITLE
Fix #1138: string + string uses numeric semantics with null on non-numeric

### DIFF
--- a/crates/robin-sparkless-polars/src/column.rs
+++ b/crates/robin-sparkless-polars/src/column.rs
@@ -1630,23 +1630,17 @@ impl Column {
     }
 
     /// Add with PySpark-style string/number coercion (used by Python Column operators).
-    /// Schema: when both inputs are string, output is String (so filter col("x") == "y" after
-    /// withColumn(string + string) is not coerced to numeric by coerce_string_numeric_comparisons).
+    /// For string columns, + attempts numeric addition so non-numeric strings become null (issue #1138).
     pub fn add_pyspark(&self, other: &Column) -> Column {
         let args = [other.expr().clone()];
         let expr = self.expr().clone().map_many(
             |cols| expect_col(crate::udfs::apply_pyspark_add(cols)),
             &args,
             |_schema, fields| {
-                let out_dtype = if fields.len() >= 2
-                    && fields[0].dtype == DataType::String
-                    && fields[1].dtype == DataType::String
-                {
-                    DataType::String
-                } else {
-                    DataType::Float64
-                };
-                Ok(Field::new(fields[0].name().clone(), out_dtype))
+                Ok(Field::new(
+                    fields[0].name().clone(),
+                    DataType::Float64,
+                ))
             },
         );
         Self::from_expr(expr, None)

--- a/crates/robin-sparkless-polars/src/udfs/rest.rs
+++ b/crates/robin-sparkless-polars/src/udfs/rest.rs
@@ -3598,51 +3598,11 @@ fn pyspark_binary_arith(
     Ok(Some(Column::new(name, out)))
 }
 
-/// PySpark-style addition: string + string => concat; numeric + numeric => add (Python Column + operator).
+/// PySpark-style addition for Python Column + operator.
+/// For string inputs, PySpark treats + as numeric addition: non-numeric strings become null.
+/// We implement this via pyspark_binary_arith so that all operands are coerced to f64 and
+/// invalid parses become null, matching PySpark behavior from issue #1138.
 pub fn apply_pyspark_add(columns: &mut [Column]) -> PolarsResult<Option<Column>> {
-    if columns.len() < 2 {
-        return Err(PolarsError::ComputeError(
-            "pyspark_add needs two columns".into(),
-        ));
-    }
-    let both_string = columns[0].field().dtype() == &DataType::String
-        && columns[1].field().dtype() == &DataType::String;
-    if both_string {
-        let name = columns[0].field().into_owned().name;
-        let a_s = std::mem::take(&mut columns[0]).take_materialized_series();
-        let b_s = std::mem::take(&mut columns[1]).take_materialized_series();
-        let ca_a = a_s.str().map_err(|e| compute_err("pyspark_add str", e))?;
-        let ca_b = b_s.str().map_err(|e| compute_err("pyspark_add str", e))?;
-        let len_a = ca_a.len();
-        let len_b = ca_b.len();
-        #[allow(clippy::type_complexity)]
-        let (iter_a, iter_b): (
-            Box<dyn Iterator<Item = Option<&str>>>,
-            Box<dyn Iterator<Item = Option<&str>>>,
-        ) = if len_a == 1 && len_b > 1 {
-            let v = ca_a.get(0);
-            (
-                Box::new(std::iter::repeat_n(v, len_b)),
-                Box::new(ca_b.into_iter()),
-            )
-        } else if len_b == 1 && len_a > 1 {
-            let v = ca_b.get(0);
-            (
-                Box::new(ca_a.into_iter()),
-                Box::new(std::iter::repeat_n(v, len_a)),
-            )
-        } else {
-            (Box::new(ca_a.into_iter()), Box::new(ca_b.into_iter()))
-        };
-        let out = StringChunked::from_iter_options(
-            name.as_str().into(),
-            iter_a
-                .zip(iter_b)
-                .map(|(oa, ob)| oa.and_then(|a| ob.map(|b| format!("{a}{b}")))),
-        )
-        .into_series();
-        return Ok(Some(Column::new(name, out)));
-    }
     pyspark_binary_arith(columns, "pyspark_add", |a, b| a + b)
 }
 

--- a/tests/dataframe/test_issue_188_string_concat_cache.py
+++ b/tests/dataframe/test_issue_188_string_concat_cache.py
@@ -21,9 +21,6 @@ class TestStringConcatenationCacheEdgeCases:
         """Use conftest spark fixture."""
         return request.getfixturevalue("spark")
 
-    @pytest.mark.skip(
-        reason="Issue #1138: unskip when fixing string + string (PySpark yields null for non-numeric)"
-    )
     def test_string_concat_with_empty_strings(self, spark):
         """Test string concatenation with empty strings in cached DataFrame."""
         df = spark.createDataFrame([("", ""), ("a", ""), ("", "b")], ["col1", "col2"])
@@ -65,9 +62,6 @@ class TestStringConcatenationCacheEdgeCases:
             and results[2]["concat"] is None
         ), "String concatenation with None values when cached"
 
-    @pytest.mark.skip(
-        reason="Issue #1138: unskip when fixing string + string (PySpark yields null for non-numeric)"
-    )
     def test_nested_string_concat(self, spark):
         """Test nested string concatenation operations in cached DataFrame."""
         df = spark.createDataFrame([("a", "b", "c")], ["col1", "col2", "col3"])
@@ -107,9 +101,6 @@ class TestStringConcatenationCacheEdgeCases:
             "Numeric addition should not be affected by cache"
         )
 
-    @pytest.mark.skip(
-        reason="Issue #1138: unskip when fixing string + string (PySpark yields null for non-numeric)"
-    )
     def test_string_concat_with_literal(self, spark):
         """Test string concatenation with literal strings in cached DataFrame."""
         df = spark.createDataFrame([("John",)], ["name"])
@@ -129,9 +120,6 @@ class TestStringConcatenationCacheEdgeCases:
             "String + literal yields null for non-numeric strings in PySpark"
         )
 
-    @pytest.mark.skip(
-        reason="Issue #1138: unskip when fixing string + string (PySpark yields null for non-numeric)"
-    )
     def test_multiple_string_concat_columns(self, spark):
         """Test multiple string concatenation columns in cached DataFrame."""
         df = spark.createDataFrame(
@@ -153,9 +141,6 @@ class TestStringConcatenationCacheEdgeCases:
         assert result["concat1"] is None, "First string concat column yields null"
         assert result["concat2"] is None, "Second string concat column yields null"
 
-    @pytest.mark.skip(
-        reason="Issue #1138: unskip when fixing string + string (PySpark yields null for non-numeric)"
-    )
     def test_string_concat_with_select(self, spark):
         """Test string concatenation followed by select in cached DataFrame."""
         df = spark.createDataFrame([("a", "b")], ["col1", "col2"])
@@ -175,9 +160,6 @@ class TestStringConcatenationCacheEdgeCases:
         # String concat in select yields null when using + on strings.
         assert result["concat"] is None, "String addition in select yields null"
 
-    @pytest.mark.skip(
-        reason="Issue #1138: unskip when fixing string + string (PySpark yields null for non-numeric)"
-    )
     def test_string_concat_chained_operations(self, spark):
         """Test string concatenation with chained operations in cached DataFrame."""
         df = spark.createDataFrame([("a", "b", "c")], ["col1", "col2", "col3"])
@@ -201,9 +183,6 @@ class TestStringConcatenationCacheEdgeCases:
             "Chained operations yield no rows under PySpark + semantics"
         )
 
-    @pytest.mark.skip(
-        reason="Issue #1138: unskip when fixing string + string (PySpark yields null for non-numeric)"
-    )
     def test_string_concat_without_caching(self, spark):
         """Test that string concatenation works normally without caching."""
         df = spark.createDataFrame([("a", "b")], ["col1", "col2"])


### PR DESCRIPTION
## Summary
- Change the Python Column '+' operator (via add_pyspark/apply_pyspark_add) so that for string inputs it behaves like PySpark numeric addition: non-numeric strings are cast to null instead of being concatenated.
- Remove the special string+string concatenation path in the Polars UDF and always go through pyspark_binary_arith, which coerces inputs to f64 and yields null on invalid parses.
- Unskip and pass the Issue #188 string concatenation cache tests in tests/dataframe/test_issue_188_string_concat_cache.py, which assert that col + col and col + lit(x) on string columns yield nulls for non-numeric strings while F.concat() continues to handle string concatenation.

## Test plan
- Created and activated virtualenv: python -m venv .venv && source .venv/bin/activate.
- Installed build/runtime deps: pip install maturin pyspark.
- Built and installed sparkless native extension: cd python && maturin develop.
- Ran targeted tests for Issue #188: pytest tests/dataframe/test_issue_188_string_concat_cache.py -n 4.
- Ran full Python test suite: pytest tests -n 12.
