### PR TITLE
Fix pivot.agg tests for issue #1117

### DIFF
--- a/crates/robin-sparkless-polars/src/dataframe/aggregations.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/aggregations.rs
@@ -889,10 +889,20 @@ fn pivot_agg_input_column_name(input_expr: &Expr) -> Option<String> {
 /// Supports sum, avg, min, max, count_distinct, first, last, collect_list, stddev, variance (PySpark pivot.agg parity).
 /// When no alias is present, use a default like "sum(salary)" (PySpark parity).
 fn parse_pivot_agg_expr(expr: &Expr) -> Option<(String, &'static str, String)> {
-    let (inner, alias_opt) = match expr {
-        Expr::Alias(inner, name) => (inner.as_ref(), Some(name.as_str().to_string())),
-        other => (other, None),
-    };
+    // Unwrap one or more Alias layers so we see the underlying Agg, keeping the
+    // outermost alias name (PySpark: F.sum(\"v\").alias(\"total\") is often built on
+    // top of a default alias like \"sum(v)\" from the underlying expression).
+    let mut inner = expr;
+    let mut alias_opt: Option<String> = None;
+    loop {
+        match inner {
+            Expr::Alias(e, name) => {
+                alias_opt = Some(name.as_str().to_string());
+                inner = e.as_ref();
+            }
+            _ => break,
+        }
+    }
     // Unwrap Cast so we see Agg (e.g. count_distinct returns Cast(NUnique(...), Int64))
     let inner = match inner {
         Expr::Cast { expr: e, .. } => e.as_ref(),

--- a/tests/unit/dataframe/test_pivot_grouped_data.py
+++ b/tests/unit/dataframe/test_pivot_grouped_data.py
@@ -311,7 +311,6 @@ class TestPivotGroupedData:
         assert row_b["A"] is None
         assert row_b["B"] == 5.0
 
-    @pytest.mark.skip(reason="Issue #1117: unskip when fixing")
     def test_pivot_multiple_aggregates(self, spark, sample_data):
         """Test pivot with multiple aggregate expressions."""
         df = spark.createDataFrame(sample_data)
@@ -332,7 +331,6 @@ class TestPivotGroupedData:
         assert "B_total" in schema_names
         assert "B_avg_val" in schema_names
 
-    @pytest.mark.skip(reason="Issue #1117: unskip when fixing")
     def test_pivot_single_aggregate_with_alias(self, spark, sample_data):
         """Test pivot with single aggregate expression with alias."""
         df = spark.createDataFrame(sample_data)


### PR DESCRIPTION
## Summary

- Unskip pivot tests from [issue #1117](https://github.com/eddiethedean/robin-sparkless/issues/1117):
  - tests/dataframe/test_issue_215_row_kwargs_init.py::test_row_kwargs_with_createDataFrame (already passing on main, re-verified here)
  - tests/unit/dataframe/test_pivot_grouped_data.py::TestPivotGroupedData::test_pivot_multiple_aggregates
  - tests/unit/dataframe/test_pivot_grouped_data.py::TestPivotGroupedData::test_pivot_single_aggregate_with_alias
- Fix Rust pivot parser so pivot().agg(...) accepts aliased aggregate expressions like F.sum(value).alias(total) and F.avg(value).alias(avg_val), matching GroupedData.agg behavior and PySpark parity.

## Technical details

- Update parse_pivot_agg_expr in crates/robin-sparkless-polars/src/dataframe/aggregations.rs to unwrap one or more Expr::Alias layers before inspecting the underlying Expr::Agg:
  - This handles the case where the Column expression already has a default alias like "sum(value)" and a user-applied alias "total" wraps it again, resulting in nested Alias(Alias(Agg(...))).
  - The outermost alias name is preserved as the pivot output base name, as expected by the tests.
- Existing pivot behavior for single vs multiple expressions is unchanged:
  - Single sum/avg/min/max with alias -> one output column using the alias (e.g. "total").
  - Multiple expressions with aliases -> one column per (pivot value, alias) pair with names like "A_total", "A_avg_val", "B_total", "B_avg_val".

## Testing

- source .venv/bin/activate && pytest     tests/unit/dataframe/test_pivot_grouped_data.py::TestPivotGroupedData::test_pivot_multiple_aggregates     tests/unit/dataframe/test_pivot_grouped_data.py::TestPivotGroupedData::test_pivot_single_aggregate_with_alias -vv
- source .venv/bin/activate && pytest     tests/dataframe/test_issue_215_row_kwargs_init.py::test_row_kwargs_with_createDataFrame -vv
