### PR TITLE
fix: wire add_months native function

### DIFF
--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -8175,6 +8175,14 @@ fn ceil(column: &PyColumn) -> PyColumn {
 }
 
 #[pyfunction]
+#[pyo3(name = "native_add_months")]
+fn native_add_months(column: &PyColumn, months: i32) -> PyColumn {
+    PyColumn {
+        inner: functions::add_months(&column.inner, months),
+    }
+}
+
+#[pyfunction]
 fn make_date(year: &PyColumn, month: &PyColumn, day: &PyColumn) -> PyColumn {
     PyColumn {
         inner: functions::make_date(&year.inner, &month.inner, &day.inner),
@@ -9029,6 +9037,7 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(length, m)?)?;
     m.add_function(wrap_pyfunction!(floor, m)?)?;
     m.add_function(wrap_pyfunction!(ceil, m)?)?;
+    m.add_function(wrap_pyfunction!(native_add_months, m)?)?;
     m.add_function(wrap_pyfunction!(make_date, m)?)?;
     m.add_function(wrap_pyfunction!(abs, m)?)?;
     m.add_function(wrap_pyfunction!(sqrt, m)?)?;

--- a/tests/date/test_issue_1405_add_months.py
+++ b/tests/date/test_issue_1405_add_months.py
@@ -1,0 +1,28 @@
+"""Regression test for #1405: date.add_months parity."""
+
+from tests.fixtures.spark_backend import BackendType, SparkBackend
+from tests.fixtures.spark_imports import get_spark_imports
+
+
+def test_add_months_parity():
+    imports = get_spark_imports(BackendType.ROBIN)
+    F = imports.F
+    spark = SparkBackend.create_mock_spark_session("add_months_1405", backend_type="robin")
+
+    df = spark.createDataFrame(
+        [("2020-01-31",), ("2020-02-29",), (None,)],
+        ["s"],
+    )
+
+    # Cast string to date, then add one month as PySpark does.
+    out = df.select(F.add_months(F.to_date("s"), 1).alias("dt")).collect()
+    vals = [row["dt"] for row in out]
+
+    # PySpark behavior:
+    # - add_months(date("2020-01-31"), 1) -> 2020-02-29
+    # - add_months(date("2020-02-29"), 1) -> 2020-03-29
+    # - add_months(None, 1)              -> null
+    assert vals[0].strftime("%Y-%m-%d") == "2020-02-29"
+    assert vals[1].strftime("%Y-%m-%d") == "2020-03-29"
+    assert vals[2] is None
+


### PR DESCRIPTION
## Summary
- Implement the missing `_native.native_add_months` binding so `F.add_months` works with the robin backend.
- Add a regression test for the issue #1405 repro using `add_months(to_date(s), 1)`.

Fixes #1405.

## Test plan
- `pytest -n 10 tests/date/test_issue_1405_add_months.py`
- `pytest -n 10`