### PR TITLE
fix: string.regexp_extract parity (fixes #1396)

### DIFF
--- a/crates/robin-sparkless-polars/src/column.rs
+++ b/crates/robin-sparkless-polars/src/column.rs
@@ -1062,12 +1062,12 @@ impl Column {
         } else {
             let pat = pattern.to_string();
             Self::from_expr(
-                // PySpark implicitly casts non-string inputs to string for regex functions.
-                self.expr()
-                    .clone()
-                    .cast(DataType::String)
-                    .str()
-                    .extract(lit(pat), group_index),
+                // PySpark implicitly casts non-string inputs to string for regex functions,
+                // returns empty string for no-match, and null only for null input.
+                self.expr().clone().map(
+                    move |s| expect_col(crate::udfs::apply_regexp_extract(s, &pat, group_index)),
+                    |_schema, field| Ok(Field::new(field.name().clone(), DataType::String)),
+                ),
                 None,
             )
         }

--- a/crates/robin-sparkless-polars/src/udfs/rest.rs
+++ b/crates/robin-sparkless-polars/src/udfs/rest.rs
@@ -1687,10 +1687,58 @@ pub fn apply_regexp_extract_lookaround(
     let out = StringChunked::from_iter_options(
         name.as_str().into(),
         ca.into_iter().map(|opt_s| {
-            opt_s.and_then(|s| {
-                let caps = re.captures(s).ok().flatten()?;
-                let m = caps.get(group_index)?;
-                Some(m.as_str().to_string())
+            // Null input stays null; no-match yields empty string (PySpark parity).
+            opt_s.map(|s| {
+                let caps_opt = re.captures(s).ok().flatten();
+                if let Some(caps) = caps_opt {
+                    if let Some(m) = caps.get(group_index) {
+                        return m.as_str().to_string();
+                    }
+                }
+                String::new()
+            })
+        }),
+    );
+    Ok(Some(Column::new(name, out.into_series())))
+}
+
+/// regexp_extract using regex crate (no lookaround). PySpark semantics:
+/// - null input -> null
+/// - non-null, no match -> empty string
+/// - non-null, match -> captured group (or full match for group 0).
+pub fn apply_regexp_extract(
+    column: Column,
+    pattern: &str,
+    group_index: usize,
+) -> PolarsResult<Option<Column>> {
+    use regex::Regex;
+    use polars::prelude::*;
+    let name = column.field().into_owned().name;
+    let series = column.take_materialized_series();
+    let casted = if series.dtype() == &DataType::String {
+        series
+    } else {
+        series
+            .cast(&DataType::String)
+            .map_err(|e| compute_err("regexp_extract cast", e))?
+    };
+    let ca = casted
+        .str()
+        .map_err(|e| compute_err("regexp_extract", e))?;
+    let re = Regex::new(pattern)
+        .map_err(|e| compute_err(&format!("regexp_extract invalid regex '{pattern}'"), e))?;
+    let out = StringChunked::from_iter_options(
+        name.as_str().into(),
+        ca.into_iter().map(|opt_s| {
+            // Null input stays null; no-match yields empty string (PySpark parity).
+            opt_s.map(|s| {
+                let caps_opt = re.captures(s);
+                if let Some(caps) = caps_opt {
+                    if let Some(m) = caps.get(group_index) {
+                        return m.as_str().to_string();
+                    }
+                }
+                String::new()
             })
         }),
     );

--- a/tests/dataframe/test_issue_1396_string_regexp_extract.py
+++ b/tests/dataframe/test_issue_1396_string_regexp_extract.py
@@ -1,0 +1,37 @@
+"""Regression test for issue #1396: string.regexp_extract parity.
+
+Scenario (paraphrased from the issue):
+
+    df = session.createDataFrame([("abc123",), ("zzz",), (None,)], ["s"])
+    df.select(F.regexp_extract("s", r"(\d+)$", 1).alias("out"))
+
+PySpark semantics for regexp_extract:
+- null input -> null
+- non-null input with no match -> empty string
+- non-null input with match -> captured substring
+
+This test locks in that behavior for Sparkless.
+"""
+
+from __future__ import annotations
+
+from sparkless.sql import SparkSession, functions as F
+
+
+def test_issue_1396_string_regexp_extract_null_and_no_match() -> None:
+    spark = SparkSession.builder.appName("issue_1396_string_regexp_extract").getOrCreate()
+    try:
+        df = spark.createDataFrame(
+            [("abc123",), ("zzz",), (None,)],
+            ["s"],
+        )
+        out = df.select(F.regexp_extract("s", r"(\d+)$", 1).alias("out"))
+
+        # Preserve input order to make expectations clear.
+        rows = [r["out"] for r in out.collect()]
+        # Match expected PySpark behavior for this pattern: non-matching input
+        # yields empty string; null input yields null.
+        assert rows == ["123", "", None]
+    finally:
+        spark.stop()
+


### PR DESCRIPTION
## Summary

- Add a regression test for the string.regexp_extract parity-hunt scenario over rows ('abc123'), ('zzz'), (None) and pattern r'(\d+)$', asserting that Sparkless returns ['123', '', None] like PySpark.
- Implement a dedicated regexp_extract helper in the Polars backend (and update the lookaround path) so that:
  - null input yields null
  - non-null inputs with no match yield an empty string
  - matching inputs yield the requested capture group.

## Test Plan

- python -m venv .venv && source .venv/bin/activate
- maturin develop -m python/Cargo.toml
- pytest tests/dataframe/test_issue_1396_string_regexp_extract.py
- pytest tests -n 10