### PR TITLE
fix: implement make_date function

### DIFF
--- a/python/sparkless/sparkless/sql/functions.py
+++ b/python/sparkless/sparkless/sql/functions.py
@@ -702,7 +702,9 @@ def weekofyear(col_or_name):
     return _native.native_weekofyear(_as_col(col_or_name))
 
 
-make_date = _ni("make_date")
+def make_date(year, month, day):
+    """Build date from year, month, day (PySpark make_date)."""
+    return _native.make_date(_as_col(year), _as_col(month), _as_col(day))
 typeof = _ni("typeof")
 
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -8175,6 +8175,13 @@ fn ceil(column: &PyColumn) -> PyColumn {
 }
 
 #[pyfunction]
+fn make_date(year: &PyColumn, month: &PyColumn, day: &PyColumn) -> PyColumn {
+    PyColumn {
+        inner: functions::make_date(&year.inner, &month.inner, &day.inner),
+    }
+}
+
+#[pyfunction]
 fn abs(column: &PyColumn) -> PyColumn {
     PyColumn {
         inner: functions::abs(&column.inner),
@@ -9022,6 +9029,7 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(length, m)?)?;
     m.add_function(wrap_pyfunction!(floor, m)?)?;
     m.add_function(wrap_pyfunction!(ceil, m)?)?;
+    m.add_function(wrap_pyfunction!(make_date, m)?)?;
     m.add_function(wrap_pyfunction!(abs, m)?)?;
     m.add_function(wrap_pyfunction!(sqrt, m)?)?;
     m.add_function(wrap_pyfunction!(log, m)?)?;

--- a/tests/date/test_issue_1406_make_date.py
+++ b/tests/date/test_issue_1406_make_date.py
@@ -1,0 +1,27 @@
+"""Regression test for #1406: date.make_date parity."""
+
+from tests.fixtures.spark_backend import BackendType, SparkBackend
+from tests.fixtures.spark_imports import get_spark_imports
+
+
+def test_make_date_parity():
+    imports = get_spark_imports(BackendType.ROBIN)
+    F = imports.F
+    spark = SparkBackend.create_mock_spark_session("make_date_1406", backend_type="robin")
+
+    df = spark.createDataFrame(
+        [(2020, 1, 2), (2020, 2, 30), (None, 1, 2)],
+        ["y", "m", "d"],
+    )
+
+    out = df.select(F.make_date("y", "m", "d").alias("dt")).collect()
+    vals = [row["dt"] for row in out]
+
+    # PySpark behavior:
+    # - make_date(2020,1,2)   -> 2020-01-02
+    # - make_date(2020,2,30)  -> null (invalid day for month)
+    # - make_date(None,1,2)   -> null
+    assert vals[0].strftime("%Y-%m-%d") == "2020-01-02"
+    assert vals[1] is None
+    assert vals[2] is None
+


### PR DESCRIPTION
## Summary
- Wire the already-implemented `make_date(year, month, day)` UDF into the Python `_native` module and `sparkless.sql.functions.F.make_date`.
- Add a regression test for the issue #1406 repro: valid date, invalid day (null), and null year.

Fixes #1406.

## Test plan
- `pytest -n 10 tests/date/test_issue_1406_make_date.py`
- `pytest -n 10`