### PR TITLE
docs: reference #1343 for empty schema parity (same as #1345)

### DIFF
--- a/docs/PYSPARK_DIFFERENCES.md
+++ b/docs/PYSPARK_DIFFERENCES.md
@@ -90,7 +90,7 @@ This document lists **intentional or known divergences** from PySpark semantics 
 - **Column name case (#786, #785)**: Column names from the schema are preserved as returned by `columns()` and in collect row keys. Pass the exact case you need (e.g. `NaMe`) in the schema so `'NaMe' in df.columns` succeeds.
 - **Duplicate field names in StructType (#1347)**: PySpark allows duplicate field names in a schema (e.g. two fields both named `id`). Robin-sparkless **rejects** them and raises an error: `create_dataframe_from_rows: duplicate column name '…' in schema`. Use unique field names when creating DataFrames with an explicit schema so tests and pipelines work under both.
 - **Invalid data type (#1346)**: When `data` is not a list, RDD, or pandas DataFrame, robin-sparkless raises **SparklessError** (PySparkTypeError) with message `[CANNOT_ACCEPT_OBJECT_IN_TYPE] \`StructType\` can not accept object in type \`<type>\`.` to match PySpark.
-- **Empty schema + empty rows (#1345)**: `createDataFrame([{}], StructType([]))` (or `[]` with empty schema) is supported: produces 1 row, 0 columns, matching PySpark.
+- **Empty schema + empty rows (#1345, #1343)**: `createDataFrame([{}], StructType([]))` (or `[]` with empty schema) is supported: produces 1 row, 0 columns, matching PySpark.
 
 ## SparkSession type / engine detection (#1344)
 

--- a/tests/dataframe/test_issue_1345_empty_schema_empty_row_parity.py
+++ b/tests/dataframe/test_issue_1345_empty_schema_empty_row_parity.py
@@ -1,5 +1,5 @@
 """
-Tests for #1345: createDataFrame([], StructType([])) and createDataFrame([{}], StructType([])) parity.
+Tests for #1345 / #1343: createDataFrame([], StructType([])) and createDataFrame([{}], StructType([])) parity.
 
 PySpark accepts both; sparkless now matches (empty schema + empty row -> 1 row, 0 cols).
 """
@@ -24,7 +24,7 @@ def test_empty_schema_empty_list(spark):
 
 
 def test_empty_schema_single_empty_dict(spark):
-    """createDataFrame([{}], StructType([])) -> 1 row, 0 cols (#1345 PySpark parity)."""
+    """createDataFrame([{}], StructType([])) -> 1 row, 0 cols (#1345, #1343 PySpark parity)."""
     schema = StructType([])
     df = spark.createDataFrame([{}], schema)
     assert df.count() == 1


### PR DESCRIPTION
Fixes #1343

## Summary
Issue #1343 describes the same behavior as #1345: `createDataFrame([{}], StructType([]))` (empty schema + single empty row) should produce 1 row, 0 columns. That was already fixed in PR #1352 (issue #1345).

This PR adds #1343 to the documentation and test references so the issue is linked and will close when merged. No code change.