### PR TITLE
docs: align README Documentation table with PyPI and RELEASING

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ CI runs format, clippy, audit, deny, Rust tests, and parity tests on push/PR (se
 
 | Resource | Description |
 |----------|-------------|
-| [**Python package**](python/README.md) | **Sparkless 4.0** — install (`pip install ./python`), quick start, Sparkless 3 vs 4.0, API overview |
+| [**Python package**](python/README.md) | **Sparkless 4.0** — install from PyPI (`pip install sparkless`) or `pip install ./python`, quick start, Sparkless 3 vs 4.0, API overview |
 | [**Read the Docs**](https://robin-sparkless.readthedocs.io/) | Full docs: quickstart, Rust usage, Python getting started, Sparkless integration (MkDocs) |
 | [**docs.rs**](https://docs.rs/robin-sparkless) | Rust API reference |
 | [QUICKSTART](docs/QUICKSTART.md) | Build, usage, optional features, benchmarks |
@@ -215,7 +215,7 @@ CI runs format, clippy, audit, deny, Rust tests, and parity tests on push/PR (se
 | [UDF Guide](docs/UDF_GUIDE.md) | Scalar, vectorized, and grouped UDFs |
 | [PySpark Differences](docs/PYSPARK_DIFFERENCES.md) | Known divergences |
 | [Roadmap](docs/ROADMAP.md) | Development phases, Sparkless integration |
-| [RELEASING](docs/RELEASING.md) | Publishing to crates.io |
+| [RELEASING](docs/RELEASING.md) | Publishing to crates.io and PyPI |
 
 See [CHANGELOG.md](CHANGELOG.md) for version history.
 


### PR DESCRIPTION
Updates the README Documentation table to match current behavior:

- **Python package**: Mention install from PyPI (`pip install sparkless`) in addition to `pip install ./python`.
- **RELEASING**: Change description from "Publishing to crates.io" to "Publishing to crates.io and PyPI" (RELEASING.md already documents both).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only edits that don’t affect runtime behavior or build/release tooling.
> 
> **Overview**
> Updates the README documentation table to reflect current distribution: the Python package entry now mentions installing `sparkless` from PyPI (in addition to `pip install ./python`), and the `RELEASING` entry now states it covers publishing to both crates.io and PyPI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 027638094a89075bc6bc7971ea6364916932f26e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->