### PR TITLE
Fix count(lit(1)) row-count parity (#1472)

### DIFF
--- a/crates/robin-sparkless-polars/src/functions/rest.rs
+++ b/crates/robin-sparkless-polars/src/functions/rest.rs
@@ -13,7 +13,25 @@ use polars::prelude::*;
 pub fn count(col: &Column) -> Column {
     use polars::prelude::len;
 
-    let (expr, name) = if col.name() == "*" {
+    // Treat count("*") and count(lit(1)) (and similar numeric/bool literals) as
+    // "count all rows", matching PySpark's count(lit(1)) / count("*") semantics.
+    let is_star = col.name() == "*";
+    let is_literal_numeric_or_bool = matches!(col.expr(), Expr::Literal(lv) if matches!(
+        lv.get_datatype(),
+        DataType::Int8
+            | DataType::Int16
+            | DataType::Int32
+            | DataType::Int64
+            | DataType::UInt8
+            | DataType::UInt16
+            | DataType::UInt32
+            | DataType::UInt64
+            | DataType::Float32
+            | DataType::Float64
+            | DataType::Boolean
+    ));
+
+    let (expr, name) = if is_star || is_literal_numeric_or_bool {
         (len().cast(DataType::Int64), "count(1)".to_string())
     } else {
         (

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -7953,6 +7953,24 @@ fn when(
 
 #[pyfunction]
 fn count(col: &Bound<'_, PyAny>) -> PyResult<PyColumn> {
+    // Special-case count(lit(1)) / count(lit(constant)) so it behaves like
+    // PySpark's count(lit(1)) and counts all rows, not just the literal.
+    // When the argument is a literal PyColumn, route it through count("*")
+    // semantics (len()) instead of counting non-null values.
+    if let Ok(py_col) = col.downcast::<PyColumn>() {
+        let inner = py_col.borrow().inner.clone();
+        if let Some(json_str) = inner.literal_as_json_string() {
+            if let Ok(json_val) = serde_json::from_str::<serde_json::Value>(&json_str) {
+                if json_val.is_number() || json_val.is_boolean() {
+                    let star_col = robin_sparkless::functions::col("*");
+                    return Ok(PyColumn {
+                        inner: functions::count(&star_col),
+                    });
+                }
+            }
+        }
+    }
+
     let c = coerce_to_column(col)?;
     Ok(PyColumn {
         inner: functions::count(&c),

--- a/tests/dataframe/test_issue_1472_count_lit_one.py
+++ b/tests/dataframe/test_issue_1472_count_lit_one.py
@@ -1,0 +1,31 @@
+"""
+Tests for issue #1472: count(lit(1)) should return row count (PySpark parity).
+
+Sparkless previously returned the literal value (1) instead of counting all rows.
+"""
+
+from __future__ import annotations
+
+from sparkless.testing import get_imports
+
+
+imports = get_imports()
+SparkSession = imports.SparkSession
+F = imports.F
+
+
+def test_count_lit_one_counts_all_rows(spark) -> None:
+    """F.count(F.lit(1)) counts all rows, including nulls."""
+    df = spark.createDataFrame(
+        [
+            {"val": 1},
+            {"val": None},
+            {"val": 3},
+            {"val": None},
+        ]
+    )
+
+    result = df.agg(F.count(F.lit(1)).alias("count_all")).collect()
+    assert len(result) == 1
+    assert result[0]["count_all"] == 4
+


### PR DESCRIPTION
## Summary

- Fix `F.count(F.lit(1))` in sparkless mode so it returns the **row count** (including nulls) instead of the literal value `1`, matching PySpark's `count(lit(1))` behavior as described in [#1472](https://github.com/eddiethedean/robin-sparkless/issues/1472).
- Extend the Rust `functions::count` implementation to treat both `count("*")` and `count` of numeric/bool literal expressions as `len()` (count-all-rows) while preserving existing `count(column)` semantics.
- Add a small Python binding fast-path so `count(lit(1))` and similar literal `PyColumn` arguments are routed through the `count("*")`/len() path.
- Add a regression test `tests/dataframe/test_issue_1472_count_lit_one.py` that covers the scenario from the issue.

## Testing

- `.venv/bin/python -m pytest tests/dataframe/test_issue_1472_count_lit_one.py tests/dataframe/test_issue_397_groupby_alias.py -n 0`
- `.venv/bin/python -m pytest -n 10`