### PR TITLE
Unskip passing expression tests for issue #1116

### DIFF
--- a/tests/unit/dataframe/test_string_arithmetic.py
+++ b/tests/unit/dataframe/test_string_arithmetic.py
@@ -137,7 +137,6 @@ class TestStringArithmetic:
         assert rows[0]["result"] == 1.0  # 10 % 3
         assert rows[1]["result"] == 1.0  # 7 % 3
 
-    @pytest.mark.skip(reason="Issue #1116: unskip when fixing")
     def test_string_arithmetic_with_string_column(self, spark):
         """Test arithmetic operations between two string columns."""
         schema = StructType(
@@ -229,7 +228,6 @@ class TestStringArithmetic:
         result_field = next(f for f in result.schema.fields if f.name == "result")
         assert isinstance(result_field.dataType, DoubleType)
 
-    @pytest.mark.skip(reason="Issue #1116: unskip when fixing")
     def test_string_arithmetic_chained_operations(self, spark):
         """Test chained arithmetic operations with string columns."""
         schema = StructType(
@@ -581,7 +579,6 @@ class TestStringArithmetic:
         assert rows[0]["result"] == 5.0  # -0 + 5
         assert rows[1]["result"] == 5.0  # -0.0 + 5
 
-    @pytest.mark.skip(reason="Issue #1116: unskip when fixing")
     def test_string_arithmetic_complex_expression(self, spark):
         """Test complex nested arithmetic expressions with strings."""
         schema = StructType(


### PR DESCRIPTION
## Summary

- Unskip expression-related tests tracked in [issue #1116](https://github.com/eddiethedean/robin-sparkless/issues/1116):
  - \
  - \
  - \
- All tests listed in the issue (isin negation, between on string, log with float/int base, date vs datetime comparison, string arithmetic) currently pass with the existing implementation; only the three string arithmetic tests were still marked skipped.

## Technical details

- No engine or library changes were required for this issue; behavior already matches the documented PySpark semantics for:
  - \ with string vs int list.
  - \ on string columns with numeric bounds.
  - \ with float/int base and natural log \.
  - Date vs datetime comparisons in filters and combined conditions.
  - String arithmetic (string vs numeric, string vs string) including chained and complex expressions.
- The PR simply removes the \ decorators from the three string arithmetic tests now confirmed to pass.

## Testing

- source .venv/bin/activate && pytest \
    tests/dataframe/test_issue_369_isin_negation.py::TestIssue369IsinNegation::test_negation_isin_show \
    tests/dataframe/test_issue_369_isin_negation.py::TestIssue369IsinNegation::test_negation_isin_string_column_int_list \
    tests/dataframe/test_issue_369_isin_negation.py::TestIssue369IsinNegation::test_negation_isin_string_to_string \
    tests/dataframe/test_issue_445_between_string_column_numeric_bounds.py::test_between_string_column_not_between \
    tests/dataframe/test_issue_329_log_float_constant.py::TestIssue329LogFloatConstant::test_log_with_float_base \
    tests/dataframe/test_issue_329_log_float_constant.py::TestIssue329LogFloatConstant::test_log_with_int_base \
    tests/dataframe/test_issue_329_log_float_constant.py::TestIssue329LogFloatConstant::test_log_natural_log \
    tests/dataframe/test_issue_329_log_float_constant.py::TestIssue329LogFloatConstant::test_log_with_different_bases \
    tests/dataframe/test_issue_329_log_float_constant.py::TestIssue329LogFloatConstant::test_log_with_null_values \
    tests/dataframe/test_issue_329_log_float_constant.py::TestIssue329LogFloatConstant::test_log_in_with_column \
    tests/dataframe/test_issue_329_log_float_constant.py::TestIssue329LogFloatConstant::test_log_edge_cases \
    tests/dataframe/test_issue_431_date_datetime_comparison.py::test_date_datetime_with_and \
    tests/dataframe/test_issue_431_date_datetime_comparison.py::test_date_eq_datetime \
    tests/dataframe/test_issue_431_date_datetime_comparison.py::test_date_less_than_datetime \
    tests/dataframe/test_issue_431_date_datetime_comparison.py::test_date_lte_datetime \
    tests/dataframe/test_issue_431_date_datetime_comparison.py::test_date_ne_datetime \
    tests/dataframe/test_issue_431_date_datetime_comparison.py::test_datetime_less_than_date \
    tests/unit/dataframe/test_string_arithmetic.py::TestStringArithmetic::test_string_arithmetic_chained_operations \
    tests/unit/dataframe/test_string_arithmetic.py::TestStringArithmetic::test_string_arithmetic_complex_expression \
    tests/unit/dataframe/test_string_arithmetic.py::TestStringArithmetic::test_string_arithmetic_with_string_column -vv
- source .venv/bin/activate && pytest tests -n 10
