### PR TITLE
test: datediff schema parity int not long (fixes #1404)

### DIFF
--- a/tests/dataframe/test_issue_1404_datediff_schema.py
+++ b/tests/dataframe/test_issue_1404_datediff_schema.py
@@ -1,0 +1,37 @@
+"""
+Regression test for issue #1404: datediff must return IntegerType (int), not LongType (long).
+
+PySpark: struct<dd:int>
+Sparkless (before fix): struct<dd:long>
+"""
+
+import pytest
+
+from sparkless.sql import SparkSession, functions as F
+
+
+def test_datediff_returns_integer_type_not_long():
+    """Exact repro from issue #1404: datediff result schema must be int, not long."""
+    spark = SparkSession.builder.appName("issue_1404").getOrCreate()
+    try:
+        df = spark.createDataFrame(
+            [("2020-01-10", "2020-01-02"), (None, "2020-01-02")],
+            ["a", "b"],
+        )
+        result = df.select(F.datediff(F.col("a"), F.col("b")).alias("dd"))
+
+        # PySpark returns struct<dd:int>; we must match (issue #1404).
+        simple = result.schema.simpleString()
+        assert "dd:int" in simple, (
+            f"datediff result must be IntegerType (dd:int), got schema: {simple}"
+        )
+        assert "dd:long" not in simple, (
+            f"datediff result must not be LongType (dd:long), got schema: {simple}"
+        )
+
+        rows = result.collect()
+        assert len(rows) == 2
+        assert rows[0]["dd"] == 8  # 2020-01-10 - 2020-01-02
+        assert rows[1]["dd"] is None  # null - 2020-01-02
+    finally:
+        spark.stop()


### PR DESCRIPTION
## Fixes #1404

**Issue:** [PySpark parity gap: date.datediff (mismatch in: schema) #1404](https://github.com/eddiethedean/robin-sparkless/issues/1404) — PySpark returns `struct<dd:int>`, Sparkless was returning `struct<dd:long>`.

**Schema fix:** The return type fix is already in `main`: `Column::datediff` in `crates/robin-sparkless-polars/src/column.rs` casts the result to `DataType::Int32` so the schema matches PySpark `IntegerType` (see comment in that commit).

**This PR:** Adds a regression test that reproduces the exact scenario from the issue (`createDataFrame([("2020-01-10", "2020-01-02"), (None, "2020-01-02")], ["a", "b"])` then `datediff(a, b).alias("dd")`) and asserts the schema is `dd:int` and not `dd:long`.