### PR TITLE
fix: sort_array() null ordering to match PySpark

### DIFF
--- a/crates/robin-sparkless-polars/src/column.rs
+++ b/crates/robin-sparkless-polars/src/column.rs
@@ -3022,13 +3022,13 @@ impl Column {
     }
 
     /// Sort list elements (PySpark array_sort/sort_array).
-    /// When asc=true (default), sorts ascending with nulls last.
-    /// When asc=false, sorts descending with nulls first.
+    /// When asc=true (default), sorts ascending with nulls first.
+    /// When asc=false, sorts descending with nulls last.
     pub fn array_sort(&self, asc: bool) -> Column {
         use polars::prelude::SortOptions;
         let opts = SortOptions {
             descending: !asc,
-            nulls_last: asc, // PySpark: nulls last for asc, nulls first for desc
+            nulls_last: !asc, // PySpark: nulls first for asc, nulls last for desc
             ..Default::default()
         };
         Self::from_expr(self.expr().clone().list().sort(opts), None)

--- a/crates/robin-sparkless-polars/src/functions/rest.rs
+++ b/crates/robin-sparkless-polars/src/functions/rest.rs
@@ -2632,7 +2632,7 @@ pub fn element_at(column: &Column, index: i64) -> Column {
 }
 
 /// Sort list elements (PySpark array_sort/sort_array).
-/// When asc=true (default), sorts ascending. When asc=false, sorts descending.
+/// When asc=true (default), sorts ascending with nulls first. When asc=false, sorts descending with nulls last.
 pub fn array_sort(column: &Column, asc: bool) -> Column {
     column.clone().array_sort(asc)
 }

--- a/tests/parity/functions/test_pyspark_strictness_parity.py
+++ b/tests/parity/functions/test_pyspark_strictness_parity.py
@@ -260,6 +260,38 @@ class TestSortArrayAscParameter(ParityTestBase):
         assert rows[0]["sorted"] == [1, 2, 3]
 
 
+class TestSortArrayNullOrdering(ParityTestBase):
+    """Test sort_array null ordering matches PySpark (#1480): asc=nulls first, desc=nulls last."""
+
+    def test_sort_array_nulls_ascending(self, spark):
+        """Ascending: nulls come first."""
+        imports = get_imports()
+        F = imports.F
+
+        df = spark.createDataFrame(
+            [{"arr": [3, None, 1, None, 2]}],
+            schema="arr array<int>",
+        )
+        result = df.select(F.sort_array("arr", asc=True).alias("asc"))
+        rows = result.collect()
+        assert len(rows) == 1
+        assert rows[0]["asc"] == [None, None, 1, 2, 3]
+
+    def test_sort_array_nulls_descending(self, spark):
+        """Descending: nulls come last."""
+        imports = get_imports()
+        F = imports.F
+
+        df = spark.createDataFrame(
+            [{"arr": [3, None, 1, None, 2]}],
+            schema="arr array<int>",
+        )
+        result = df.select(F.sort_array("arr", asc=False).alias("desc"))
+        rows = result.collect()
+        assert len(rows) == 1
+        assert rows[0]["desc"] == [3, 2, 1, None, None]
+
+
 class TestArraySortNoAscParameter(ParityTestBase):
     """Test that array_sort always sorts ascending (PySpark parity).
 


### PR DESCRIPTION
## Summary

Fixed `sort_array()` null ordering to match PySpark (#1480).

**PySpark behavior:**
- **Ascending** (`asc=True`): nulls **first**
- **Descending** (`asc=False`): nulls **last**

Sparkless previously did the opposite. Updated `SortOptions` in `array_sort` to use `nulls_last: !asc`.

## Reproduction (from issue)

```python
df = spark.createDataFrame([{'arr': [3, None, 1, None, 2]}], schema='arr array<int>')
result = df.select(
    F.sort_array('arr', True).alias('asc'),
    F.sort_array('arr', False).alias('desc'),
)
result.show()
```

|        | Before (sparkless)   | After / PySpark       |
|--------|---------------------|------------------------|
| asc    | [1, 2, 3, null, null] | [null, null, 1, 2, 3] |
| desc   | [null, null, 3, 2, 1] | [3, 2, 1, null, null] |

Fixes #1480

## Test plan

- [x] Added `TestSortArrayNullOrdering` in `test_pyspark_strictness_parity.py` (nulls asc/desc)
- [x] Tests pass with `SPARKLESS_TEST_MODE=sparkless` and `SPARKLESS_TEST_MODE=pyspark`
