### PR TITLE
Fix #1326: enable parity filter boolean tests

### DIFF
--- a/tests/parity/dataframe/test_filter.py
+++ b/tests/parity/dataframe/test_filter.py
@@ -54,7 +54,6 @@ class TestFilterParity(ParityTestBase):
         assert rows[0]["a"] == 2
         assert rows[0]["b"] == 3
 
-    @pytest.mark.skip(reason="Tracked in issue #1326; unskip when fixed.")
     def test_filter_with_or_operator(self, spark):
         """Test filter with combined expressions using | (OR) operator.
 

--- a/tests/parity/dataframe/test_filter_isinstance_ordering.py
+++ b/tests/parity/dataframe/test_filter_isinstance_ordering.py
@@ -260,7 +260,6 @@ class TestIsInstanceOrdering(ParityTestBase):
         result3 = read_df.filter(read_df.name.startswith("A"))
         assert result3.count() == 1, "String operations should work on table DataFrames"
 
-    @pytest.mark.skip(reason="Tracked in issue #1326; unskip when fixed.")
     def test_logical_operations_in_filters(self, spark):
         """Test that logical operations (AND, OR) work correctly.
 


### PR DESCRIPTION
## Summary

- Unskip the two PySpark parity tests that cover boolean coercion and logical OR/AND semantics in `DataFrame.filter()`.
- Verified that both tests now pass using the `sparkless` package installed into `.venv` via `maturin develop`, confirming that the underlying Rust engine changes already match PySpark behavior.

## Details

Issue #1326 tracked failing parity tests when combining comparison expressions with `&` and `|` in filter predicates. Recent engine work on `expr_coerce_to_boolean` and the filter pipeline has corrected the behavior so that combined predicates remain Boolean and are accepted by Polars.

This PR simply removes the `@pytest.mark.skip` decorators from:

- `tests/parity/dataframe/test_filter.py::TestFilterParity::test_filter_with_or_operator`
- `tests/parity/dataframe/test_filter_isinstance_ordering.py::TestIsInstanceOrdering::test_logical_operations_in_filters`

No other test changes were made.

## Testing

- Created `.venv` and installed `sparkless` via `maturin develop` in `python/`.
- Ran the previously skipped tests with the venv:
  - `.venv/bin/python -m pytest tests/parity/dataframe/test_filter.py::TestFilterParity::test_filter_with_or_operator tests/parity/dataframe/test_filter_isinstance_ordering.py::TestIsInstanceOrdering::test_logical_operations_in_filters -v`
- Both tests passed.