### PR TITLE
fix: dayofmonth return IntegerType not StringType (fixes #1403)

### DIFF
--- a/crates/robin-sparkless-polars/src/column.rs
+++ b/crates/robin-sparkless-polars/src/column.rs
@@ -2070,7 +2070,7 @@ impl Column {
         Self::from_expr(self.expr().clone().dt().day(), None)
     }
 
-    /// Alias for day. PySpark dayofmonth.
+    /// Alias for day. PySpark dayofmonth. Returns IntegerType (int) for schema parity (#1403).
     pub fn dayofmonth(&self) -> Column {
         let name = format!("dayofmonth({})", self.name());
         use polars::prelude::*;
@@ -2078,7 +2078,8 @@ impl Column {
             |s| expect_col(crate::udfs::apply_string_to_date_format(s, None, false)),
             |_schema, field| Ok(Field::new(field.name().clone(), DataType::Date)),
         );
-        Self::from_expr(parsed.dt().day().alias(&name), Some(name))
+        let day_expr = parsed.dt().day().cast(DataType::Int32);
+        Self::from_expr(day_expr.alias(&name), Some(name))
     }
 
     /// Extract quarter (1-4) from date/datetime column (PySpark quarter).

--- a/tests/dataframe/test_issue_1403_dayofmonth_schema.py
+++ b/tests/dataframe/test_issue_1403_dayofmonth_schema.py
@@ -1,0 +1,40 @@
+"""
+Regression test for issue #1403: dayofmonth must return IntegerType (int), not StringType (string).
+
+PySpark: struct<d:int>, data [{'d': None}, {'d': 2}]
+Sparkless (before fix): struct<d:string>, data [{'d': '2'}, {'d': None}]
+"""
+
+import pytest
+
+from sparkless.sql import SparkSession, functions as F
+
+
+def test_dayofmonth_returns_integer_type_not_string():
+    """Exact repro from issue #1403: dayofmonth result schema and data must be int, not string."""
+    spark = SparkSession.builder.appName("issue_1403").getOrCreate()
+    try:
+        df = spark.createDataFrame([("2020-12-02",), (None,)], ["s"])
+        result = df.select(F.dayofmonth(F.col("s")).alias("d"))
+
+        # PySpark returns struct<d:int>; we must match (issue #1403).
+        simple = result.schema.simpleString()
+        assert "d:int" in simple, (
+            f"dayofmonth result must be IntegerType (d:int), got schema: {simple}"
+        )
+        assert "d:string" not in simple, (
+            f"dayofmonth result must not be StringType (d:string), got schema: {simple}"
+        )
+
+        rows = result.collect()
+        assert len(rows) == 2
+        # Value for "2020-12-02" must be integer 2 (day of month), not string "2".
+        values = [row["d"] for row in rows]
+        assert 2 in values
+        assert None in values
+        for v in values:
+            assert v is None or isinstance(v, int), (
+                f"dayofmonth values must be int or None, got {type(v).__name__}: {v!r}"
+            )
+    finally:
+        spark.stop()


### PR DESCRIPTION
## Fixes #1403

**Issue:** [PySpark parity gap: date.dayofmonth (mismatch in: data, schema) #1403](https://github.com/eddiethedean/robin-sparkless/issues/1403)

- **Schema:** PySpark returns `struct<d:int>`, Sparkless was returning `struct<d:string>`.
- **Data:** PySpark `[{'d': None}, {'d': 2}]`, Sparkless was `[{'d': '2'}, {'d': None}]` (string `'2'` instead of int `2`).

**Cause:** `Column::dayofmonth` used `.dt().day()` without casting; the resulting type was inferred as string in the schema/collect path.

**Fix:** Cast the day-of-month expression to `DataType::Int32` in `crates/robin-sparkless-polars/src/column.rs` so the schema is IntegerType and collected values are Python `int`.

**Test:** Added `tests/dataframe/test_issue_1403_dayofmonth_schema.py` with the exact repro from the issue (createDataFrame with one string date column and one null, then `dayofmonth(s).alias("d")`), asserting schema `d:int` and values int/None.