### PR TITLE
fix: make groupBy().count() return bigint

### DIFF
--- a/crates/robin-sparkless-polars/src/dataframe/aggregations.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/aggregations.rs
@@ -200,7 +200,8 @@ impl GroupedData {
     /// Count rows in each group
     pub fn count(&self) -> Result<DataFrame, PolarsError> {
         use polars::prelude::*;
-        let agg_expr = vec![len().alias("count")];
+        // PySpark parity: groupBy(...).count() returns BIGINT (i64), not int.
+        let agg_expr = vec![len().cast(DataType::Int64).alias("count")];
         let lf = self.lazy_grouped.clone().agg(agg_expr);
         let mut pl_df = lf.collect()?;
         pl_df = reorder_groupby_columns(&mut pl_df, &self.grouping_cols)?;
@@ -1369,7 +1370,8 @@ impl CubeRollupData {
     /// Count rows per grouping set (PySpark cube/rollup .count()).
     pub fn count(&self) -> Result<DataFrame, PolarsError> {
         use polars::prelude::*;
-        self.agg(vec![len().alias("count")])
+        // PySpark parity: count is BIGINT (i64).
+        self.agg(vec![len().cast(DataType::Int64).alias("count")])
     }
 
     /// Run aggregation on each grouping set and union results. Missing keys become null.

--- a/crates/robin-sparkless-polars/src/dataframe/joins.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/joins.rs
@@ -1250,9 +1250,9 @@ mod tests {
         let pl_df = out.collect().unwrap();
 
         let key_col = pl_df.column("key").unwrap().i64().unwrap();
-        let count_col = pl_df.column("count").unwrap().u32().unwrap();
+        let count_col = pl_df.column("count").unwrap().i64().unwrap();
 
-        let mut by_key: HashMap<Option<i64>, u32> = HashMap::new();
+        let mut by_key: HashMap<Option<i64>, i64> = HashMap::new();
         for idx in 0..key_col.len() {
             let key = key_col.get(idx);
             let cnt = count_col.get(idx).unwrap_or(0);

--- a/tests/dataframe/test_issue_1415_groupby_count_bigint.py
+++ b/tests/dataframe/test_issue_1415_groupby_count_bigint.py
@@ -1,0 +1,11 @@
+"""Regression test for #1415: groupBy().count() schema uses BIGINT for count."""
+
+
+def test_groupby_count_schema_bigint(spark):
+    df = spark.createDataFrame([("a",), ("a",), ("b",), (None,)], ["g"])
+    out = df.groupBy("g").count()
+
+    # PySpark: struct<g:string,count:bigint>
+    assert out.schema.fields[1].name == "count"
+    assert out.schema.fields[1].dataType.__class__.__name__ in ("LongType", "long")
+


### PR DESCRIPTION
## Summary
- Make `groupBy(...).count()` (and cube/rollup `.count()`) return BIGINT/Int64 to match PySpark schema.
- Add regression coverage for the issue #1415 repro.

Fixes #1415.

## Test plan
- `cargo test -p robin-sparkless-polars`
- `maturin develop` (in `python/`)
- `pytest -n 10 tests/dataframe/test_issue_1415_groupby_count_bigint.py`