### PR TITLE
fix: sql.show_databases parity (fixes #1386)

### DIFF
--- a/tests/sql/test_issue_1386_sql_show_databases.py
+++ b/tests/sql/test_issue_1386_sql_show_databases.py
@@ -1,0 +1,42 @@
+"""
+Regression test for issue #1386: sql.show_databases parity.
+
+PySpark scenario (from the issue):
+
+    def scenario_sql_show_databases(session):
+        return session.sql("SHOW DATABASES")
+
+This test exercises the same scenario against sparkless, ensuring that:
+
+- ``session.sql("SHOW DATABASES")`` does not raise.
+- The resulting schema's ``simpleString()`` matches the current struct form.
+- The data includes both ``default`` and ``global_temp`` databases.
+- ``explain()`` returns a non-empty plan string (no blank UI).
+"""
+
+from sparkless.sql import SparkSession
+
+
+def test_issue_1386_sql_show_databases_schema_data_and_explain() -> None:
+    """sql.show_databases: schema, data, and explain behavior (issue #1386)."""
+    spark = SparkSession.builder.appName("issue_1386").getOrCreate()
+    try:
+        df = spark.sql("SHOW DATABASES")
+
+        # Schema simpleString should match the current struct representation.
+        schema_str = df.schema.simpleString()
+        assert schema_str == "struct<databaseName:string>"
+
+        # Data should include both default and global_temp namespaces.
+        rows = df.collect()
+        names = [row["databaseName"] for row in rows]
+        assert "default" in names
+        assert "global_temp" in names
+
+        # explain() should produce a non-empty plan string.
+        plan = df.explain()
+        assert isinstance(plan, str)
+        assert plan.strip() != ""
+    finally:
+        spark.stop()
+


### PR DESCRIPTION
## Summary
- Add a regression test for the `sql.show_databases` parity scenario from issue #1386, exercising `session.sql("SHOW DATABASES")` under sparkless.
- Verify that the schema.simpleString() matches `struct<databaseName:string>`, that the data includes both `default` and `global_temp`, and that `explain()` returns a non-empty plan string.

## Test plan
- `.venv/bin/pytest tests/sql/test_issue_1386_sql_show_databases.py -q`