### PR TITLE
fix: expose instr, locate, next_day, trunc in native module

### DIFF
--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -9140,6 +9140,22 @@ fn date_trunc(format: &str, column: &PyColumn) -> PyColumn {
 }
 
 #[pyfunction]
+#[pyo3(name = "native_next_day")]
+fn native_next_day(column: &PyColumn, day_of_week: &str) -> PyColumn {
+    PyColumn {
+        inner: functions::next_day(&column.inner, day_of_week),
+    }
+}
+
+#[pyfunction]
+#[pyo3(name = "native_trunc")]
+fn native_trunc(column: &PyColumn, format: &str) -> PyColumn {
+    PyColumn {
+        inner: functions::trunc(&column.inner, format),
+    }
+}
+
+#[pyfunction]
 #[pyo3(signature = (col, ignorenulls=false))]
 fn first(col: &PyColumn, ignorenulls: bool) -> PyColumn {
     PyColumn {
@@ -9159,6 +9175,23 @@ fn last(col: &PyColumn, ignorenulls: bool) -> PyColumn {
 fn translate(column: &PyColumn, from_str: &str, to_str: &str) -> PyColumn {
     PyColumn {
         inner: functions::translate(&column.inner, from_str, to_str),
+    }
+}
+
+#[pyfunction]
+#[pyo3(name = "native_instr")]
+fn native_instr(column: &PyColumn, substr: &str) -> PyColumn {
+    PyColumn {
+        inner: functions::instr(&column.inner, substr),
+    }
+}
+
+#[pyfunction]
+#[pyo3(name = "native_locate")]
+#[pyo3(signature = (substr, column, pos=1))]
+fn native_locate(substr: &str, column: &PyColumn, pos: i64) -> PyColumn {
+    PyColumn {
+        inner: functions::locate(substr, &column.inner, pos),
     }
 }
 
@@ -9429,9 +9462,13 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Phase 4: missing functions (checklist)
     m.add_function(wrap_pyfunction!(approx_count_distinct, m)?)?;
     m.add_function(wrap_pyfunction!(date_trunc, m)?)?;
+    m.add_function(wrap_pyfunction!(native_next_day, m)?)?;
+    m.add_function(wrap_pyfunction!(native_trunc, m)?)?;
     m.add_function(wrap_pyfunction!(first, m)?)?;
     m.add_function(wrap_pyfunction!(last, m)?)?;
     m.add_function(wrap_pyfunction!(translate, m)?)?;
+    m.add_function(wrap_pyfunction!(native_instr, m)?)?;
+    m.add_function(wrap_pyfunction!(native_locate, m)?)?;
     m.add_function(wrap_pyfunction!(substring_index, m)?)?;
     m.add_function(wrap_pyfunction!(crc32, m)?)?;
     m.add_function(wrap_pyfunction!(xxhash64, m)?)?;

--- a/tests/parity/functions/test_issue_1478_instr_locate_next_day_trunc.py
+++ b/tests/parity/functions/test_issue_1478_instr_locate_next_day_trunc.py
@@ -1,0 +1,63 @@
+"""
+Tests for issue #1478: instr, locate, next_day, trunc must be implemented in native module.
+
+These functions are defined in functions.py and call native_*; without Rust bindings
+they raise AttributeError. This test verifies they run without error and produce
+sensible results.
+"""
+
+import pytest
+from tests.tools.parity_base import ParityTestBase
+from sparkless.testing import get_imports
+
+
+class TestIssue1478InstrLocateNextDayTrunc(ParityTestBase):
+    """Verify instr, locate, next_day, trunc are implemented (#1478)."""
+
+    def test_instr_returns_1based_position(self, spark):
+        """instr(str, substr) returns 1-based position; 0 if not found."""
+        imports = get_imports()
+        F = imports.F
+
+        df = spark.createDataFrame([{"val": "Hello World"}])
+        result = df.select(F.instr("val", "o").alias("pos")).collect()
+        assert len(result) == 1
+        assert result[0]["pos"] == 5  # first 'o' at 1-based index 5
+
+        df2 = spark.createDataFrame([{"val": "abc"}])
+        result2 = df2.select(F.instr("val", "x").alias("pos")).collect()
+        assert result2[0]["pos"] == 0  # not found
+
+    def test_locate_returns_1based_position(self, spark):
+        """locate(substr, str, pos=1) returns 1-based position; 0 if not found."""
+        imports = get_imports()
+        F = imports.F
+
+        df = spark.createDataFrame([{"val": "Hello World"}])
+        result = df.select(F.locate("o", "val", 1).alias("pos")).collect()
+        assert len(result) == 1
+        assert result[0]["pos"] == 5
+
+    def test_next_day_returns_next_weekday(self, spark):
+        """next_day(date, dayOfWeek) returns next date matching weekday."""
+        imports = get_imports()
+        F = imports.F
+
+        df = spark.createDataFrame([{"date": "2024-03-15"}])  # Friday
+        result = df.select(
+            F.next_day(F.to_date("date"), "Mon").alias("next_monday")
+        ).collect()
+        assert len(result) == 1
+        assert result[0]["next_monday"] is not None  # 2024-03-18
+
+    def test_trunc_truncates_date(self, spark):
+        """trunc(date, format) truncates to year/month/etc."""
+        imports = get_imports()
+        F = imports.F
+
+        df = spark.createDataFrame([{"date": "2024-03-15"}])
+        result = df.select(
+            F.trunc(F.to_date("date"), "month").alias("trunc_month")
+        ).collect()
+        assert len(result) == 1
+        assert result[0]["trunc_month"] is not None  # 2024-03-01


### PR DESCRIPTION
## Summary

Implements the four missing native functions from #1478 so `F.instr()`, `F.locate()`, `F.next_day()`, and `F.trunc()` no longer raise `AttributeError`.

**Root cause:** `functions.py` calls `_native.native_instr`, `native_locate`, `native_next_day`, `native_trunc`. The Rust extension did not expose these; the engine (robin-sparkless-polars) already had `instr`, `locate`, `next_day`, `trunc`.

## Changes

- **python/src/lib.rs**
  - `native_instr(column, substr)` → `functions::instr`
  - `native_locate(substr, column, pos=1)` → `functions::locate`
  - `native_next_day(column, day_of_week)` → `functions::next_day`
  - `native_trunc(column, format)` → `functions::trunc`
  - Registered all four in the PyModule.

- **tests/parity/functions/test_issue_1478_instr_locate_next_day_trunc.py**
  - Tests for instr (1-based position, 0 if not found), locate, next_day, trunc.

Fixes #1478

## Test plan

- [x] `pytest tests/parity/functions/test_issue_1478_instr_locate_next_day_trunc.py -v` passes with `SPARKLESS_TEST_MODE=sparkless` and `SPARKLESS_TEST_MODE=pyspark`
- [x] Manual `F.instr`, `F.locate`, `F.next_day`, `F.trunc` run without AttributeError
