### PR TITLE
fix: month return IntegerType not StringType (fixes #1402)

### DIFF
--- a/crates/robin-sparkless-polars/src/column.rs
+++ b/crates/robin-sparkless-polars/src/column.rs
@@ -2054,7 +2054,7 @@ impl Column {
         Self::from_expr(parsed.dt().year().alias(&name), Some(name))
     }
 
-    /// Extract month from datetime column (PySpark month)
+    /// Extract month from datetime column (PySpark month). Returns IntegerType (int) for schema parity (#1402).
     pub fn month(&self) -> Column {
         let name = format!("month({})", self.name());
         use polars::prelude::*;
@@ -2062,7 +2062,8 @@ impl Column {
             |s| expect_col(crate::udfs::apply_string_to_date_format(s, None, false)),
             |_schema, field| Ok(Field::new(field.name().clone(), DataType::Date)),
         );
-        Self::from_expr(parsed.dt().month().alias(&name), Some(name))
+        let month_expr = parsed.dt().month().cast(DataType::Int32);
+        Self::from_expr(month_expr.alias(&name), Some(name))
     }
 
     /// Extract day of month from datetime column (PySpark day)

--- a/tests/dataframe/test_issue_1402_month_schema.py
+++ b/tests/dataframe/test_issue_1402_month_schema.py
@@ -1,0 +1,41 @@
+"""
+Regression test for issue #1402: month must return IntegerType (int), not StringType (string).
+
+PySpark: struct<m:int>, data [{'m': None}, {'m': 12}]
+Sparkless (before fix): struct<m:string>, data [{'m': '12'}, {'m': None}]
+"""
+
+import pytest
+
+from sparkless.sql import SparkSession, functions as F
+
+
+def test_month_returns_integer_type_not_string():
+    """Exact repro from issue #1402: month result schema and data must be int, not string."""
+    spark = SparkSession.builder.appName("issue_1402").getOrCreate()
+    try:
+        df = spark.createDataFrame([("2020-12-02",), (None,)], ["s"])
+        result = df.select(F.month(F.col("s")).alias("m"))
+
+        # PySpark returns struct<m:int>; we must match (issue #1402).
+        simple = result.schema.simpleString()
+        assert "m:int" in simple, (
+            f"month result must be IntegerType (m:int), got schema: {simple}"
+        )
+        assert "m:string" not in simple, (
+            f"month result must not be StringType (m:string), got schema: {simple}"
+        )
+
+        rows = result.collect()
+        assert len(rows) == 2
+        # Value for "2020-12-02" must be integer 12 (month), not string "12".
+        values = [row["m"] for row in rows]
+        assert 12 in values
+        assert None in values
+        for v in values:
+            assert v is None or isinstance(v, int), (
+                f"month values must be int or None, got {type(v).__name__}: {v!r}"
+            )
+    finally:
+        spark.stop()
+


### PR DESCRIPTION
## Fixes #1402

**Issue:** [PySpark parity gap: date.month (mismatch in: data, schema) #1402](https://github.com/eddiethedean/robin-sparkless/issues/1402)

- **Schema:** PySpark returns `struct<m:int>`, Sparkless was returning `struct<m:string>`.
- **Data:** PySpark `[{'m': None}, {'m': 12}]`, Sparkless was `[{'m': '12'}, {'m': None}]` (string `'12'` instead of int `12`).

**Fix:** In `crates/robin-sparkless-polars/src/column.rs`, `Column::month` now casts `dt().month()` to `DataType::Int32` and aliases it as `month(<col>)`, so the schema is IntegerType and collected values are Python `int` or `None`.

**Test:** Added `tests/dataframe/test_issue_1402_month_schema.py` with the exact repro from the issue (`createDataFrame([('2020-12-02',), (None,)], ['s'])` and `month(s).alias('m')`), asserting schema `m:int` and values int/None.
