### PR TITLE
fix: join.on_expression parity (fixes #1393)

### DIFF
--- a/crates/robin-sparkless-polars/src/dataframe/transformations.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/transformations.rs
@@ -770,6 +770,12 @@ pub fn order_by(
         asc.push(true);
     }
     asc.truncate(column_names.len());
+    // Before resolving column names, enforce ambiguous-column semantics for
+    // unqualified user-facing orderBy references, just like select/select_items
+    // do via check_ambiguous_unqualified (#1393).
+    for name in &column_names {
+        df.check_ambiguous_unqualified(name)?;
+    }
     let resolved: Vec<String> = column_names
         .iter()
         .map(|c| df.resolve_column_name(c))

--- a/tests/dataframe/test_issue_1393_join_on_expression.py
+++ b/tests/dataframe/test_issue_1393_join_on_expression.py
@@ -1,0 +1,46 @@
+"""Regression test for issue #1393: join.on_expression parity.
+
+Scenario from the issue:
+
+    def scenario_join_on_expression(session):
+        df1 = session.createDataFrame([(1, "a"), (2, "b")], ["id", "v"])
+        df2 = session.createDataFrame([(1, "x"), (3, "y")], ["id", "w"])
+        return df1.join(df2, on=df1["id"] == df2["id"], how="inner").orderBy("id")
+
+PySpark raises an AnalysisException for the unqualified/ambiguous ORDER BY
+column `id` after the join. Sparkless should not silently succeed; this test
+locks in the expectation that Sparkless raises a SparklessError for the
+ambiguous column reference.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sparkless.errors import SparklessError
+from sparkless.sql import SparkSession, functions as F
+
+
+def _scenario_join_on_expression(session: SparkSession):
+    df1 = session.createDataFrame([(1, "a"), (2, "b")], ["id", "v"])
+    df2 = session.createDataFrame([(1, "x"), (3, "y")], ["id", "w"])
+    return df1.join(df2, on=df1["id"] == df2["id"], how="inner").orderBy("id")
+
+
+def test_issue_1393_join_on_expression_ambiguous_order_by_raises() -> None:
+    """join(on expression) followed by orderBy(\"id\") should raise SparklessError for ambiguity."""
+    spark = SparkSession.builder.appName("issue_1393_join_on_expression").getOrCreate()
+    try:
+        with pytest.raises(SparklessError) as excinfo:
+            df = _scenario_join_on_expression(spark)
+            # Trigger execution (the error may surface on collect).
+            _ = df.collect()
+
+        msg = str(excinfo.value)
+        # Lock in current ambiguous/column-not-found error shape so future
+        # changes are intentional and visible in tests.
+        assert "unresolved_column" in msg or "AMBIGUOUS_REFERENCE" in msg
+        assert "id" in msg
+    finally:
+        spark.stop()
+


### PR DESCRIPTION
## Summary

- Add a regression test that reproduces the join.on_expression parity-hunt scenario, asserting that a join on an equality expression followed by orderBy('id') raises a SparklessError for ambiguous column reference (matching PySpark's AnalysisException).
- Update the Polars backend  implementation to call  on user-facing sort column names before resolving them, so ambiguous join keys surface as AMBIGUOUS_REFERENCE instead of silently picking a side.

## Test Plan

- python -m venv .venv && source .venv/bin/activate
- maturin develop -m python/Cargo.toml
- pytest tests/dataframe/test_issue_1393_join_on_expression.py
- pytest tests -n 10