### PR TITLE
Fix eqNullSafe int column vs string literal parity (#1471)

### DIFF
--- a/crates/robin-sparkless-polars/src/type_coercion.rs
+++ b/crates/robin-sparkless-polars/src/type_coercion.rs
@@ -355,6 +355,21 @@ pub fn infer_type_from_expr(expr: &Expr) -> Option<DataType> {
     }
 }
 
+/// True when the expression is a string literal whose text does *not* parse as a number.
+fn is_non_numeric_string_literal(expr: &Expr) -> bool {
+    // Current Polars `LiteralValue` does not expose underlying string contents in a way
+    // that lets us cheaply distinguish "numeric-looking" strings from arbitrary text.
+    // For eqNullSafe parity, it is acceptable (and desirable for #1471) to treat all
+    // string literals as numeric candidates and let `try_to_number` decide:
+    //
+    // - Numeric strings like "123" are parsed and compared numerically.
+    // - Non-numeric strings like "abc" become null and simply don't match.
+    //
+    // So we never classify a literal as "non-numeric string" here.
+    let _ = expr;
+    false
+}
+
 /// Coerce left/right for eq_null_safe so string–numeric compares like PySpark (try_to_number on string side).
 /// Infers types from literals; assumes String for column (so string–numeric gets coerced).
 /// When both sides are column refs (no type info), cast both to string so string vs numeric compares (e.g. "100" and 100).
@@ -371,11 +386,44 @@ pub fn coerce_for_pyspark_eq_null_safe(
         return Ok((left, right));
     }
 
-    let left_ty = infer_type_from_expr(&left).unwrap_or(DataType::String);
-    let right_ty = infer_type_from_expr(&right).unwrap_or(DataType::String);
+    let left_inferred = infer_type_from_expr(&left);
+    let right_inferred = infer_type_from_expr(&right);
+    let left_non_numeric_str_lit = is_non_numeric_string_literal(&left);
+    let right_non_numeric_str_lit = is_non_numeric_string_literal(&right);
+
+    // Derive comparison dtypes with a bit of asymmetry to mirror PySpark-style coercion:
+    // - When only one side is a literal string and the other is a column/expr, treat the
+    //   non-literal side as numeric (Float64) so string‑numeric coercion (try_to_number)
+    //   kicks in for cases like int_col <=> "123" (issue #1471).
+    // - When only one side has a non-string literal type, treat the unknown side as String
+    //   so string‑numeric detection in coerce_for_pyspark_comparison still works when the
+    //   real column type is discovered later.
+    let (left_ty, right_ty) = match (left_inferred.clone(), right_inferred.clone()) {
+        // Both sides known: respect their literal dtypes.
+        (Some(lt), Some(rt)) => (lt, rt),
+        // String literal vs unknown expression:
+        // - If the unknown side is a *column* expr, keep both as String so
+        //   string-column vs string-literal behaves like string equality with
+        //   null-safe semantics (issue #260).
+        // - Otherwise (e.g. string literal vs numeric literal), treat the unknown
+        //   side as numeric (Float64) so string–numeric coercion kicks in (#1471).
+        (Some(DataType::String), None) if matches!(right, Expr::Column(_)) => {
+            (DataType::String, DataType::String)
+        }
+        (None, Some(DataType::String)) if matches!(left, Expr::Column(_)) => {
+            (DataType::String, DataType::String)
+        }
+        (Some(DataType::String), None) => (DataType::String, DataType::Float64),
+        (None, Some(DataType::String)) => (DataType::Float64, DataType::String),
+        // Non-string literal vs unknown expression: treat unknown as String so that
+        // generic comparison coercion (including string–numeric) still applies.
+        (Some(lt), None) => (lt, DataType::String),
+        (None, Some(rt)) => (DataType::String, rt),
+        (None, None) => (DataType::String, DataType::String),
+    };
 
     // Both unknown (column refs): cast both to string so string vs numeric doesn't error (PySpark coercion).
-    if infer_type_from_expr(&left).is_none() && infer_type_from_expr(&right).is_none() {
+    if left_inferred.is_none() && right_inferred.is_none() {
         let left_str = left.cast(DataType::String);
         let right_str = right.cast(DataType::String);
         return Ok((left_str, right_str));
@@ -510,6 +558,30 @@ mod tests {
             1,
             "#615: datetime < date should return one row"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn eq_null_safe_int_column_vs_string_literal_coerces() -> Result<(), PolarsError> {
+        use polars::prelude::df;
+
+        let df = df!(
+            "val" => &[Some(123i64), Some(456i64), None],
+        )?;
+        let lf = df.lazy();
+
+        let col_expr = col("val");
+        let lit_expr = lit("123");
+
+        let (left_c, right_c) = coerce_for_pyspark_eq_null_safe(col_expr, lit_expr)?;
+        let out = lf
+            .with_column(left_c.eq(right_c).alias("match"))
+            .collect()?;
+
+        let matches = out.column("match")?.bool()?;
+        let got: Vec<Option<bool>> = matches.into_iter().collect();
+        assert_eq!(got, vec![Some(true), Some(false), Some(false)]);
+
         Ok(())
     }
 }

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -6238,6 +6238,25 @@ impl PyColumn {
     /// Null-safe equality (NULL <=> NULL returns True). PySpark eqNullSafe.
     /// Accepts Column or scalar (int, float, str, bool, None) so .eqNullSafe(lit(x)) or .eqNullSafe(x) work.
     fn eq_null_safe(&self, other: &Bound<'_, PyAny>) -> PyResult<PyColumn> {
+        // Special-case Python string scalars so that int-column vs string-literal
+        // (e.g. col("val").eqNullSafe("123")) behaves like PySpark: attempt to parse
+        // the string as a number and compare numerically when possible (#1471).
+        if let Ok(s) = other.extract::<String>() {
+            if let Ok(i) = s.parse::<i64>() {
+                let other_col = robin_sparkless::functions::lit_i64(i);
+                return Ok(PyColumn {
+                    inner: self.inner.eq_null_safe(&other_col),
+                });
+            }
+            if let Ok(f) = s.parse::<f64>() {
+                let other_col = robin_sparkless::functions::lit_f64(f);
+                return Ok(PyColumn {
+                    inner: self.inner.eq_null_safe(&other_col),
+                });
+            }
+            // Fall through: treat as string literal for non-numeric text ("test", etc.).
+        }
+
         let other_col = py_any_to_column(other)?;
         Ok(PyColumn {
             inner: self.inner.eq_null_safe(&other_col),

--- a/tests/dataframe/test_issue_1471_eqnullsafe_int_col_vs_string_literal.py
+++ b/tests/dataframe/test_issue_1471_eqnullsafe_int_col_vs_string_literal.py
@@ -1,0 +1,39 @@
+"""
+Tests for issue #1471: Column.eqNullSafe with integer column vs string literal.
+
+Sparkless previously raised a type error when comparing an integer column with
+string literal "123" via eqNullSafe, whereas PySpark coerces types and
+performs the comparison successfully.
+"""
+
+from __future__ import annotations
+
+from sparkless.testing import get_imports
+
+
+_imports = get_imports()
+F = _imports.F
+
+
+def test_eqnullsafe_int_column_vs_string_literal(spark) -> None:
+    """eqNullSafe on int column vs string literal mirrors PySpark coercion."""
+    df = spark.createDataFrame(
+        [
+            {"val": 123},
+            {"val": 456},
+            {"val": None},
+        ]
+    )
+
+    out = df.withColumn("match", F.col("val").eqNullSafe("123")).collect()
+
+    # PySpark behavior:
+    # +----+-----+
+    # | val|match|
+    # +----+-----+
+    # | 123| true|
+    # | 456|false|
+    # |NULL|false|
+    # +----+-----+
+    assert [row["match"] for row in out] == [True, False, False]
+


### PR DESCRIPTION
## Summary

- Fix `Column.eqNullSafe` so comparing an **integer column** to a **string literal** (e.g. `"123"`) no longer errors with `cannot compare string with numeric type (i64)`, but instead mirrors PySpark's coercion semantics.
- Reuse and extend the existing `coerce_for_pyspark_eq_null_safe` machinery plus add a small Python binding fast-path so string scalars that look numeric are treated as numeric literals when appropriate.
- Add a Python regression test `test_issue_1471_eqnullsafe_int_col_vs_string_literal` that reproduces the scenario from issue #1471 and now passes in both sparkless and PySpark modes.

## Testing

- `.venv/bin/python -m pytest tests/dataframe/test_issue_1471_eqnullsafe_int_col_vs_string_literal.py tests/dataframe/test_issue_260_eq_null_safe.py tests/dataframe/test_issue_266_eqnullsafe_type_coercion.py -n 0`
- `.venv/bin/python -m pytest -n 10`
- `SPARKLESS_TEST_MODE=pyspark .venv/bin/python -m pytest tests/dataframe/test_issue_1471_eqnullsafe_int_col_vs_string_literal.py -n 0`