### PR TITLE
Fix #1118: robust substring_index and string function edge cases

### DIFF
--- a/crates/robin-sparkless-polars/src/column.rs
+++ b/crates/robin-sparkless-polars/src/column.rs
@@ -1403,6 +1403,14 @@ impl Column {
     /// Substring before/after nth delimiter (PySpark substring_index). count > 0: before nth from left; count < 0: after nth from right.
     pub fn substring_index(&self, delimiter: &str, count: i64) -> Column {
         use polars::prelude::*;
+        // PySpark edge case: empty delimiter always yields empty string for non-null input,
+        // and null when the input is null.
+        if delimiter.is_empty() {
+            let expr = when(self.expr().clone().is_null())
+                .then(lit(NULL))
+                .otherwise(lit("").cast(DataType::String));
+            return Self::from_expr(expr, None);
+        }
         let delim = delimiter.to_string();
         let split_expr = self.expr().clone().str().split(lit(delim.clone()));
         let n = count.unsigned_abs() as i64;

--- a/tests/unit/functions/test_issue_189_string_functions_robust.py
+++ b/tests/unit/functions/test_issue_189_string_functions_robust.py
@@ -50,7 +50,6 @@ class TestIssue189StringFunctionsRobust:
         assert rows[2]["m3"] == ""
         assert rows[2]["m4"] == ""
 
-    @pytest.mark.skip(reason="Issue #1118: unskip when fixing")
     def test_substring_index_edge_cases(self, spark):
         df = spark.createDataFrame(
             [


### PR DESCRIPTION
## Summary
- Unskip the robust substring_index test in `tests/unit/functions/test_issue_189_string_functions_robust.py` and ensure it passes alongside the other string/JSON robustness tests for issue #1118.
- Align `substring_index` behavior with PySpark for the empty-delimiter edge case, while preserving existing semantics for positive/negative counts and missing delimiters.

## Technical details
- **`substring_index` empty-delimiter handling**
  - In `crates/robin-sparkless-polars/src/column.rs`, special-case `delimiter == ""` inside `Column::substring_index`:
    - When the input column is non-null, the result is always an empty string `""` regardless of `count`.
    - When the input is null, the result is null.
  - For non-empty delimiters, the existing logic using `str.split`, list slicing, and `join` is unchanged.
- **Tests**
  - The robust test `TestIssue189StringFunctionsRobust.test_substring_index_edge_cases` now runs without skip and verifies:
    - Correct behavior for `count > 0`, `count < 0`, and `count == 0`.
    - Behavior when the delimiter is missing (returns the original string).
    - Behavior when the delimiter is empty (always `""` for non-null input, `None` for null).
- Other robust tests in `test_issue_189_string_functions_robust.py` (translate, levenshtein, soundex, crc32, xxhash64, get_json_object, json_tuple, regexp_extract_all) already passed and required no engine changes for this issue.

## Testing
- Focused:
  - `pytest tests/unit/functions/test_issue_189_string_functions_robust.py::TestIssue189StringFunctionsRobust::test_substring_index_edge_cases -vv`
- Full module:
  - `pytest tests/unit/functions/test_issue_189_string_functions_robust.py -vv`
- Full Python suite:
  - `pytest tests -n 10`

All tests pass: `2781 passed, 37 skipped`.