### PR TITLE
test: cover array literal after range

### DIFF
--- a/tests/array/test_issue_1411_array_literal.py
+++ b/tests/array/test_issue_1411_array_literal.py
@@ -1,0 +1,16 @@
+"""Regression test for #1411: array literal of simple values after range()."""
+
+from tests.fixtures.spark_imports import get_spark_imports
+
+
+def test_array_literal_after_range(spark):
+    imports = get_spark_imports()
+    F = imports.F
+
+    df = spark.range(1, 2).select(F.array(F.lit("a"), F.lit("b")).alias("arr"))
+
+    rows = df.collect()
+    assert len(rows) == 1
+    arr = rows[0]["arr"]
+    assert arr == ["a", "b"]
+


### PR DESCRIPTION
## Summary
- Add a regression test for building an array literal via `array(lit("a"), lit("b"))` after `SparkSession.range`, matching the scenario in #1411.

Fixes #1411.

## Test plan
- `pytest -n 10 tests/array/test_issue_1411_array_literal.py`