### PR TITLE
test: string.split_basic parity (issue #1397)

### DIFF
--- a/tests/dataframe/test_issue_1397_string_split_basic.py
+++ b/tests/dataframe/test_issue_1397_string_split_basic.py
@@ -1,0 +1,37 @@
+"""Regression test for issue #1397: string.split_basic parity.
+
+Scenario (from the issue, reconstructed):
+
+    df = session.createDataFrame([("a,b,c",), ("a",), (None,)], ["s"])
+    df.select(F.split("s", ",").alias("arr")).orderBy("s")
+
+Previously, Sparkless raised a SparklessError:
+
+    unresolved_column: cannot be resolved: not found: cannot resolve: column 's' not found.
+    Available columns: [arr].
+
+PySpark succeeds for this scenario. This test locks in the expectation that
+Sparkless also succeeds (no unresolved_column error) and returns a 3-row
+DataFrame with an array<string> column.
+"""
+
+from __future__ import annotations
+
+from sparkless.sql import SparkSession, functions as F
+
+
+def test_issue_1397_string_split_basic_no_unresolved_column_error() -> None:
+    spark = SparkSession.builder.appName("issue_1397_string_split_basic").getOrCreate()
+    try:
+        df = spark.createDataFrame(
+            [("a,b,c",), ("a",), (None,)],
+            ["s"],
+        )
+        out = df.select(F.split("s", ",").alias("arr")).orderBy("s")
+
+        rows = list(out.collect())
+        assert len(rows) == 3
+        assert out.schema.simpleString() == "struct<arr:array<string>>"
+    finally:
+        spark.stop()
+


### PR DESCRIPTION
## Summary

- Add a regression test that exercises the string.split_basic parity-hunt scenario: df.select(F.split('s', ',').alias('arr')).orderBy('s') over rows ('a,b,c'), ('a'), (None).
- Assert that Sparkless no longer raises an unresolved_column error for 's' and returns a 3-row DataFrame with arr: array<string>.

## Test Plan

- python -m venv .venv && source .venv/bin/activate
- maturin develop -m python/Cargo.toml
- pytest tests/dataframe/test_issue_1397_string_split_basic.py
- pytest tests -n 10