### PR TITLE
fix: createDataFrame([{}], StructType([])) parity with PySpark (issue #1345)

### DIFF
--- a/crates/robin-sparkless-polars/src/session/mod.rs
+++ b/crates/robin-sparkless-polars/src/session/mod.rs
@@ -1987,16 +1987,20 @@ impl SparkSession {
         verify_schema: bool,
         schema_was_inferred: bool,
     ) -> Result<DataFrame, PolarsError> {
-        // When schema is explicitly empty and rows are not, fail with LENGTH_SHOULD_BE_THE_SAME (Phase 6 / PySpark parity).
+        // #1345: Empty schema + rows with 0 fields each is valid (PySpark: createDataFrame([{}], StructType([])) -> 1 row, 0 cols).
+        // Only fail when a row has more than 0 fields (LENGTH_SHOULD_BE_THE_SAME).
         if schema.is_empty() && !rows.is_empty() {
-            let got = rows[0].len();
-            return Err(PolarsError::InvalidOperation(
-                format!(
-                    "create_dataframe_from_rows: LENGTH_SHOULD_BE_THE_SAME. Expected 0 fields, got {} (row index 0).",
-                    got
-                )
-                    .into(),
-            ));
+            for (row_idx, row) in rows.iter().enumerate() {
+                if !row.is_empty() {
+                    return Err(PolarsError::InvalidOperation(
+                        format!(
+                            "create_dataframe_from_rows: LENGTH_SHOULD_BE_THE_SAME. Expected 0 fields, got {} (row index {}).",
+                            row.len(), row_idx
+                        )
+                            .into(),
+                    ));
+                }
+            }
         }
         // #624: When schema is only column names (all "string"), infer from data (PySpark parity).
         // #731, #769, #772: createDataFrame(rows, ["name", "age"]) yields int/double/bool columns.
@@ -2140,6 +2144,13 @@ impl SparkSession {
             if rows.is_empty() {
                 return Ok(DataFrame::from_eager_with_options(
                     PlDataFrame::new(0, vec![])?,
+                    self.is_case_sensitive(),
+                ));
+            }
+            // #1345: PySpark allows createDataFrame([{}], StructType([])) -> 1 row, 0 cols.
+            if rows.iter().all(|r| r.is_empty()) {
+                return Ok(DataFrame::from_eager_with_options(
+                    PlDataFrame::new(rows.len(), vec![])?,
                     self.is_case_sensitive(),
                 ));
             }
@@ -3081,22 +3092,26 @@ mod tests {
         assert!(result.is_err());
     }
 
+    /// #1345: Empty schema + rows with 0 fields each succeeds (PySpark: createDataFrame([{}], StructType([]))).
     #[test]
     fn test_create_dataframe_from_rows_empty_schema_with_rows_returns_error() {
         let spark = SparkSession::builder().app_name("test").get_or_create();
         let rows: Vec<Vec<JsonValue>> = vec![vec![]];
         let schema: Vec<(String, String)> = vec![];
         let result = spark.create_dataframe_from_rows(rows, schema, false, false);
-        match &result {
-            Err(e) => assert!(
-                e.to_string().contains("LENGTH_SHOULD_BE_THE_SAME")
-                    || e.to_string().contains("Expected 0 fields")
-                    || e.to_string().contains("schema must not be empty"),
-                "expected error for empty schema with non-empty rows: {}",
-                e
-            ),
-            Ok(_) => panic!("expected error for empty schema with non-empty rows"),
-        }
+        let df = result.expect("#1345: empty schema + empty row(s) should succeed");
+        assert_eq!(df.count().unwrap(), 1);
+        assert_eq!(df.columns().unwrap().len(), 0);
+        // Empty schema + row with >0 fields still errors
+        let rows_bad: Vec<Vec<JsonValue>> = vec![vec![JsonValue::Null]];
+        let result_bad = spark.create_dataframe_from_rows(rows_bad, vec![], false, false);
+        let err_msg = match &result_bad {
+            Err(e) => e.to_string(),
+            Ok(_) => panic!("expected error for empty schema with row containing 1 field"),
+        };
+        assert!(
+            err_msg.contains("LENGTH_SHOULD_BE_THE_SAME") || err_msg.contains("Expected 0 fields")
+        );
     }
 
     #[test]
@@ -3674,6 +3689,19 @@ mod tests {
             ),
             Ok(_) => panic!("expected error for empty schema with non-empty rows"),
         }
+    }
+
+    /// #1345: Empty schema + rows with 0 fields each is valid (PySpark: createDataFrame([{}], StructType([])) -> 1 row, 0 cols).
+    #[test]
+    fn test_issue_1345_empty_schema_empty_rows_parity() {
+        let spark = SparkSession::builder().app_name("test").get_or_create();
+        let schema: Vec<(String, String)> = vec![];
+        let rows: Vec<Vec<JsonValue>> = vec![vec![]];
+        let df = spark
+            .create_dataframe_from_rows(rows, schema, false, false)
+            .expect("#1345: empty schema + empty row should succeed");
+        assert_eq!(df.count().unwrap(), 1);
+        assert_eq!(df.columns().unwrap().len(), 0);
     }
 
     /// #627: create_dataframe_from_rows accepts map column (dict/object). PySpark MapType parity.

--- a/docs/PYSPARK_DIFFERENCES.md
+++ b/docs/PYSPARK_DIFFERENCES.md
@@ -90,6 +90,7 @@ This document lists **intentional or known divergences** from PySpark semantics 
 - **Column name case (#786, #785)**: Column names from the schema are preserved as returned by `columns()` and in collect row keys. Pass the exact case you need (e.g. `NaMe`) in the schema so `'NaMe' in df.columns` succeeds.
 - **Duplicate field names in StructType (#1347)**: PySpark allows duplicate field names in a schema (e.g. two fields both named `id`). Robin-sparkless **rejects** them and raises an error: `create_dataframe_from_rows: duplicate column name '…' in schema`. Use unique field names when creating DataFrames with an explicit schema so tests and pipelines work under both.
 - **Invalid data type (#1346)**: When `data` is not a list, RDD, or pandas DataFrame, robin-sparkless raises **SparklessError** (PySparkTypeError) with message `[CANNOT_ACCEPT_OBJECT_IN_TYPE] \`StructType\` can not accept object in type \`<type>\`.` to match PySpark.
+- **Empty schema + empty rows (#1345)**: `createDataFrame([{}], StructType([]))` (or `[]` with empty schema) is supported: produces 1 row, 0 columns, matching PySpark.
 
 ## JVM / runtime stubs { #jvm--runtime-stubs }
 

--- a/tests/dataframe/test_issue_1345_empty_schema_empty_row_parity.py
+++ b/tests/dataframe/test_issue_1345_empty_schema_empty_row_parity.py
@@ -1,0 +1,31 @@
+"""
+Tests for #1345: createDataFrame([], StructType([])) and createDataFrame([{}], StructType([])) parity.
+
+PySpark accepts both; sparkless now matches (empty schema + empty row -> 1 row, 0 cols).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.fixtures.spark_imports import get_spark_imports
+
+imports = get_spark_imports()
+SparkSession = imports.SparkSession
+StructType = imports.StructType
+
+
+def test_empty_schema_empty_list(spark):
+    """createDataFrame([], StructType([])) -> 0 rows, 0 cols (both engines)."""
+    schema = StructType([])
+    df = spark.createDataFrame([], schema)
+    assert df.count() == 0
+    assert len(df.columns) == 0
+
+
+def test_empty_schema_single_empty_dict(spark):
+    """createDataFrame([{}], StructType([])) -> 1 row, 0 cols (#1345 PySpark parity)."""
+    schema = StructType([])
+    df = spark.createDataFrame([{}], schema)
+    assert df.count() == 1
+    assert len(df.columns) == 0


### PR DESCRIPTION
Fixes #1345

## Summary
`createDataFrame([{}], StructType([]))` (empty schema + one empty row) now succeeds and returns a DataFrame with 1 row and 0 columns, matching PySpark. Previously sparkless raised `LENGTH_SHOULD_BE_THE_SAME. Expected 0 fields, got 0`.

## Changes
- **session/mod.rs**: When schema is empty and rows are not empty, only error if any row has `row.len() > 0`. When all rows are empty, return `DataFrame::new(rows.len(), vec![])` (0 columns, N rows). Also handle this in the later `schema.is_empty()` block.
- **Rust tests**: `test_create_dataframe_from_rows_empty_schema_with_rows_returns_error` now expects success for `vec![vec![]]` and still expects error for `vec![vec![Null]]`. Added `test_issue_1345_empty_schema_empty_rows_parity`.
- **Python test**: `test_issue_1345_empty_schema_empty_row_parity.py` for `[]` and `[{}]` with empty schema.
- **PYSPARK_DIFFERENCES.md**: Note that empty schema + empty rows is supported.