### PR TITLE
fix: months_between() use PySpark formula

### DIFF
--- a/crates/robin-sparkless-polars/src/udfs/rest.rs
+++ b/crates/robin-sparkless-polars/src/udfs/rest.rs
@@ -2248,7 +2248,8 @@ pub fn apply_weekday(column: Column) -> PolarsResult<Option<Column>> {
 }
 
 /// months_between(end, start, round_off) - returns fractional number of months.
-/// When round_off is true, rounds to 8 decimal places (PySpark default).
+/// PySpark formula (issue #1481): (year1-year2)*12 + (month1-month2) + (day1-day2)/31.
+/// Not total_days/31. When round_off is true, rounds to 8 decimal places (PySpark default).
 pub fn apply_months_between(
     columns: &mut [Column],
     round_off: bool,
@@ -2263,14 +2264,17 @@ pub fn apply_months_between(
     let start_series = std::mem::take(&mut columns[1]).take_materialized_series();
     let end_ca = date_series_to_days(&end_series)?;
     let start_ca = date_series_to_days(&start_series)?;
-    // PySpark: fractional months using 31 days per month; roundOff rounds to 8 decimal places.
     let out = end_ca
         .into_iter()
         .zip(&start_ca)
         .map(|(oe, os)| match (oe, os) {
             (Some(e), Some(s)) => {
-                let days = (e - s) as f64;
-                let months = days / 31.0;
+                let end_d = days_to_naive_date(e)?;
+                let start_d = days_to_naive_date(s)?;
+                let month_diff = (end_d.year() - start_d.year()) * 12
+                    + (end_d.month() as i32 - start_d.month() as i32);
+                let day_diff = end_d.day() as i32 - start_d.day() as i32;
+                let months = month_diff as f64 + (day_diff as f64 / 31.0);
                 Some(if round_off {
                     (months * 1e8).round() / 1e8
                 } else {

--- a/tests/parity/functions/test_months_between_parity.py
+++ b/tests/parity/functions/test_months_between_parity.py
@@ -1,0 +1,44 @@
+"""
+Tests for months_between() PySpark parity.
+
+Issue #1481: months_between() was using total_days/31 instead of PySpark's
+formula: (year1-year2)*12 + (month1-month2) + (day1-day2)/31.
+"""
+
+from sparkless.testing import get_imports
+
+F = get_imports().F
+
+
+def test_months_between_issue_1481(spark):
+    """Exact reproduction from issue #1481: 2024-01-15 to 2024-06-20."""
+    df = spark.createDataFrame([{"start": "2024-01-15", "end": "2024-06-20"}])
+    result = df.select(
+        F.months_between(F.to_date("end"), F.to_date("start")).alias("months")
+    )
+    got = result.collect()[0]["months"]
+    # PySpark: (6-1) + (20-15)/31 = 5.16129032
+    expected = 5.16129032
+    assert abs(got - expected) < 1e-6, f"expected {expected}, got {got}"
+
+
+def test_months_between_same_day(spark):
+    """Same day of month -> integer result."""
+    df = spark.createDataFrame([{"start": "2024-01-15", "end": "2024-04-15"}])
+    result = df.select(
+        F.months_between(F.to_date("end"), F.to_date("start")).alias("months")
+    )
+    got = result.collect()[0]["months"]
+    assert got == 3.0
+
+
+def test_months_between_fractional(spark):
+    """Fractional part uses (day1-day2)/31."""
+    df = spark.createDataFrame([{"start": "2024-01-01", "end": "2024-02-11"}])
+    result = df.select(
+        F.months_between(F.to_date("end"), F.to_date("start")).alias("months")
+    )
+    got = result.collect()[0]["months"]
+    # 1 month + (11-1)/31 = 1 + 10/31 ≈ 1.32258065
+    expected = 1.0 + 10.0 / 31.0
+    assert abs(got - expected) < 1e-6, f"expected {expected}, got {got}"


### PR DESCRIPTION
## Summary

Fixed `months_between()` to use PySpark's formula (#1481).

**PySpark formula:** `(year1-year2)*12 + (month1-month2) + (day1-day2)/31`  
(see [PySpark docs](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.months_between.html) — fractional part assumes 31 days per month.)

**Previous (wrong):** `total_days_between_dates / 31`  
**Now:** Integer month difference from year/month + `(end_day - start_day) / 31`

## Example (issue reproduction)

```python
df = spark.createDataFrame([{'start': '2024-01-15', 'end': '2024-06-20'}])
result = df.select(F.months_between(F.to_date('end'), F.to_date('start')).alias('months'))
```

|        | Before (sparkless) | After / PySpark |
|--------|--------------------|------------------|
| months | 5.064516           | 5.16129032       |

Fixes #1481

## Test plan

- [x] Added 3 parity tests in `tests/parity/functions/test_months_between_parity.py`
- [x] All pass with `SPARKLESS_TEST_MODE=sparkless` and `SPARKLESS_TEST_MODE=pyspark`