### PR TITLE
fix: make session.range default step=1

### DIFF
--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1008,7 +1008,27 @@ impl PySparkSession {
         self.create_dataframe_from_rows(py, data, schema, verify_schema, sampling_ratio)
     }
 
-    fn range(&self, start: i64, end: i64, step: i64) -> PyResult<PyDataFrame> {
+    /// PySpark-compatible range:
+    /// - range(end)
+    /// - range(start, end)
+    /// - range(start, end, step)
+    #[pyo3(signature = (start, end=None, step=None))]
+    fn range(
+        &self,
+        start: i64,
+        end: Option<i64>,
+        step: Option<i64>,
+    ) -> PyResult<PyDataFrame> {
+        let (start, end, step) = match (end, step) {
+            (None, None) => (0, start, 1),
+            (Some(e), None) => (start, e, 1),
+            (Some(e), Some(s)) => (start, e, s),
+            (None, Some(_)) => {
+                return Err(pyo3::exceptions::PyTypeError::new_err(
+                    "range(end, step) is not supported; use range(start, end, step)",
+                ))
+            }
+        };
         self.inner
             .range(start, end, step)
             .map(PyDataFrame::wrap)

--- a/tests/window/test_issue_1413_df_limit_range_step_default.py
+++ b/tests/window/test_issue_1413_df_limit_range_step_default.py
@@ -1,0 +1,10 @@
+"""Regression test for #1413: df.limit after range() with default step should work."""
+
+
+def test_df_limit_after_range_with_default_step(spark):
+    df = spark.range(0, 5).limit(2).orderBy("id")
+    rows = df.collect()
+
+    assert len(rows) == 2
+    assert [r.id for r in rows] == [0, 1]
+


### PR DESCRIPTION
## Summary
- Make `SparkSession.range` support PySpark-style overloads: `range(end)`, `range(start, end)`, `range(start, end, step)`.
- Add a regression test for `session.range(0, 5).limit(2).orderBy("id")` (issue #1413).

Fixes #1413.

## Test plan
- `cargo test -p robin-sparkless-polars`
- `maturin develop` (in `python/`)
- `pytest -n 10 tests/window/test_issue_1413_df_limit_range_step_default.py`