### PR TITLE
fix: cast.invalid_string_to_int parity (fixes #1392)

### DIFF
--- a/python/sparkless/sparkless/sql/types.py
+++ b/python/sparkless/sparkless/sql/types.py
@@ -247,9 +247,16 @@ class StructType(DataType):
 
         def _dtype_json(dt: DataType):
             # Primitive types map to simple strings (e.g. \"string\").
-            from sparkless.sql.types import ArrayType as _ArrayType, MapType as _MapType  # avoid cycles
+            from sparkless.sql.types import (  # avoid cycles
+                ArrayType as _ArrayType,
+                MapType as _MapType,
+                IntegerType as _IntegerType,
+            )
 
             if isinstance(dt, DataType) and hasattr(dt, "simpleString"):
+                # IntegerType: JSON type name is \"integer\" (PySpark jsonValue).
+                if isinstance(dt, _IntegerType):
+                    return "integer"
                 # ArrayType: {"type": "array", "elementType": <inner>, "containsNull": bool}
                 if isinstance(dt, _ArrayType):
                     inner = getattr(dt, "elementType", None)

--- a/tests/dataframe/test_issue_1392_cast_invalid_string_to_int.py
+++ b/tests/dataframe/test_issue_1392_cast_invalid_string_to_int.py
@@ -1,0 +1,56 @@
+"""Regression test for issue #1392: cast.invalid_string_to_int parity.
+
+PySpark scenario (from the issue body):
+
+    def scenario_cast_invalid_string(session):
+        \"\"\"Invalid string -> int cast; compare error vs null semantics.\"\"\"
+        if _backend_is_pyspark(session):
+            from pyspark.sql import functions as F  # type: ignore
+        else:
+            from sparkless.sql import functions as F  # type: ignore
+
+        df = session.createDataFrame([(\"nope\",)], [\"s\"])
+        return df.select(F.col(\"s\").cast(\"int\").alias(\"i\"))
+
+This test locks in Sparkless behavior for:
+- Semantics: invalid string -> int cast yields null (no error), like PySpark.
+- Schema JSON (`schema.jsonValue()`): struct with integer field type.
+- UI / explain: `DataFrame.explain()` returns a non-empty description.
+"""
+
+from __future__ import annotations
+
+from sparkless.sql import SparkSession, functions as F
+
+
+def test_issue_1392_cast_invalid_string_to_int_schema_and_explain() -> None:
+    spark = SparkSession.builder.appName("issue_1392_cast_invalid_string_to_int").getOrCreate()
+    try:
+        df = spark.createDataFrame([("nope",)], ["s"])
+        out = df.select(F.col("s").cast("int").alias("i"))
+
+        rows = out.collect()
+        assert len(rows) == 1
+        # Invalid string -> int should yield null, not raise.
+        assert rows[0]["i"] is None
+
+        # Schema simpleString parity (existing behavior).
+        assert out.schema.simpleString() == "struct<i:int>"
+
+        # Schema JSON parity: integer field with nullable=True and empty metadata.
+        schema_json = out.schema.jsonValue()
+        assert schema_json["type"] == "struct"
+        assert len(schema_json["fields"]) == 1
+        field = schema_json["fields"][0]
+        assert field["name"] == "i"
+        assert field["nullable"] is True
+        assert field["metadata"] == {}
+        assert field["type"] == "integer"
+
+        # UI / explain parity: explain() should emit a non-empty description.
+        explain_str = out.explain(True)
+        assert isinstance(explain_str, str)
+        assert explain_str.strip() != ""
+    finally:
+        spark.stop()
+


### PR DESCRIPTION
## Summary

- Add a regression test that reproduces the cast.invalid_string_to_int parity-hunt scenario, asserting that invalid string-to-int casts yield null, not errors.
- Extend StructType.jsonValue() so IntegerType fields are emitted as JSON type 'integer', matching PySpark's schema JSON for integer columns.
- Confirm that DataFrame.explain() already returns a non-empty plan description, satisfying the UI parity requirement for this scenario.

## Test Plan

- python -m venv .venv && source .venv/bin/activate
- maturin develop -m python/Cargo.toml
- pytest tests/dataframe/test_issue_1392_cast_invalid_string_to_int.py
- pytest tests -n 10