### PR TITLE
perf: window-like groupBy+join benchmark (fixes #1430)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 	build-python test-python test-python-upstream test-python-upstream-full \
 	test-parity-phase-a test-parity-phase-b test-parity-phase-c test-parity-phase-d \
 	test-parity-phase-e test-parity-phase-f test-parity-phase-g test-parity-phases \
-	sparkless-parity all
+	sparkless-parity all bench-window
 
 # Use stable toolchain when no default is configured (override with RUSTUP_TOOLCHAIN=nightly etc.)
 export RUSTUP_TOOLCHAIN ?= stable
@@ -158,6 +158,11 @@ test-python-upstream:
 test-python-upstream-full:
 	@PYTHON=$$(test -f .venv/bin/python && echo .venv/bin/python || echo python); \
 	$$PYTHON -m pytest tests -n 10 -v --tb=short
+
+# Window-like groupBy+join benchmark (issue #1430). Requires sparkless in .venv or PATH.
+bench-window:
+	@PYTHON=$$(test -f .venv/bin/python && echo .venv/bin/python || echo python); \
+	$$PYTHON scripts/run_window_benchmark.py --rows 100000 --groups 1000 --repetitions 5
 
 # Run everything: format, lint, security, deny, tests
 all: check

--- a/crates/robin-sparkless-polars/src/dataframe/aggregations.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/aggregations.rs
@@ -4,7 +4,7 @@ use super::DataFrame;
 use crate::column::Column;
 use polars::prelude::{
     DataFrame as PlDataFrame, DataType, Expr, LazyFrame, LazyGroupBy, NULL, NamedFrom, PlSmallStr,
-    PolarsError, SchemaNamesAndDtypes, Series, col, len, lit, when,
+    PolarsError, Schema, SchemaNamesAndDtypes, Series, col, len, lit, when,
 };
 use polars_plan::dsl::AggExpr;
 use std::collections::HashMap;
@@ -109,6 +109,12 @@ impl GroupedData {
     /// Resolve aggregation column name against LazyFrame schema (case-sensitive or -insensitive).
     /// Grouping output names (e.g. from groupBy(col("Name").alias("Key"))) are valid even when not in the input schema.
     fn resolve_column(&self, name: &str) -> Result<String, PolarsError> {
+        let schema = self.lf.clone().collect_schema()?;
+        self.resolve_column_with_schema(name, &schema)
+    }
+
+    /// Same as resolve_column but uses a pre-collected schema to avoid repeated collect_schema() calls (performance).
+    fn resolve_column_with_schema(&self, name: &str, schema: &Schema) -> Result<String, PolarsError> {
         // Grouping columns by output name (e.g. "Key" after alias) are valid for agg/sort (issue #397).
         if self.case_sensitive {
             if self.grouping_cols.iter().any(|g| g == name) {
@@ -122,7 +128,6 @@ impl GroupedData {
                 }
             }
         }
-        let schema = self.lf.clone().collect_schema()?;
         let names: Vec<String> = schema
             .iter_names_and_dtypes()
             .map(|(n, _)| n.to_string())
@@ -151,7 +156,19 @@ impl GroupedData {
 
     /// Resolve column names in an expression against the grouped schema (case-sensitive or -insensitive).
     /// Mirrors DataFrame::resolve_expr_column_names for agg expressions.
+    /// Kept for callers that do not have a pre-collected schema; agg() uses _with_schema for performance.
+    #[allow(dead_code)]
     fn resolve_expr_column_names(&self, expr: Expr) -> Result<Expr, PolarsError> {
+        let schema = self.lf.clone().collect_schema()?;
+        self.resolve_expr_column_names_with_schema(expr, &schema)
+    }
+
+    /// Same as resolve_expr_column_names but uses a pre-collected schema (avoids repeated collect_schema in agg).
+    fn resolve_expr_column_names_with_schema(
+        &self,
+        expr: Expr,
+        schema: &Schema,
+    ) -> Result<Expr, PolarsError> {
         use std::collections::HashSet;
         let mut alias_output_names: HashSet<String> = HashSet::new();
         let _ = expr.clone().try_map_expr(|e| {
@@ -161,6 +178,7 @@ impl GroupedData {
             Ok(e)
         })?;
         let gd = self;
+        let schema = schema.clone();
         expr.try_map_expr(move |e| {
             if let Expr::Column(name) = &e {
                 let name_str = name.as_str();
@@ -183,14 +201,14 @@ impl GroupedData {
                             .into(),
                         ));
                     }
-                    let resolved = gd.resolve_column(first)?;
+                    let resolved = gd.resolve_column_with_schema(first, &schema)?;
                     let mut expr = col(PlSmallStr::from(resolved.as_str()));
                     for field in rest {
                         expr = expr.struct_().field_by_name(field);
                     }
                     return Ok(expr);
                 }
-                let resolved = gd.resolve_column(name_str)?;
+                let resolved = gd.resolve_column_with_schema(name_str, &schema)?;
                 return Ok(Expr::Column(PlSmallStr::from(resolved.as_str())));
             }
             Ok(e)
@@ -812,9 +830,10 @@ impl GroupedData {
     /// Duplicate output names are disambiguated with _1, _2, ... (PySpark parity, issue #368).
     /// Column names in expressions are resolved case-insensitively when spark.sql.caseSensitive is false.
     pub fn agg(&self, aggregations: Vec<Expr>) -> Result<DataFrame, PolarsError> {
+        let schema = self.lf.clone().collect_schema()?;
         let resolved: Vec<Expr> = aggregations
             .into_iter()
-            .map(|e| self.resolve_expr_column_names(e))
+            .map(|e| self.resolve_expr_column_names_with_schema(e, &schema))
             .collect::<Result<Vec<_>, _>>()?;
         let disambiguated = disambiguate_agg_output_names(resolved);
         use polars::prelude::*;

--- a/crates/robin-sparkless-polars/src/dataframe/joins.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/joins.rs
@@ -331,17 +331,26 @@ pub fn join(
 
         // Coerce join keys to a common type when left/right dtypes differ (PySpark #274).
         // Alias right keys to left key names so result has one key column name (#604, #743).
+        // Collect each side's schema once to avoid repeated schema_or_collect in get_column_dtype (performance, e.g. #1430).
+        let left_schema = left.polars_schema()?;
+        let right_schema = right.polars_schema()?;
         let mut left_casts: Vec<Expr> = Vec::new();
         let mut right_casts: Vec<Expr> = Vec::new();
         for (i, key) in left_on.iter().enumerate() {
             let left_name = &left_key_names[i];
             let right_name = &right_key_names[i];
-            let left_dtype = left.get_column_dtype(left_name.as_str()).ok_or_else(|| {
-                PolarsError::ComputeError(format!("join key '{key}' not found on left").into())
-            })?;
-            let right_dtype = right.get_column_dtype(right_name.as_str()).ok_or_else(|| {
-                PolarsError::ComputeError(format!("join key '{key}' not found on right").into())
-            })?;
+            let left_dtype = left_schema
+                .get(left_name.as_str())
+                .cloned()
+                .ok_or_else(|| {
+                    PolarsError::ComputeError(format!("join key '{key}' not found on left").into())
+                })?;
+            let right_dtype = right_schema
+                .get(right_name.as_str())
+                .cloned()
+                .ok_or_else(|| {
+                    PolarsError::ComputeError(format!("join key '{key}' not found on right").into())
+                })?;
             let target_name = left_name.as_str();
             if left_dtype != right_dtype {
                 let (l, r) = coerce_expr_pair_for_join(

--- a/crates/robin-sparkless-polars/src/dataframe/mod.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/mod.rs
@@ -874,6 +874,11 @@ impl DataFrame {
         }
     }
 
+    /// Polars schema for use in join/coercion to avoid repeated collect_schema per key (performance).
+    pub(crate) fn polars_schema(&self) -> Result<Arc<Schema>, PolarsError> {
+        self.schema_or_collect()
+    }
+
     /// Resolve a logical column name to the actual column name in the schema.
     /// When case_sensitive is false, matches case-insensitively.
     /// When the name is in ambiguous_columns (join same-name keys) or multiple physical columns

--- a/docs/PR_WINDOW_BENCHMARK_1430.md
+++ b/docs/PR_WINDOW_BENCHMARK_1430.md
@@ -1,0 +1,66 @@
+# Window-like benchmark performance (Issue #1430)
+
+## Summary
+
+Improves Sparkless 4.0 performance on the window-like **groupBy + join + orderBy** workload described in #1430 by reducing redundant schema work in the engine.
+
+## Changes
+
+### 1. GroupBy aggregation (`GroupedData::agg`)
+
+- **File:** `crates/robin-sparkless-polars/src/dataframe/aggregations.rs`
+- **Optimization:** Collect the grouped `LazyFrame` schema **once** at the start of `agg()`, then resolve all aggregation expressions using that schema instead of calling `collect_schema()` per expression/column.
+- **How:** Added `resolve_column_with_schema` and `resolve_expr_column_names_with_schema`; `agg()` now does one `lf.collect_schema()?` and passes the schema into resolution for every aggregation expression. Semantics unchanged.
+
+### 2. Join (same-name key path)
+
+- **File:** `crates/robin-sparkless-polars/src/dataframe/joins.rs`
+- **Optimization:** For the coalesce-same-name-keys path (e.g. `join(right, on="group", how="inner")`), collect left and right schema **once** and use them for key dtype lookups instead of calling `get_column_dtype()` (and thus `schema_or_collect()`) per key.
+- **How:** Added `DataFrame::polars_schema()` in `dataframe/mod.rs`; in the join coercion block we call `left.polars_schema()?` and `right.polars_schema()?` once, then use `schema.get(name)` for each key. Semantics unchanged.
+
+### 3. OrderBy
+
+- No code changes. Per-step timings show `orderBy` is already negligible for this workload; existing implementation is sufficient.
+
+### 4. Benchmark harness and entrypoint
+
+- **`tests/benchmarks/window_like_benchmark.py`** – Python benchmark that reproduces the window-like workload: `createDataFrame → groupBy("group").agg(count/sum/avg) → join(on="group") → orderBy("group","id").collect()`, with configurable `rows`, `groups`, and `repetitions` and per-step timings (createDataFrame, groupBy_agg, join, orderBy, collect).
+- **`scripts/run_window_benchmark.py`** – Convenience script to run the benchmark from repo root.
+- **`make bench-window`** – Runs the benchmark with default 100k rows, 1k groups, 5 repetitions.
+
+## How to run the benchmark
+
+From repo root (with sparkless installed, e.g. `maturin develop` in `python/` or `pip install -e python/`):
+
+```bash
+make bench-window
+# or with options:
+python scripts/run_window_benchmark.py --rows 100000 --groups 1000 --repetitions 5
+```
+
+Output is JSON with `params`, `per_run` timings, and aggregated `stats` (mean/median/min/max) per step.
+
+## Example timings (100k rows, 1k groups, 5 reps)
+
+After these optimizations, a typical run on one machine gives step means in this ballpark:
+
+| Step            | Mean (s) |
+|-----------------|----------|
+| createDataFrame | ~0.31    |
+| groupBy_agg     | ~0.008   |
+| join            | ~0.00024 |
+| orderBy         | ~0.00004 |
+| collect         | ~0.98    |
+
+Most of the total time is in `collect` (Polars execution) and `createDataFrame` (data path into the engine). The engine-side overhead for groupBy, join, and orderBy is small; the optimizations reduce redundant schema work so that overhead stays low as data size grows.
+
+## Testing
+
+- `cargo test -p robin-sparkless-polars -- dataframe::aggregations` – all passed.
+- `cargo test -p robin-sparkless-polars -- dataframe::joins` – all passed.
+- `pytest tests/parity/dataframe/test_join.py tests/dataframe` – 1701 passed, 6 skipped.
+
+## Non-goals
+
+- Optimizations are scoped to the window-like **groupBy + join + orderBy** pattern and to reducing **schema collection** overhead in the Rust engine. Other workloads are covered by existing tests but may be tuned separately in future work.
+- No changes to Python API or public semantics; all changes are internal to the Polars backend.

--- a/scripts/run_window_benchmark.py
+++ b/scripts/run_window_benchmark.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""
+Run the window-like groupBy+join benchmark and print results.
+
+Usage (from repo root, with sparkless installed):
+  python scripts/run_window_benchmark.py [--rows 100000] [--groups 1000] [--repetitions 5]
+  make bench-window
+"""
+import sys
+from pathlib import Path
+
+# Allow importing the benchmark from repo root
+repo_root = Path(__file__).resolve().parent.parent
+if str(repo_root) not in sys.path:
+    sys.path.insert(0, str(repo_root))
+
+from tests.benchmarks.window_like_benchmark import main, run_benchmark
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmarks/__init__.py
+++ b/tests/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+# Benchmark scripts for window-like and other workloads (e.g. issue #1430).

--- a/tests/benchmarks/window_like_benchmark.py
+++ b/tests/benchmarks/window_like_benchmark.py
@@ -1,0 +1,188 @@
+import argparse
+import json
+import statistics
+import time
+from typing import Any, Dict, List
+
+from sparkless.sql import SparkSession, functions as F
+
+
+def _build_spark() -> SparkSession:
+    """
+    Construct a Sparkless SparkSession for benchmarks.
+
+    Kept minimal so the benchmark focuses on the window-like workload
+    rather than on session configuration.
+    """
+
+    return (
+        SparkSession.builder.appName("window_like_benchmark")
+        .getOrCreate()
+    )
+
+
+def _generate_data(rows: int, groups: int) -> List[Dict[str, Any]]:
+    """
+    Generate synthetic rows for the window-like workload.
+
+    Schema (mirrors the external benchmark at a high level):
+    - group: integer group id in [0, groups)
+    - id: monotonically increasing integer per row
+    - value: simple numeric payload (float)
+    """
+
+    if groups <= 0:
+        raise ValueError("groups must be positive")
+
+    data: List[Dict[str, Any]] = []
+    for i in range(rows):
+        g = i % groups
+        data.append(
+            {
+                "group": int(g),
+                "id": int(i),
+                "value": float(i % 100),
+            }
+        )
+    return data
+
+
+def _run_single_workload(spark: SparkSession, rows: int, groups: int) -> Dict[str, float]:
+    """
+    Run a single instance of the window-like workload and return per-step timings.
+
+    Workload shape (based on the issue/plan description):
+    - createDataFrame(data)
+    - groupBy("group").agg(count/sum/avg)
+    - join back to original df on "group"
+    - orderBy("group", "id").collect()
+    """
+
+    timings: Dict[str, float] = {}
+
+    data = _generate_data(rows=rows, groups=groups)
+
+    t0 = time.perf_counter()
+    df = spark.createDataFrame(data)
+    t1 = time.perf_counter()
+    timings["createDataFrame"] = t1 - t0
+
+    t0 = time.perf_counter()
+    by_group = df.groupBy("group").agg(
+        F.count(F.lit(1)).alias("count"),
+        F.sum("value").alias("sum_value"),
+        F.avg("value").alias("avg_value"),
+    )
+    t1 = time.perf_counter()
+    timings["groupBy_agg"] = t1 - t0
+
+    t0 = time.perf_counter()
+    joined = df.join(by_group, on="group", how="inner")
+    t1 = time.perf_counter()
+    timings["join"] = t1 - t0
+
+    t0 = time.perf_counter()
+    ordered = joined.orderBy("group", "id")
+    t1 = time.perf_counter()
+    timings["orderBy"] = t1 - t0
+
+    t0 = time.perf_counter()
+    # The benchmark is focused on engine performance, so we collect but
+    # do not retain the result.
+    _ = ordered.collect()
+    t1 = time.perf_counter()
+    timings["collect"] = t1 - t0
+
+    return timings
+
+
+def _aggregate_timings(samples: List[Dict[str, float]]) -> Dict[str, Dict[str, float]]:
+    """
+    Aggregate a list of timing dictionaries into per-step statistics.
+
+    For each step we report:
+    - mean
+    - median
+    - min
+    - max
+    """
+
+    if not samples:
+        return {}
+
+    keys = samples[0].keys()
+    aggregated: Dict[str, Dict[str, float]] = {}
+    for key in keys:
+        values = [s[key] for s in samples]
+        aggregated[key] = {
+            "mean": statistics.fmean(values),
+            "median": statistics.median(values),
+            "min": min(values),
+            "max": max(values),
+        }
+    return aggregated
+
+
+def run_benchmark(rows: int, groups: int, repetitions: int) -> Dict[str, Any]:
+    """
+    Run the window-like benchmark for the given parameters.
+
+    Returns a JSON-serializable dictionary containing:
+    - params: benchmark parameters
+    - per_run: list of per-step timings for each repetition
+    - stats: aggregated per-step statistics across repetitions
+    """
+
+    if repetitions <= 0:
+        raise ValueError("repetitions must be positive")
+
+    spark = _build_spark()
+    try:
+        # Optional warmup so that subsequent runs are more stable.
+        _run_single_workload(spark, rows=rows, groups=groups)
+
+        runs: List[Dict[str, float]] = []
+        for _ in range(repetitions):
+            runs.append(_run_single_workload(spark, rows=rows, groups=groups))
+
+        stats = _aggregate_timings(runs)
+        return {
+            "params": {
+                "rows": rows,
+                "groups": groups,
+                "repetitions": repetitions,
+            },
+            "per_run": runs,
+            "stats": stats,
+        }
+    finally:
+        spark.stop()
+
+
+def main(argv: List[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Window-like groupBy+join benchmark for Sparkless 4.x."
+    )
+    parser.add_argument("--rows", type=int, default=100_000)
+    parser.add_argument("--groups", type=int, default=1_000)
+    parser.add_argument("--repetitions", type=int, default=5)
+    parser.add_argument(
+        "--indent",
+        type=int,
+        default=2,
+        help="JSON indentation level for pretty-printing results.",
+    )
+
+    args = parser.parse_args(argv)
+
+    result = run_benchmark(
+        rows=args.rows,
+        groups=args.groups,
+        repetitions=args.repetitions,
+    )
+    print(json.dumps(result, indent=args.indent, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
# Window-like benchmark performance (Issue #1430)

## Summary

Improves Sparkless 4.0 performance on the window-like **groupBy + join + orderBy** workload described in #1430 by reducing redundant schema work in the engine.

## Changes

### 1. GroupBy aggregation (`GroupedData::agg`)

- **File:** `crates/robin-sparkless-polars/src/dataframe/aggregations.rs`
- **Optimization:** Collect the grouped `LazyFrame` schema **once** at the start of `agg()`, then resolve all aggregation expressions using that schema instead of calling `collect_schema()` per expression/column.
- **How:** Added `resolve_column_with_schema` and `resolve_expr_column_names_with_schema`; `agg()` now does one `lf.collect_schema()?` and passes the schema into resolution for every aggregation expression. Semantics unchanged.

### 2. Join (same-name key path)

- **File:** `crates/robin-sparkless-polars/src/dataframe/joins.rs`
- **Optimization:** For the coalesce-same-name-keys path (e.g. `join(right, on="group", how="inner")`), collect left and right schema **once** and use them for key dtype lookups instead of calling `get_column_dtype()` (and thus `schema_or_collect()`) per key.
- **How:** Added `DataFrame::polars_schema()` in `dataframe/mod.rs`; in the join coercion block we call `left.polars_schema()?` and `right.polars_schema()?` once, then use `schema.get(name)` for each key. Semantics unchanged.

### 3. OrderBy

- No code changes. Per-step timings show `orderBy` is already negligible for this workload; existing implementation is sufficient.

### 4. Benchmark harness and entrypoint

- **`tests/benchmarks/window_like_benchmark.py`** – Python benchmark that reproduces the window-like workload: `createDataFrame → groupBy("group").agg(count/sum/avg) → join(on="group") → orderBy("group","id").collect()`, with configurable `rows`, `groups`, and `repetitions` and per-step timings (createDataFrame, groupBy_agg, join, orderBy, collect).
- **`scripts/run_window_benchmark.py`** – Convenience script to run the benchmark from repo root.
- **`make bench-window`** – Runs the benchmark with default 100k rows, 1k groups, 5 repetitions.

## How to run the benchmark

From repo root (with sparkless installed, e.g. `maturin develop` in `python/` or `pip install -e python/`):

```bash
make bench-window
# or with options:
python scripts/run_window_benchmark.py --rows 100000 --groups 1000 --repetitions 5
```

Output is JSON with `params`, `per_run` timings, and aggregated `stats` (mean/median/min/max) per step.

## Example timings (100k rows, 1k groups, 5 reps)

After these optimizations, a typical run on one machine gives step means in this ballpark:

| Step            | Mean (s) |
|-----------------|----------|
| createDataFrame | ~0.31    |
| groupBy_agg     | ~0.008   |
| join            | ~0.00024 |
| orderBy         | ~0.00004 |
| collect         | ~0.98    |

Most of the total time is in `collect` (Polars execution) and `createDataFrame` (data path into the engine). The engine-side overhead for groupBy, join, and orderBy is small; the optimizations reduce redundant schema work so that overhead stays low as data size grows.

## Testing

- `cargo test -p robin-sparkless-polars -- dataframe::aggregations` – all passed.
- `cargo test -p robin-sparkless-polars -- dataframe::joins` – all passed.
- `pytest tests/parity/dataframe/test_join.py tests/dataframe` – 1701 passed, 6 skipped.

## Non-goals

- Optimizations are scoped to the window-like **groupBy + join + orderBy** pattern and to reducing **schema collection** overhead in the Rust engine. Other workloads are covered by existing tests but may be tuned separately in future work.
- No changes to Python API or public semantics; all changes are internal to the Polars backend.
