### PR TITLE
fix: date_format 'E'/'EEEE' day-of-week to match PySpark

### DIFF
--- a/crates/robin-sparkless-polars/src/udfs/rest.rs
+++ b/crates/robin-sparkless-polars/src/udfs/rest.rs
@@ -3907,6 +3907,7 @@ fn unquote_simple_date_format(s: &str) -> String {
 
 /// Map PySpark/Java SimpleDateFormat style to chrono strftime. Public for to_char/date_format.
 /// Handles quoted literals (e.g. 'T' in "yyyy-MM-dd'T'HH:mm:ss") so they become literal in chrono (#273).
+/// Day of week: E/EE/EEE -> %a (abbreviated e.g. Fri), EEEE -> %A (full e.g. Friday) (#1479).
 pub(crate) fn pyspark_format_to_chrono(s: &str) -> String {
     let s = unquote_simple_date_format(s);
     s.replace("yyyy", "%Y")
@@ -3915,6 +3916,10 @@ pub(crate) fn pyspark_format_to_chrono(s: &str) -> String {
         .replace("HH", "%H")
         .replace("mm", "%M")
         .replace("ss", "%S")
+        .replace("EEEE", "%A")
+        .replace("EEE", "%a")
+        .replace("EE", "%a")
+        .replace("E", "%a")
 }
 
 /// unix_timestamp(column, format?) - parse string to seconds since epoch.

--- a/tests/parity/functions/test_datetime.py
+++ b/tests/parity/functions/test_datetime.py
@@ -82,3 +82,33 @@ class TestDatetimeFunctionsParity(ParityTestBase):
         df = spark.createDataFrame(expected["input_data"])
         result = df.select(F.to_date(df.hire_date))
         self.assert_parity(result, expected)
+
+
+class TestDateFormatDayOfWeek(ParityTestBase):
+    """Test date_format day-of-week patterns E and EEEE (#1479)."""
+
+    def test_date_format_E_abbreviated(self, spark):
+        """E returns abbreviated day name (e.g. Fri), not literal 'E'."""
+        imports = get_imports()
+        F = imports.F
+
+        df = spark.createDataFrame([{"ts": "2024-03-15 10:30:45"}])
+        result = df.select(
+            F.date_format(F.to_timestamp("ts"), "E").alias("day_of_week")
+        )
+        rows = result.collect()
+        assert len(rows) == 1
+        assert rows[0]["day_of_week"] == "Fri"
+
+    def test_date_format_EEEE_full(self, spark):
+        """EEEE returns full day name (e.g. Friday)."""
+        imports = get_imports()
+        F = imports.F
+
+        df = spark.createDataFrame([{"ts": "2024-03-15 10:30:45"}])
+        result = df.select(
+            F.date_format(F.to_timestamp("ts"), "EEEE").alias("day_of_week")
+        )
+        rows = result.collect()
+        assert len(rows) == 1
+        assert rows[0]["day_of_week"] == "Friday"


### PR DESCRIPTION
## Summary

Fixed `date_format()` so the `E` and `EEEE` format specifiers return day-of-week names instead of literal characters (#1479).

**PySpark/Java SimpleDateFormat:**
- `E`, `EE`, `EEE` → abbreviated day (e.g. Fri)
- `EEEE` → full day name (e.g. Friday)

**Before (sparkless):** `date_format(ts, 'E')` → `"E"`  
**After:** `date_format(ts, 'E')` → `"Fri"`

## Changes

- **`pyspark_format_to_chrono`** in `crates/robin-sparkless-polars/src/udfs/rest.rs`: map `EEEE` → `%A`, `E`/`EE`/`EEE` → `%a` (chrono strftime).
- **Tests:** `TestDateFormatDayOfWeek` in `test_datetime.py` (E → Fri, EEEE → Friday for 2024-03-15).

Fixes #1479

## Test plan

- [x] `test_date_format_E_abbreviated` and `test_date_format_EEEE_full` pass with `SPARKLESS_TEST_MODE=sparkless` and `SPARKLESS_TEST_MODE=pyspark`
