### PR TITLE
fix: corr() exclude null pairs to match PySpark

### DIFF
--- a/crates/robin-sparkless-polars/src/functions/rest.rs
+++ b/crates/robin-sparkless-polars/src/functions/rest.rs
@@ -289,22 +289,28 @@ fn covar_pop_expr_impl(e1: Expr, e2: Expr) -> Expr {
 }
 
 fn corr_expr_impl(e1: Expr, e2: Expr) -> Expr {
-    use polars::prelude::{len, lit, when};
+    use polars::prelude::{lit, when};
+    // PySpark excludes rows where either column is null (#1475). Use only pairs where both non-null.
     let c1 = e1.clone().cast(DataType::Float64);
     let c2 = e2.clone().cast(DataType::Float64);
-    let n = len().cast(DataType::Float64);
-    let n1 = (len() - lit(1)).cast(DataType::Float64);
-    let sum_ab = (c1.clone() * c2.clone()).sum();
-    let sum_a = e1.sum().cast(DataType::Float64);
-    let sum_b = e2.sum().cast(DataType::Float64);
-    let sum_a2 = (c1.clone() * c1).sum();
-    let sum_b2 = (c2.clone() * c2).sum();
+    let cond = e1.clone().is_not_null().and(e2.clone().is_not_null());
+    let n = e1
+        .clone()
+        .filter(cond.clone())
+        .count()
+        .cast(DataType::Float64);
+    let n1 = n.clone() - lit(1.0);
+    let sum_ab = (c1.clone() * c2.clone()).filter(cond.clone()).sum();
+    let sum_a = c1.clone().filter(cond.clone()).sum();
+    let sum_b = c2.clone().filter(cond.clone()).sum();
+    let sum_a2 = (c1.clone() * c1).filter(cond.clone()).sum();
+    let sum_b2 = (c2.clone() * c2).filter(cond).sum();
     let cov_samp = (sum_ab - sum_a.clone() * sum_b.clone() / n.clone()) / n1.clone();
     let var_a = (sum_a2 - sum_a.clone() * sum_a / n.clone()) / n1.clone();
     let var_b = (sum_b2 - sum_b.clone() * sum_b / n.clone()) / n1.clone();
     let std_a = var_a.sqrt();
     let std_b = var_b.sqrt();
-    when(len().gt(lit(1)))
+    when(n.gt(lit(1.0)))
         .then(cov_samp / (std_a * std_b))
         .otherwise(lit(f64::NAN))
 }

--- a/tests/parity/functions/test_corr_nulls_parity.py
+++ b/tests/parity/functions/test_corr_nulls_parity.py
@@ -1,0 +1,34 @@
+"""
+Parity tests for corr() with nulls (#1475).
+
+PySpark excludes rows where either column is null before computing correlation.
+Sparkless must do the same so e.g. (1,2), (2,4), (4,8) with one (3, None) row
+gives correlation 1.0, not ~0.53.
+"""
+
+from tests.tools.parity_base import ParityTestBase
+from sparkless.testing import get_imports
+
+
+class TestCorrNullsParity(ParityTestBase):
+    """Test corr() with nulls matches PySpark (#1475)."""
+
+    def test_corr_excludes_null_pairs(self, spark):
+        """corr(x, y) excludes rows where either is null; perfect line => 1.0."""
+        imports = get_imports()
+        F = imports.F
+
+        df = spark.createDataFrame(
+            [
+                {"x": 1.0, "y": 2.0},
+                {"x": 2.0, "y": 4.0},
+                {"x": 3.0, "y": None},
+                {"x": 4.0, "y": 8.0},
+            ]
+        )
+        result = df.agg(F.corr("x", "y").alias("correlation"))
+        rows = result.collect()
+        assert len(rows) == 1
+        corr_val = rows[0]["correlation"]
+        assert corr_val is not None
+        assert abs(corr_val - 1.0) < 1e-5, f"Expected ~1.0 (perfect line), got {corr_val}"


### PR DESCRIPTION
## Summary

Fixed `corr()` so rows where either column is null are excluded before computing correlation (#1475), matching PySpark.

**Before:** `corr('x', 'y')` with (1,2), (2,4), (3,None), (4,8) → `0.52915` (wrong).  
**After:** Same data → `1.0` (non-null pairs (1,2), (2,4), (4,8) form perfect line).

## Cause

`corr_expr_impl` used `len()` (total row count) and unfiltered `.sum()`. Polars `sum()` skips nulls, but `n = len()` was still 4, so the formula used the wrong denominator and mixed in the null row.

## Change

In `crates/robin-sparkless-polars/src/functions/rest.rs`, `corr_expr_impl`:
- `cond = e1.is_not_null().and(e2.is_not_null())`
- `n` = count of rows where both non-null: `e1.filter(cond).count()`
- All sums and sum-of-squares use `.filter(cond)` (same pattern as `regr_*`).
- Guard uses `n.gt(lit(1.0))` for at least 2 pairs.

## Tests

- `tests/parity/functions/test_corr_nulls_parity.py`: `test_corr_excludes_null_pairs` (issue reproduction).
- Passes with sparkless and PySpark.

Fixes #1475
