### PR TITLE
fix: Add tests for window function rejection in filter (closes #1469)

### DIFF
--- a/crates/robin-sparkless-polars/src/dataframe/transformations.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/transformations.rs
@@ -2868,4 +2868,68 @@ mod tests {
             "#1105: filter on string column must return 1 row"
         );
     }
+
+    /// #1469: Window functions in filter/WHERE must be rejected (PySpark parity).
+    #[test]
+    fn filter_rejects_window_function_in_condition() {
+        use crate::column::Column;
+        use polars::prelude::{df, lit};
+
+        let pl = df!["id" => &[1i64, 2, 3], "value" => &[100i64, 200, 300]].unwrap();
+        let df = DataFrame::from_polars_with_options(pl, false);
+
+        // Create a window expression: row_number().over([]).eq(1)
+        let row_num = Column::row_number_over(&[], &["value".to_string()]).unwrap();
+        let condition = row_num.eq(lit(1i64)).into_expr();
+
+        let result = filter(&df, condition, false);
+        assert!(
+            result.is_err(),
+            "#1469: filter with window function must fail"
+        );
+        match result {
+            Err(e) => {
+                let err_msg = e.to_string();
+                assert!(
+                    err_msg.contains("window functions inside WHERE clause"),
+                    "#1469: error message must mention window functions in WHERE clause, got: {err_msg}"
+                );
+            }
+            Ok(_) => panic!("#1469: filter with window function should have failed"),
+        }
+    }
+
+    /// #1469: expr_contains_over detects Expr::Over in nested expressions.
+    #[test]
+    fn expr_contains_over_detects_nested_window() {
+        use polars::prelude::{col, lit};
+
+        // Simple Over expression
+        let over_expr = col("value").over(vec![lit(1i32)]);
+        assert!(
+            super::expr_contains_over(&over_expr),
+            "expr_contains_over must detect simple Over"
+        );
+
+        // Over inside BinaryExpr (e.g. row_number().over(w) == 1)
+        let binary_with_over = over_expr.clone().eq(lit(1i64));
+        assert!(
+            super::expr_contains_over(&binary_with_over),
+            "expr_contains_over must detect Over inside BinaryExpr"
+        );
+
+        // Over inside Alias
+        let aliased_over = over_expr.clone().alias("rn");
+        assert!(
+            super::expr_contains_over(&aliased_over),
+            "expr_contains_over must detect Over inside Alias"
+        );
+
+        // No Over - should return false
+        let simple_expr = col("value").gt(lit(10i64));
+        assert!(
+            !super::expr_contains_over(&simple_expr),
+            "expr_contains_over must return false for non-window expression"
+        );
+    }
 }

--- a/tests/parity/functions/test_window_function_comparison_parity.py
+++ b/tests/parity/functions/test_window_function_comparison_parity.py
@@ -81,7 +81,11 @@ class TestWindowFunctionComparisonParity:
         reason="PySpark parity test - only run with SPARKLESS_TEST_MODE=pyspark",
     )
     def test_window_function_comparison_in_filter_parity(self):
-        """Test WindowFunction comparison in filter matches PySpark."""
+        """Test WindowFunction comparison in filter raises error (PySpark parity).
+
+        PySpark raises AnalysisException: "It is not allowed to use window
+        functions inside WHERE clause." Sparkless must match this behavior.
+        """
         spark = SparkSession.builder.appName("issue-336-parity").getOrCreate()
         try:
             df = spark.createDataFrame(
@@ -93,13 +97,15 @@ class TestWindowFunctionComparisonParity:
             )
 
             w = Window().partitionBy("Type").orderBy(F.col("Score").desc())
-            result = df.filter(F.row_number().over(w) == 1).select(
-                "Name", "Type", "Score"
-            )
-            rows = result.collect()
+            # PySpark raises AnalysisException for window functions in WHERE clause
+            with pytest.raises(Exception) as exc_info:
+                df.filter(F.row_number().over(w) == 1).select(
+                    "Name", "Type", "Score"
+                ).collect()
 
-            assert len(rows) == 1
-            assert rows[0]["Name"] == "Alice"
-            assert rows[0]["Score"] == 100
+            msg = str(exc_info.value).lower()
+            assert "window" in msg and "where" in msg, (
+                f"Expected error about window functions in WHERE clause, got: {exc_info.value}"
+            )
         finally:
             spark.stop()


### PR DESCRIPTION
## Summary

- Add Rust tests verifying that window functions are correctly rejected in filter/WHERE clauses
- Fix parity test `test_window_function_comparison_in_filter_parity` to expect an error instead of success

## Details

PySpark raises `AnalysisException: "It is not allowed to use window functions inside WHERE clause"` when window functions are used in filter conditions. The Rust validation was already correctly implemented via `expr_contains_over` in `transformations.rs`, but there were no tests to verify this behavior.

The parity test was incorrectly expecting the filter to succeed and return rows, when it should have been testing that an error is raised.

## Test plan

- [x] `cargo test -p robin-sparkless-polars filter_rejects_window` - verifies Rust validation
- [x] `cargo test -p robin-sparkless-polars expr_contains_over` - verifies window detection in nested expressions
- [x] Python manual test confirms error is raised: `df.filter(F.row_number().over(w) == 1)` raises `SparklessError: it is not allowed to use window functions inside WHERE clause`
- [x] `pytest tests/dataframe/test_issue_336_window_function_comparison.py::TestIssue336WindowFunctionComparison::test_window_function_comparison_with_filter` - passes

Closes #1469