### PR TITLE
test: cover array(struct) in select after range

### DIFF
--- a/tests/array/test_issue_1412_struct_in_array.py
+++ b/tests/array/test_issue_1412_struct_in_array.py
@@ -1,0 +1,20 @@
+"""Regression test for #1412: array of struct built from literals inside select."""
+
+from tests.fixtures.spark_imports import get_spark_imports
+
+
+def test_array_struct_in_array_with_range(spark):
+    imports = get_spark_imports()
+    F = imports.F
+
+    df = spark.range(1, 2).select(
+        F.array(F.struct(F.lit(1).alias("x"), F.lit("a").alias("s"))).alias("arr")
+    )
+
+    rows = df.collect()
+    assert len(rows) == 1
+    arr = rows[0]["arr"]
+    assert len(arr) == 1
+    assert arr[0]["x"] == 1
+    assert arr[0]["s"] == "a"
+


### PR DESCRIPTION
## Summary
- Add a regression test for building `array(struct(...))` from literals after `SparkSession.range`, matching the scenario in #1412.

Fixes #1412.

## Test plan
- `pytest -n 10 tests/array/test_issue_1412_struct_in_array.py`