### PR TITLE
fix: ntile() handles NULL values with PySpark parity

### DIFF
--- a/crates/robin-sparkless-polars/src/column.rs
+++ b/crates/robin-sparkless-polars/src/column.rs
@@ -2794,6 +2794,10 @@ impl Column {
     }
 
     /// Ntile: bucket 1..n by rank within partition (ceil(rank * n / count)). Window is applied; do not call .over() again.
+    /// PySpark parity (#1484): NULL values in the ORDER BY column are handled as follows:
+    /// - Ascending: NULLs come FIRST (fill with NEG_INFINITY so they rank lowest)
+    /// - Descending: NULLs come LAST (fill with NEG_INFINITY so they rank highest when descending)
+    /// ntile always returns an integer, even for rows where ORDER BY column is NULL.
     pub fn ntile(&self, n: u32, partition_by: &[&str], descending: bool) -> Column {
         use polars::prelude::*;
         let partition_exprs: Vec<Expr> = if partition_by.is_empty() {
@@ -2805,12 +2809,17 @@ impl Column {
             method: RankMethod::Ordinal,
             descending,
         };
-        let rank_expr = self
+        // Fill nulls with NEG_INFINITY so they rank correctly:
+        // - Ascending: NEG_INFINITY is smallest, so nulls rank first
+        // - Descending: NEG_INFINITY is smallest, so it ranks last when sorted descending
+        let filled_expr = self
             .expr()
             .clone()
-            .rank(opts, None)
-            .over(partition_exprs.clone());
-        let count_expr = self.expr().clone().count().over(partition_exprs.clone());
+            .cast(DataType::Float64)
+            .fill_null(lit(f64::NEG_INFINITY));
+        let rank_expr = filled_expr.clone().rank(opts, None).over(partition_exprs.clone());
+        // Count ALL rows including nulls (use len() instead of count())
+        let count_expr = len().over(partition_exprs.clone());
         let n_expr = lit(n as f64);
         let rank_f = rank_expr.cast(DataType::Float64);
         let count_f = count_expr.cast(DataType::Float64);

--- a/tests/parity/dataframe/test_ntile_nulls.py
+++ b/tests/parity/dataframe/test_ntile_nulls.py
@@ -1,0 +1,196 @@
+"""
+Tests for ntile() window function with NULL values.
+
+Issue #1484: ntile() was handling NULL values differently than PySpark:
+1. NULL ordering: PySpark puts NULLs first in ascending, last in descending
+2. ntile for NULL rows: should return integer, not NULL
+
+These tests work with both sparkless and PySpark backends.
+Set SPARKLESS_TEST_MODE=pyspark to run with real PySpark.
+"""
+
+from sparkless.testing import get_imports
+
+imports = get_imports()
+F = imports.F
+Window = imports.Window
+
+
+class TestNtileNulls:
+    """Test ntile() handles NULL values like PySpark."""
+
+    def test_ntile_nulls_ascending(self, spark):
+        """Test ntile() with NULL in ascending order - NULL should come first (#1484)."""
+        df = spark.createDataFrame([
+            {"grp": "A", "val": 1},
+            {"grp": "A", "val": None},
+            {"grp": "A", "val": 2},
+            {"grp": "A", "val": 3},
+        ], schema="grp string, val int")
+
+        w = Window.partitionBy("grp").orderBy("val")
+        result = df.withColumn("ntile", F.ntile(2).over(w))
+        rows = result.orderBy("val").collect()
+
+        # PySpark behavior: NULL comes first in ascending order
+        # 4 rows, ntile(2): first 2 get bucket 1, last 2 get bucket 2
+        assert len(rows) == 4
+        
+        # NULL row should be first and have ntile=1 (not NULL!)
+        null_row = next((r for r in rows if r["val"] is None), None)
+        assert null_row is not None
+        assert null_row["ntile"] == 1, f"NULL row should have ntile=1, got {null_row['ntile']}"
+
+        # Row with val=1 should have ntile=1 (second row in ascending)
+        row_1 = next((r for r in rows if r["val"] == 1), None)
+        assert row_1["ntile"] == 1
+
+        # Row with val=2 should have ntile=2
+        row_2 = next((r for r in rows if r["val"] == 2), None)
+        assert row_2["ntile"] == 2
+
+        # Row with val=3 should have ntile=2
+        row_3 = next((r for r in rows if r["val"] == 3), None)
+        assert row_3["ntile"] == 2
+
+    def test_ntile_nulls_descending(self, spark):
+        """Test ntile() with NULL in descending order - NULL should come last (#1484)."""
+        df = spark.createDataFrame([
+            {"grp": "A", "val": 1},
+            {"grp": "A", "val": None},
+            {"grp": "A", "val": 2},
+            {"grp": "A", "val": 3},
+        ], schema="grp string, val int")
+
+        w = Window.partitionBy("grp").orderBy(F.col("val").desc())
+        result = df.withColumn("ntile", F.ntile(2).over(w))
+        rows = result.collect()
+
+        # PySpark behavior: NULL comes last in descending order
+        # Order: 3, 2, 1, NULL -> ntile: 1, 1, 2, 2
+        assert len(rows) == 4
+
+        # Row with val=3 should be first, ntile=1
+        row_3 = next((r for r in rows if r["val"] == 3), None)
+        assert row_3["ntile"] == 1
+
+        # Row with val=2 should have ntile=1
+        row_2 = next((r for r in rows if r["val"] == 2), None)
+        assert row_2["ntile"] == 1
+
+        # Row with val=1 should have ntile=2
+        row_1 = next((r for r in rows if r["val"] == 1), None)
+        assert row_1["ntile"] == 2
+
+        # NULL row should be last and have ntile=2 (not NULL!)
+        null_row = next((r for r in rows if r["val"] is None), None)
+        assert null_row is not None
+        assert null_row["ntile"] == 2, f"NULL row should have ntile=2, got {null_row['ntile']}"
+
+    def test_ntile_all_nulls(self, spark):
+        """Test ntile() when all ORDER BY values are NULL."""
+        df = spark.createDataFrame([
+            {"grp": "A", "val": None},
+            {"grp": "A", "val": None},
+            {"grp": "A", "val": None},
+            {"grp": "A", "val": None},
+        ], schema="grp string, val int")
+
+        w = Window.partitionBy("grp").orderBy("val")
+        result = df.withColumn("ntile", F.ntile(2).over(w))
+        rows = result.collect()
+
+        assert len(rows) == 4
+        # All rows should have integer ntile values (1 or 2), not NULL
+        ntile_values = [r["ntile"] for r in rows]
+        assert all(v is not None for v in ntile_values), "ntile should never be NULL"
+        assert set(ntile_values) == {1, 2}, f"Expected ntile values 1 and 2, got {set(ntile_values)}"
+
+    def test_ntile_no_nulls(self, spark):
+        """Test ntile() without NULL values still works correctly."""
+        df = spark.createDataFrame([
+            {"grp": "A", "val": 1},
+            {"grp": "A", "val": 2},
+            {"grp": "A", "val": 3},
+            {"grp": "A", "val": 4},
+        ])
+
+        w = Window.partitionBy("grp").orderBy("val")
+        result = df.withColumn("ntile", F.ntile(2).over(w))
+        rows = result.orderBy("val").collect()
+
+        assert len(rows) == 4
+        assert rows[0]["val"] == 1 and rows[0]["ntile"] == 1
+        assert rows[1]["val"] == 2 and rows[1]["ntile"] == 1
+        assert rows[2]["val"] == 3 and rows[2]["ntile"] == 2
+        assert rows[3]["val"] == 4 and rows[3]["ntile"] == 2
+
+    def test_ntile_multiple_groups_with_nulls(self, spark):
+        """Test ntile() with NULL values across multiple groups."""
+        df = spark.createDataFrame([
+            {"grp": "A", "val": 1},
+            {"grp": "A", "val": None},
+            {"grp": "A", "val": 2},
+            {"grp": "B", "val": None},
+            {"grp": "B", "val": 10},
+        ], schema="grp string, val int")
+
+        w = Window.partitionBy("grp").orderBy("val")
+        result = df.withColumn("ntile", F.ntile(2).over(w))
+        rows = result.collect()
+
+        # Group A: 3 rows, ntile(2) -> [1, 1, 2] for [NULL, 1, 2]
+        grp_a = [r for r in rows if r["grp"] == "A"]
+        assert len(grp_a) == 3
+        null_a = next((r for r in grp_a if r["val"] is None), None)
+        assert null_a["ntile"] == 1
+
+        # Group B: 2 rows, ntile(2) -> [1, 2] for [NULL, 10]
+        grp_b = [r for r in rows if r["grp"] == "B"]
+        assert len(grp_b) == 2
+        null_b = next((r for r in grp_b if r["val"] is None), None)
+        assert null_b["ntile"] == 1
+        val_10 = next((r for r in grp_b if r["val"] == 10), None)
+        assert val_10["ntile"] == 2
+
+    def test_ntile_single_null_row(self, spark):
+        """Test ntile() with a single NULL row."""
+        df = spark.createDataFrame([
+            {"grp": "A", "val": None},
+        ], schema="grp string, val int")
+
+        w = Window.partitionBy("grp").orderBy("val")
+        result = df.withColumn("ntile", F.ntile(2).over(w))
+        rows = result.collect()
+
+        assert len(rows) == 1
+        assert rows[0]["ntile"] == 1, "Single row should have ntile=1"
+
+    def test_ntile_ntile3_with_nulls(self, spark):
+        """Test ntile(3) with NULL values."""
+        df = spark.createDataFrame([
+            {"grp": "A", "val": None},
+            {"grp": "A", "val": 1},
+            {"grp": "A", "val": 2},
+            {"grp": "A", "val": 3},
+            {"grp": "A", "val": 4},
+            {"grp": "A", "val": 5},
+        ], schema="grp string, val int")
+
+        w = Window.partitionBy("grp").orderBy("val")
+        result = df.withColumn("ntile", F.ntile(3).over(w))
+        rows = result.orderBy("val").collect()
+
+        # 6 rows, ntile(3): [1,1], [2,2], [3,3]
+        # Order: NULL, 1, 2, 3, 4, 5
+        assert len(rows) == 6
+        
+        # NULL comes first
+        null_row = next((r for r in rows if r["val"] is None), None)
+        assert null_row["ntile"] == 1
+
+        # Check distribution
+        ntile_values = [r["ntile"] for r in rows]
+        assert ntile_values.count(1) == 2
+        assert ntile_values.count(2) == 2
+        assert ntile_values.count(3) == 2


### PR DESCRIPTION
## Summary

Fixed two issues with `ntile()` window function NULL handling (#1484):

1. **NULL ordering**: PySpark puts NULLs first in ascending order, last in descending order. Fixed by filling NULLs with `NEG_INFINITY` before ranking.

2. **ntile for NULL rows**: `ntile()` now returns an integer for all rows, including those where the ORDER BY column is NULL (was incorrectly returning NULL).

Also fixed count to use `len()` instead of `count()` to include all rows in the calculation (since `count()` excludes NULLs).

## Before (sparkless)
```
| grp | val  | ntile |
|-----|------|-------|
| A   | 1    | 1     |
| A   | null | null  |  <- Wrong: ntile is NULL
| A   | 2    | 1     |  <- Wrong: should be 2
| A   | 3    | 2     |
```

## After (matches PySpark)
```
| grp | val  | ntile |
|-----|------|-------|
| A   | null | 1     |  <- NULL comes first, ntile = 1
| A   | 1    | 1     |
| A   | 2    | 2     |
| A   | 3    | 2     |
```

Fixes #1484

## Test plan

- [x] Added 7 comprehensive tests in `tests/parity/dataframe/test_ntile_nulls.py`
- [x] All tests pass with `SPARKLESS_TEST_MODE=sparkless`
- [x] All tests pass with `SPARKLESS_TEST_MODE=pyspark`
- [x] All 11 existing ntile-related tests still pass