### PR TITLE
Fix alias and case-sensitive column resolution for joins

### DIFF
--- a/crates/robin-sparkless-polars/src/dataframe/joins.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/joins.rs
@@ -744,11 +744,12 @@ pub fn join(
     } else {
         result_lf
     };
-    // When we coalesced same-named columns, result has one column per logical name; do not mark
-    // any as ambiguous so select(df1["age"]) works (#297).
-    let ambiguous_columns = if did_coalesce_same_name_columns {
-        None
-    } else if keys_match_for_coalesce && mark_join_keys_ambiguous {
+    // When mark_join_keys_ambiguous is true (condition join on same-named keys), unqualified
+    // references to those key names must be treated as ambiguous (PySpark parity #1230 /
+    // issue #374), regardless of whether we coalesced the physical columns. Column-name
+    // joins (on = "id") never set mark_join_keys_ambiguous, so df1["age"] continues to work
+    // after coalescing same-named columns (#297).
+    let ambiguous_columns = if mark_join_keys_ambiguous {
         Some(left_key_names.iter().cloned().collect::<HashSet<String>>())
     } else {
         None

--- a/crates/robin-sparkless-polars/src/dataframe/transformations.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/transformations.rs
@@ -522,15 +522,26 @@ pub fn filter(
     // the predicate is effectively pushed below the projection while the visible columns stay
     // unchanged (issue #1135 / #158). In case-sensitive mode we keep raising unresolved_column
     // so wrong-case filters continue to fail as expected.
+    //
+    // Do not treat alias-qualified or dotted names (e.g. "o.amount", "t1.id", "struct.field")
+    // as missing here: those may still resolve via suffix/struct-field logic in
+    // resolve_expr_column_names and are required for join alias and case-insensitive parity
+    // (issue #1325).
     if !case_sensitive {
         if let Ok(cols) = df.columns() {
             let df_cols: HashSet<String> =
                 cols.into_iter().map(|c| c.to_lowercase()).collect();
             let referenced = expr_referenced_columns(&condition);
             if !referenced.is_empty() {
-                let all_missing = referenced
-                    .iter()
-                    .all(|name| !df_cols.contains(&name.to_lowercase()));
+                let all_missing = referenced.iter().all(|name| {
+                    if name.contains('.') {
+                        // Alias-qualified or dotted reference: let resolve_expr_column_names
+                        // attempt to resolve it (join aliases, struct fields, etc.).
+                        false
+                    } else {
+                        !df_cols.contains(&name.to_lowercase())
+                    }
+                });
                 if all_missing {
                     return Ok(df.clone());
                 }

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -4544,12 +4544,16 @@ impl PyDataFrame {
                             )
                             .map_err(to_py_err)?;
 
-                        // When the expression is only key equalities, the join already enforces them;
-                        // do not filter afterward or left/right/outer would lose unmatched rows (#1242),
-                        // except for the LEFT/RIGHT-as-OUTER case handled below.
-                        // When the expression is compound (e.g. key equality AND filter), reapply the
-                        // full predicate after the key-based join (issue #380).
-                        if !expr_contains_only_join_key_equalities(&expr) {
+                        // When the expression is only key equalities, the join itself already
+                        // enforces the predicate; applying filter(expr) would be redundant and,
+                        // for LEFT/RIGHT/OUTER joins, would drop unmatched rows and break join
+                        // semantics (#1242). For compound predicates (e.g. key equality AND an
+                        // additional filter like amount > 30, issue #380), we must reapply the
+                        // full predicate after the key-based join.
+                        let expr_has_only_key_equalities =
+                            expr_contains_only_join_key_equalities(&expr);
+                        let should_apply_filter = !expr_has_only_key_equalities;
+                        if should_apply_filter {
                             joined = joined.filter(expr).map_err(to_py_err)?;
                         }
 

--- a/tests/dataframe/test_issue_374_join_aliased_columns.py
+++ b/tests/dataframe/test_issue_374_join_aliased_columns.py
@@ -173,7 +173,6 @@ class TestIssue374JoinAliasedColumns:
         finally:
             spark.stop()
 
-    @pytest.mark.skip(reason="Tracked in issue #1325; unskip when fixed.")
     def test_join_complex_condition_with_aliases(self):
         """Test join with complex conditions using aliased columns."""
         import inspect

--- a/tests/dataframe/test_issues_376_382_robust.py
+++ b/tests/dataframe/test_issues_376_382_robust.py
@@ -155,7 +155,6 @@ def test_robust_self_join_manager_column_and_row_count(spark):
 # -----------------------------------------------------------------------------
 
 
-@pytest.mark.skip(reason="Tracked in issue #1325; unskip when fixed.")
 def test_robust_join_compound_condition(spark):
     """#380: Join with (a.id == b.id) & (a.amount > 30)."""
 

--- a/tests/unit/test_column_case_variations.py
+++ b/tests/unit/test_column_case_variations.py
@@ -389,10 +389,6 @@ class TestColumnCaseVariations:
 
     def test_chained_operations_all_cases(self, sample_df):
         """Test chained operations with various case combinations."""
-        import pytest
-
-        pytest.skip("Tracked in issue #1325; unskip when fixed.")
-
         # Filter -> Select
         result = sample_df.filter(F.col("age") > 25).select("name", "salary").collect()
         assert len(result) == 2


### PR DESCRIPTION
Fixes [#1325](https://github.com/eddiethedean/robin-sparkless/issues/1325) by tightening alias-qualified and case-insensitive column resolution in joins and filters.\n\n- Ensure condition joins on aliased tables correctly resolve qualified column names (e.g. "o.customer_id", "c.customer_id").\n- Preserve PySpark-style ambiguity errors for unqualified join key names when appropriate.\n- Make case-insensitive resolution robust across chained filter/select/group/order operations.\n- Unskip the parity tests that cover these scenarios and keep the full Python suite passing with SPARKLESS_TEST_BACKEND=robin.