### PR TITLE
fix(python): SparkSession type __module__ for engine detection (issue #1344)

### DIFF
--- a/docs/PYSPARK_DIFFERENCES.md
+++ b/docs/PYSPARK_DIFFERENCES.md
@@ -92,6 +92,10 @@ This document lists **intentional or known divergences** from PySpark semantics 
 - **Invalid data type (#1346)**: When `data` is not a list, RDD, or pandas DataFrame, robin-sparkless raises **SparklessError** (PySparkTypeError) with message `[CANNOT_ACCEPT_OBJECT_IN_TYPE] \`StructType\` can not accept object in type \`<type>\`.` to match PySpark.
 - **Empty schema + empty rows (#1345)**: `createDataFrame([{}], StructType([]))` (or `[]` with empty schema) is supported: produces 1 row, 0 columns, matching PySpark.
 
+## SparkSession type / engine detection (#1344)
+
+- **`type(spark).__module__`**: Sparkless sets `SparkSession` and `SparkSessionBuilder` to `__module__ = "sparkless.sql.session"` (PyO3 `#[pyclass(module = "...")]`) so code that checks the session type for engine detection can use `"sparkless" in type(spark).__module__` or `type(spark).__module__ == "sparkless.sql.session"`. PySpark reports `pyspark.sql.session`.
+
 ## JVM / runtime stubs { #jvm--runtime-stubs }
 
 The following JVM- or runtime-related functions are implemented as **stubs for API compatibility**, not full equivalents of PySpark behavior:

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -557,7 +557,8 @@ fn json_value_to_py_with_schema(
     })
 }
 
-#[pyclass]
+/// #1344: module = "sparkless.sql.session" so type(spark).__module__ identifies engine (not builtins).
+#[pyclass(module = "sparkless.sql.session")]
 struct PySparkSessionBuilder {
     inner: SparkSessionBuilder,
 }
@@ -650,7 +651,8 @@ impl PySparkSessionBuilder {
 /// Default backend type so tests that read session.backend_type always get a value (e.g. "robin").
 const DEFAULT_BACKEND_TYPE: &str = "robin";
 
-#[pyclass]
+/// #1344: module = "sparkless.sql.session" so type(spark).__module__ identifies engine (not builtins).
+#[pyclass(module = "sparkless.sql.session")]
 struct PySparkSession {
     inner: SparkSession,
     /// Writable from Python so conftest/fixtures can set backend_type = "robin" (e.g. under pytest-xdist).

--- a/tests/unit/session/test_issue_1344_spark_session_type_module.py
+++ b/tests/unit/session/test_issue_1344_spark_session_type_module.py
@@ -1,0 +1,29 @@
+"""
+Tests for #1344: SparkSession type __module__ identifies sparkless (not builtins).
+
+Code that detects engine via type(spark).__module__ should see "sparkless" for sparkless.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.fixtures.spark_backend import BackendType, get_backend_type
+from tests.fixtures.spark_imports import get_spark_imports
+
+imports = get_spark_imports()
+SparkSession = imports.SparkSession
+
+
+def test_spark_session_type_module_identifies_sparkless(spark):
+    """type(spark).__module__ should contain 'sparkless' for engine detection (#1344)."""
+    if get_backend_type() == BackendType.PYSPARK:
+        pytest.skip("PySpark reports pyspark.sql.session; test is for sparkless")
+    t = type(spark)
+    assert "sparkless" in t.__module__, (
+        f"Expected 'sparkless' in type(spark).__module__ for engine detection, got {t.__module__!r}"
+    )
+    assert t.__module__ == "sparkless.sql.session", (
+        f"Expected __module__ 'sparkless.sql.session', got {t.__module__!r}"
+    )
+    assert t.__name__ in ("SparkSession", "PySparkSession")


### PR DESCRIPTION
Fixes #1344

## Summary
`type(spark).__module__` was `builtins` for sparkless, breaking code that detects the engine via the session type. It is now set to `sparkless.sql.session` (PySpark uses `pyspark.sql.session`) so `"sparkless" in type(spark).__module__` works.

## Changes
- **python/src/lib.rs**: `#[pyclass(module = "sparkless.sql.session")]` on `PySparkSession` and `PySparkSessionBuilder`.
- **PYSPARK_DIFFERENCES.md**: New "SparkSession type / engine detection (#1344)" section.
- **Tests**: `test_issue_1344_spark_session_type_module.py` asserts `__module__ == "sparkless.sql.session"` and `"sparkless" in __module__` (sparkless backend only).