### PR TITLE
fix: slice() with negative start returns correct elements

### DIFF
--- a/crates/robin-sparkless-polars/src/column.rs
+++ b/crates/robin-sparkless-polars/src/column.rs
@@ -3062,12 +3062,21 @@ impl Column {
     }
 
     /// Slice list from start with optional length (PySpark slice). 1-based start.
+    /// Negative start counts from the end (-1 = last, -2 = second-to-last); then take length elements (#1477).
     pub fn array_slice(&self, start: i64, length: Option<i64>) -> Column {
         use polars::prelude::*;
-        let start_expr = lit((start - 1).max(0)); // 1-based to 0-based
+        let list_expr = self.expr().clone();
+        let len_expr = list_expr.clone().list().len().cast(DataType::Int64);
+        let start_expr = when(lit(start).lt(0))
+            .then(
+                when((len_expr.clone() + lit(start)).lt(0))
+                    .then(lit(0i64))
+                    .otherwise(len_expr + lit(start)),
+            )
+            .otherwise(lit((start - 1).max(0)));
         let length_expr = length.map(lit).unwrap_or_else(|| lit(i64::MAX));
         Self::from_expr(
-            self.expr().clone().list().slice(start_expr, length_expr),
+            list_expr.list().slice(start_expr, length_expr),
             None,
         )
     }

--- a/tests/parity/functions/test_slice_negative_start_parity.py
+++ b/tests/parity/functions/test_slice_negative_start_parity.py
@@ -1,0 +1,43 @@
+"""
+Parity tests for slice() with negative start index (#1477).
+
+PySpark: negative start counts from the end (-1 = last, -2 = second-to-last).
+slice(arr, -2, 2) should return the last 2 elements, not the first 2.
+"""
+
+from tests.tools.parity_base import ParityTestBase
+from sparkless.testing import get_imports
+
+
+class TestSliceNegativeStartParity(ParityTestBase):
+    """Test slice() negative start matches PySpark (#1477)."""
+
+    def test_slice_positive_start(self, spark):
+        """slice(arr, 1, 3) returns first 3 elements."""
+        imports = get_imports()
+        F = imports.F
+
+        df = spark.createDataFrame([{"arr": [1, 2, 3, 4, 5]}])
+        result = df.select(F.slice("arr", 1, 3).alias("first_3")).collect()
+        assert len(result) == 1
+        assert result[0]["first_3"] == [1, 2, 3]
+
+    def test_slice_negative_start_last_two(self, spark):
+        """slice(arr, -2, 2) returns last 2 elements [4, 5], not [1, 2]."""
+        imports = get_imports()
+        F = imports.F
+
+        df = spark.createDataFrame([{"arr": [1, 2, 3, 4, 5]}])
+        result = df.select(F.slice("arr", -2, 2).alias("last_2")).collect()
+        assert len(result) == 1
+        assert result[0]["last_2"] == [4, 5]
+
+    def test_slice_negative_one_last_element(self, spark):
+        """slice(arr, -1, 1) returns last element."""
+        imports = get_imports()
+        F = imports.F
+
+        df = spark.createDataFrame([{"arr": [10, 20, 30]}])
+        result = df.select(F.slice("arr", -1, 1).alias("last")).collect()
+        assert len(result) == 1
+        assert result[0]["last"] == [30]


### PR DESCRIPTION
## Summary

Fixed `slice()` array function when using a negative start index (#1477).

**PySpark:** Negative start counts from the end (-1 = last element, -2 = second-to-last).  
**Before (sparkless):** `slice(arr, -2, 2)` returned [1, 2] (wrong).  
**After:** `slice(arr, -2, 2)` returns [4, 5] (last 2 elements).

## Cause

`array_slice` used `(start - 1).max(0)` for 1-based→0-based conversion. For start=-2 that became 0, so we always sliced from the beginning.

## Change

In `crates/robin-sparkless-polars/src/column.rs`, `array_slice`:
- When `start < 0`: effective 0-based start = `(list.len() + start).max(0)` (per-row using `list().len()`).
- When `start >= 0`: unchanged, `(start - 1).max(0)`.

## Tests

- `tests/parity/functions/test_slice_negative_start_parity.py`: positive start, `slice(-2, 2)` → last 2, `slice(-1, 1)` → last element.
- Pass with `SPARKLESS_TEST_MODE=sparkless` and `SPARKLESS_TEST_MODE=pyspark`.

Fixes #1477
