### PR TITLE
fix: numeric.floor schema parity (fixes #1398)

### DIFF
--- a/crates/robin-sparkless-polars/src/column.rs
+++ b/crates/robin-sparkless-polars/src/column.rs
@@ -1634,7 +1634,15 @@ impl Column {
 
     /// Floor (PySpark floor)
     pub fn floor(&self) -> Column {
-        Self::from_expr(self.expr().clone().floor(), None)
+        use polars::prelude::*;
+        // PySpark floor returns an integral (bigint) type. Cast the floor result
+        // to Int64 so the schema reflects LongType/bigint instead of double.
+        let expr = self
+            .expr()
+            .clone()
+            .floor()
+            .cast(DataType::Int64);
+        Self::from_expr(expr, None)
     }
 
     /// Round to given decimal places (PySpark round). scale can be negative (e.g. -3 rounds to thousands).

--- a/tests/dataframe/test_issue_1398_numeric_floor_schema.py
+++ b/tests/dataframe/test_issue_1398_numeric_floor_schema.py
@@ -1,0 +1,46 @@
+"""Regression test for issue #1398: numeric.floor schema parity.
+
+Scenario (from the issue, paraphrased):
+
+    df = session.createDataFrame([(1.9,), (-1.1,), (None,)], ["x"])
+    df.select(F.floor("x").alias("out"))
+
+PySpark schema:
+
+    struct<out:bigint>
+
+Sparkless schema (before fix):
+
+    struct<out:double>
+
+This test locks in PySpark parity for the output schema: floor() should yield
+an integral type (bigint in PySpark, LongType in Sparkless).
+"""
+
+from __future__ import annotations
+
+from sparkless.sql import SparkSession, functions as F
+from sparkless.sql.types import LongType
+
+
+def test_issue_1398_numeric_floor_schema_is_long() -> None:
+    spark = SparkSession.builder.appName("issue_1398_numeric_floor_schema").getOrCreate()
+    try:
+        df = spark.createDataFrame(
+            [(1.9,), (-1.1,), (None,)],
+            ["x"],
+        )
+        out = df.select(F.floor("x").alias("out"))
+
+        # Value semantics: floor matches PySpark (sanity check).
+        rows = [r["out"] for r in out.collect()]
+        assert rows == [1, -2, None]
+
+        # Schema parity: floor outputs an integral type. Sparkless uses LongType()
+        # with simpleString \"long\"; PySpark reports bigint. We assert LongType
+        # here, and higher-level parity harness can remap \"long\" vs \"bigint\".
+        field = out.schema.fields[0]
+        assert isinstance(field.dataType, LongType)
+    finally:
+        spark.stop()
+


### PR DESCRIPTION
## Summary

- Add a regression test for the numeric.floor parity-hunt scenario over rows (1.9), (-1.1), (None), asserting that Sparkless returns [1, -2, None] and uses LongType for the result column.
- Update the Polars backend Column.floor implementation to cast the floor result to Int64 so the schema reflects an integral type (LongType / bigint) instead of double.

## Test Plan

- python -m venv .venv && source .venv/bin/activate
- maturin develop -m python/Cargo.toml
- pytest tests/dataframe/test_issue_1398_numeric_floor_schema.py
- pytest tests -n 10