### PR TITLE
fix: nvl() treat string second arg as column name

### DIFF
--- a/python/sparkless/sparkless/sql/functions.py
+++ b/python/sparkless/sparkless/sql/functions.py
@@ -891,9 +891,10 @@ def isnotnull(col_or_name):
 def nvl(col_or_name, replacement):
     """Replace null with replacement. PySpark: F.nvl(col, replacement)."""
     c = _as_col(col_or_name)
+    # PySpark: string second arg is column name (value of that column), not literal (#1476).
     rep = (
         lit(replacement)
-        if isinstance(replacement, (int, float, bool, str, type(None)))
+        if isinstance(replacement, (int, float, bool, type(None)))
         else _as_col(replacement)
     )
     return coalesce(c, rep)

--- a/tests/parity/functions/test_null_handling.py
+++ b/tests/parity/functions/test_null_handling.py
@@ -56,6 +56,23 @@ class TestNullHandlingFunctionsParity(ParityTestBase):
         result = df.select(F.nvl(df.salary, F.lit(0)))
         self.assert_parity(result, expected)
 
+    def test_nvl_column_replacement(self, spark):
+        """nvl(col1, col2) uses value of col2 when col1 is null, not literal column name (#1476)."""
+        imports = get_imports()
+        F = imports.F
+
+        df = spark.createDataFrame(
+            [
+                {"a": None, "b": "default"},
+                {"a": "value", "b": "default"},
+            ]
+        )
+        result = df.select(F.nvl("a", "b").alias("result"))
+        rows = result.collect()
+        assert len(rows) == 2
+        assert rows[0]["result"] == "default"
+        assert rows[1]["result"] == "value"
+
     def test_nullif(self, spark):
         """Test nullif function matches PySpark behavior."""
         imports = get_imports()


### PR DESCRIPTION
## Summary

Fixed `nvl()` so a string as the second argument is treated as a column name (value of that column), not as a literal (#1476).

**Before:** `F.nvl('a', 'b')` when col `a` is null → `"b"` (literal).  
**After:** `F.nvl('a', 'b')` when col `a` is null → value of column `b` (e.g. `"default"`).

## Cause

`nvl` used `lit(replacement)` for `isinstance(replacement, (int, float, bool, str, type(None)))`, so `'b'` became a literal column with value `"b"`.

## Change

In `python/sparkless/sparkless/sql/functions.py`: use `lit(replacement)` only for `(int, float, bool, type(None))`. For `str` (and Column), use `_as_col(replacement)` so `'b'` → `col('b')`. For a literal string, callers use `F.nvl('a', F.lit('hello'))`.

## Tests

- `test_nvl_column_replacement` in `test_null_handling.py`: `nvl('a', 'b')` with rows `{a: None, b: 'default'}` and `{a: 'value', b: 'default'}` → `"default"` and `"value"`.
- Passes with sparkless and PySpark.

Fixes #1476
