### PR TITLE
fix: Add sum(), avg(), min(), max() to rollup() and cube()

### DIFF
--- a/crates/robin-sparkless-polars/src/dataframe/aggregations.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/aggregations.rs
@@ -1397,6 +1397,39 @@ impl CubeRollupData {
         self.agg(vec![len().cast(DataType::Int64).alias("count")])
     }
 
+    /// Sum of a column per grouping set (PySpark cube/rollup .sum(col)).
+    pub fn sum(&self, column: &str) -> Result<DataFrame, PolarsError> {
+        use polars::prelude::*;
+        self.agg(vec![col(column).sum().alias(format!("sum({column})"))])
+    }
+
+    /// Average of one or more columns per grouping set (PySpark cube/rollup .avg(...)).
+    pub fn avg(&self, columns: &[&str]) -> Result<DataFrame, PolarsError> {
+        if columns.is_empty() {
+            return Err(PolarsError::ComputeError(
+                "avg requires at least one column".into(),
+            ));
+        }
+        use polars::prelude::*;
+        let agg_exprs: Vec<Expr> = columns
+            .iter()
+            .map(|c| col(*c).mean().alias(format!("avg({c})")))
+            .collect();
+        self.agg(agg_exprs)
+    }
+
+    /// Minimum of a column per grouping set (PySpark cube/rollup .min(col)).
+    pub fn min(&self, column: &str) -> Result<DataFrame, PolarsError> {
+        use polars::prelude::*;
+        self.agg(vec![col(column).min().alias(format!("min({column})"))])
+    }
+
+    /// Maximum of a column per grouping set (PySpark cube/rollup .max(col)).
+    pub fn max(&self, column: &str) -> Result<DataFrame, PolarsError> {
+        use polars::prelude::*;
+        self.agg(vec![col(column).max().alias(format!("max({column})"))])
+    }
+
     /// Run aggregation on each grouping set and union results. Missing keys become null.
     /// Duplicate agg output names are disambiguated (issue #368).
     /// Column names in agg expressions are resolved case-insensitively when case_sensitive is false.

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -7132,6 +7132,54 @@ impl PyCubeRollupData {
         self.inner.count().map(PyDataFrame::wrap).map_err(to_py_err)
     }
 
+    fn sum(&self, col_name: &Bound<'_, PyAny>) -> PyResult<PyDataFrame> {
+        let name = py_col_to_name(col_name)?;
+        self.inner
+            .sum(&name)
+            .map(PyDataFrame::wrap)
+            .map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (*cols))]
+    fn avg(&self, cols: &Bound<'_, PyTuple>) -> PyResult<PyDataFrame> {
+        let mut names = Vec::new();
+        for item in cols.iter() {
+            names.extend(py_one_or_many_cols(&item)?);
+        }
+        if names.is_empty() {
+            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                "avg requires at least one column",
+            ));
+        }
+        let refs: Vec<&str> = names.iter().map(|s| s.as_str()).collect();
+        self.inner
+            .avg(&refs)
+            .map(PyDataFrame::wrap)
+            .map_err(to_py_err)
+    }
+
+    /// PySpark cube/rollup().mean(*cols).
+    #[pyo3(signature = (*cols))]
+    fn mean(&self, cols: &Bound<'_, PyTuple>) -> PyResult<PyDataFrame> {
+        self.avg(cols)
+    }
+
+    fn min(&self, col_name: &Bound<'_, PyAny>) -> PyResult<PyDataFrame> {
+        let name = py_col_to_name(col_name)?;
+        self.inner
+            .min(&name)
+            .map(PyDataFrame::wrap)
+            .map_err(to_py_err)
+    }
+
+    fn max(&self, col_name: &Bound<'_, PyAny>) -> PyResult<PyDataFrame> {
+        let name = py_col_to_name(col_name)?;
+        self.inner
+            .max(&name)
+            .map(PyDataFrame::wrap)
+            .map_err(to_py_err)
+    }
+
     #[pyo3(signature = (*exprs))]
     fn agg(&self, exprs: &Bound<'_, PyTuple>) -> PyResult<PyDataFrame> {
         fn push_expr(

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -865,6 +865,22 @@ impl CubeRollupData {
         self.0.count().map(DataFrame)
     }
 
+    pub fn sum(&self, column: &str) -> Result<DataFrame, PolarsError> {
+        self.0.sum(column).map(DataFrame)
+    }
+
+    pub fn avg(&self, columns: &[&str]) -> Result<DataFrame, PolarsError> {
+        self.0.avg(columns).map(DataFrame)
+    }
+
+    pub fn min(&self, column: &str) -> Result<DataFrame, PolarsError> {
+        self.0.min(column).map(DataFrame)
+    }
+
+    pub fn max(&self, column: &str) -> Result<DataFrame, PolarsError> {
+        self.0.max(column).map(DataFrame)
+    }
+
     pub fn agg(&self, exprs: Vec<Expr>) -> Result<DataFrame, PolarsError> {
         self.0.agg(exprs).map(DataFrame)
     }

--- a/tests/dataframe/test_issue_382_cube_rollup_count_agg.py
+++ b/tests/dataframe/test_issue_382_cube_rollup_count_agg.py
@@ -46,3 +46,51 @@ def test_cube_agg(spark) -> None:
     # Sum of v is 60 total; per-group sums 30, 30
     vals = [r for r in rows]
     assert len(vals) >= 1
+
+
+def test_rollup_sum(spark) -> None:
+    """df.rollup("a", "b").sum("val") - exact reproduction from issue #1482."""
+    df = spark.createDataFrame(
+        [
+            {"a": "A", "b": "X", "val": 1},
+            {"a": "A", "b": "Y", "val": 2},
+            {"a": "B", "b": "X", "val": 3},
+        ]
+    )
+    result = df.rollup("a", "b").sum("val")
+    rows = result.collect()
+    assert len(rows) >= 1
+    assert "sum(val)" in (list(rows[0].asDict().keys()) if rows else [])
+    # Rollup: (A,X), (A,Y), (B,X), (A), (B), () -> 6 grouping sets
+    sums = {r["sum(val)"] for r in rows}
+    assert 1 in sums or 2 in sums or 3 in sums or 6 in sums  # some expected sums
+
+
+def test_cube_sum(spark) -> None:
+    """df.cube("a", "b").sum("val") - issue #1482."""
+    df = spark.createDataFrame(
+        [
+            {"a": "A", "b": "X", "val": 1},
+            {"a": "A", "b": "Y", "val": 2},
+            {"a": "B", "b": "X", "val": 3},
+        ]
+    )
+    result = df.cube("a", "b").sum("val")
+    rows = result.collect()
+    assert len(rows) >= 1
+    assert "sum(val)" in (list(rows[0].asDict().keys()) if rows else [])
+
+
+def test_rollup_avg_min_max(spark) -> None:
+    """PyCubeRollupData.avg(), .min(), .max() work (issue #1482)."""
+    df = spark.createDataFrame(
+        [{"a": 1, "val": 10}, {"a": 1, "val": 20}, {"a": 2, "val": 30}],
+        schema=["a", "val"],
+    )
+    for method, col_name in [("avg", "avg(val)"), ("min", "min(val)"), ("max", "max(val)")]:
+        out = getattr(df.rollup("a"), method)("val")
+        rows = out.collect()
+        assert len(rows) >= 1, f"rollup().{method}() should return rows"
+        assert col_name in (list(rows[0].asDict().keys()) if rows else []), (
+            f"rollup().{method}() should have column {col_name}"
+        )


### PR DESCRIPTION
## Summary

`PyCubeRollupData` (returned by `df.rollup()` and `df.cube()`) now implements the same aggregation methods as `GroupedData` (#1482).

Previously:
```python
df.rollup('a', 'b').sum('val')  # AttributeError: 'PyCubeRollupData' object has no attribute 'sum'
df.cube('a', 'b').sum('val')    # same error
```

Now supported:
- `sum(col)` / `sum("col")`
- `avg(*cols)` / `mean(*cols)`
- `min(col)` / `min("col")`
- `max(col)` / `max("col")`
- `agg(*exprs)` (was already present)

## Changes

- **crates/robin-sparkless-polars/src/dataframe/aggregations.rs**: Added `sum()`, `avg()`, `min()`, `max()` to `CubeRollupData` (each delegates to `agg()` with the appropriate expression).
- **src/dataframe.rs**: Exposed `sum`, `avg`, `min`, `max` on root `CubeRollupData`.
- **python/src/lib.rs**: Added `sum()`, `avg()`, `mean()`, `min()`, `max()` to `PyCubeRollupData` with PySpark-compatible signatures (column name or Column, `*cols` for avg/mean).
- **tests**: Added `test_rollup_sum`, `test_cube_sum`, `test_rollup_avg_min_max` to `test_issue_382_cube_rollup_count_agg.py`.

Fixes #1482

## Test plan

- [x] New tests pass with `SPARKLESS_TEST_MODE=sparkless`
- [x] New tests pass with `SPARKLESS_TEST_MODE=pyspark`
- [x] All 17 existing rollup/cube tests still pass