### PR TITLE
Fix #1324: enable string vs numeric/datetime parity tests

### DIFF
--- a/tests/dataframe/test_issue_139_datetime_validation_compatibility.py
+++ b/tests/dataframe/test_issue_139_datetime_validation_compatibility.py
@@ -83,7 +83,6 @@ class TestIssue139DatetimeValidationCompatibility:
         finally:
             spark.stop()
 
-    @pytest.mark.skip(reason="Tracked in issue #1324; unskip when fixed.")
     def test_validation_with_datetime_comparison(self):
         """Test validation with datetime column comparisons."""
         spark = SparkSession.builder.appName("BugRepro").getOrCreate()

--- a/tests/dataframe/test_issue_164_schema_inference_numeric.py
+++ b/tests/dataframe/test_issue_164_schema_inference_numeric.py
@@ -15,7 +15,6 @@ F = _imports.F
 class TestIssue164SchemaInferenceNumeric:
     """Test cases for issue #164: schema inference for numeric types."""
 
-    @pytest.mark.skip(reason="Tracked in issue #1324; unskip when fixed.")
     def test_schema_inference_for_numeric_columns(self):
         """Test that numeric columns are inferred as numeric types, not strings."""
         spark = SparkSession.builder.appName("test").getOrCreate()
@@ -49,7 +48,6 @@ class TestIssue164SchemaInferenceNumeric:
 
         spark.stop()
 
-    @pytest.mark.skip(reason="Tracked in issue #1324; unskip when fixed.")
     def test_schema_inference_for_integer_columns(self):
         """Test that integer columns are inferred as LongType, not strings."""
         spark = SparkSession.builder.appName("test").getOrCreate()
@@ -76,7 +74,6 @@ class TestIssue164SchemaInferenceNumeric:
 
         spark.stop()
 
-    @pytest.mark.skip(reason="Tracked in issue #1324; unskip when fixed.")
     def test_schema_inference_mixed_types(self):
         """Test that schema inference works correctly for mixed types."""
         spark = SparkSession.builder.appName("test").getOrCreate()

--- a/tests/dataframe/test_issue_419_filter_in_or_parse_exception.py
+++ b/tests/dataframe/test_issue_419_filter_in_or_parse_exception.py
@@ -166,7 +166,6 @@ class TestIssue419FilterInOrParseException:
         codes = {r["Code"] for r in rows}
         assert codes == {"A", "B", "C"}
 
-    @pytest.mark.skip(reason="Tracked in issue #1324; unskip when fixed.")
     def test_filter_in_or_with_show(self, spark):
         """IN + OR with show() - regression for full pipeline."""
         df = spark.createDataFrame(

--- a/tests/dataframe/test_issue_445_between_string_column_numeric_bounds.py
+++ b/tests/dataframe/test_issue_445_between_string_column_numeric_bounds.py
@@ -19,7 +19,6 @@ from tests.fixtures.spark_imports import get_spark_imports
 import pytest
 
 
-@pytest.mark.skip(reason="Tracked in issue #1324; unskip when fixed.")
 def test_between_string_column_numeric_bounds_exact_issue_445(spark, spark_backend):
     """Exact scenario from #445 - string column with numeric bounds."""
     F = get_spark_imports(spark_backend).F
@@ -215,7 +214,6 @@ def test_between_string_column_negative_numbers(spark, spark_backend):
     assert rows[0]["val"] == "-5"
 
 
-@pytest.mark.skip(reason="Tracked in issue #1324; unskip when fixed.")
 def test_between_string_column_then_orderby(spark, spark_backend):
     """Filter with between then orderBy."""
     F = get_spark_imports(spark_backend).F


### PR DESCRIPTION
## Summary

- Unskip the PySpark parity tests that cover string vs numeric and datetime comparisons, BETWEEN on string columns with numeric bounds, and IN + OR filter behavior.
- Confirm that these tests now pass against the existing engine coercion pipeline, meaning the underlying Rust changes for string/numeric and datetime comparison handling are already in place.

## Details

Issue [#1324](https://github.com/eddiethedean/robin-sparkless/issues/1324) tracks a set of parity tests that were previously skipped because string vs numeric or datetime comparisons raised engine errors instead of matching PySpark semantics.

Recent work in `coerce_string_numeric_comparisons` and `coerce_for_pyspark_comparison` has implemented the intended behavior:

- String columns compared to numeric literals (e.g. `>= 0`, `between(1, 10)`) are handled via `try_to_number`-style coercion so that parsable strings are compared numerically and invalid strings behave like null / non-matching rows.
- Datetime comparisons where a `TimestampType` column is compared to Python `datetime` values are treated as proper timestamp literals before reaching Polars, avoiding string-vs-datetime errors.
- BETWEEN on string columns with numeric bounds, including usage inside `when/otherwise` and chained with `orderBy`, now behaves like PySpark.

This PR only removes the `@pytest.mark.skip` decorators; the tests themselves remain unchanged and now pass.

## Tests

Ran the previously skipped tests using the `.venv` environment with `sparkless` installed via `maturin develop`:

- `.venv/bin/python -m pytest tests/dataframe/test_issue_164_schema_inference_numeric.py tests/dataframe/test_issue_139_datetime_validation_compatibility.py::TestIssue139DatetimeValidationCompatibility::test_validation_with_datetime_comparison tests/dataframe/test_issue_419_filter_in_or_parse_exception.py::TestIssue419FilterInOrParseException::test_filter_in_or_with_show tests/dataframe/test_issue_445_between_string_column_numeric_bounds.py -v --tb=short`

All 21 tests passed.