### PR TITLE
fix: string.concat_ws parity (fixes #1395)

### DIFF
--- a/crates/robin-sparkless-polars/src/functions/rest.rs
+++ b/crates/robin-sparkless-polars/src/functions/rest.rs
@@ -2330,7 +2330,10 @@ pub fn concat_ws(separator: &str, columns: &[&Column]) -> Column {
         .iter()
         .map(|c| c.expr().clone().cast(DataType::String))
         .collect();
-    crate::column::Column::from_expr(concat_str(&exprs, separator, false), None)
+    // PySpark semantics: concat_ws ignores nulls across all arguments, and returns
+    // null only when all inputs are null. Polars' concat_str with ignore_nulls=true
+    // implements the same behavior.
+    crate::column::Column::from_expr(concat_str(&exprs, separator, true), None)
 }
 
 /// Row number window function (1, 2, 3 by order within partition).

--- a/tests/dataframe/test_issue_1395_string_concat_ws.py
+++ b/tests/dataframe/test_issue_1395_string_concat_ws.py
@@ -1,0 +1,49 @@
+"""Regression test for issue #1395: string.concat_ws parity.
+
+PySpark scenario (from the issue body, paraphrased):
+
+    lambda session: session.createDataFrame(
+        [("a", "b"), ("a", None), (None, "c")],
+        ["a", "b"],
+    )
+
+Expected PySpark behavior for:
+
+    df.select(F.concat_ws("-", "a", "b").alias("out"))
+
+is:
+
+    [{'out': 'a-b'}, {'out': 'a'}, {'out': 'c'}]
+
+Sparkless previously produced:
+
+    [{'out': 'a-b'}, {'out': None}, {'out': None}]
+
+This test locks in the PySpark semantics:
+- nulls are ignored (dropped) from concat_ws arguments;
+- rows with all-null inputs yield null.
+"""
+
+from __future__ import annotations
+
+from sparkless.sql import SparkSession, functions as F
+
+
+def test_issue_1395_string_concat_ws_null_handling() -> None:
+    spark = SparkSession.builder.appName("issue_1395_string_concat_ws").getOrCreate()
+    try:
+        df = spark.createDataFrame(
+            [("a", "b"), ("a", None), (None, "c")],
+            ["a", "b"],
+        )
+        out = df.select(F.concat_ws("-", "a", "b").alias("out"))
+
+        rows = [{k: v for k, v in r.asDict().items()} for r in out.collect()]
+        assert rows == [
+            {"out": "a-b"},
+            {"out": "a"},
+            {"out": "c"},
+        ]
+    finally:
+        spark.stop()
+


### PR DESCRIPTION
## Summary

- Add a regression test that reproduces the string.concat_ws parity-hunt scenario with rows (a,b), (a,None), (None,c) and asserts PySpark semantics: ['a-b', 'a', 'c'].
- Update the Polars backend  implementation to ignore nulls across all arguments and return null only when all inputs are null, by using  with .

## Test Plan

- python -m venv .venv && source .venv/bin/activate
- maturin develop -m python/Cargo.toml
- pytest tests/dataframe/test_issue_1395_string_concat_ws.py
- pytest tests -n 10