### PR TITLE
fix: support empty delta saveAsTable bootstrap

### DIFF
--- a/crates/robin-sparkless-polars/src/delta/mod.rs
+++ b/crates/robin-sparkless-polars/src/delta/mod.rs
@@ -381,10 +381,6 @@ pub fn write_delta(
 
     let path = path.as_ref();
 
-    if df.height() == 0 {
-        return Ok(());
-    }
-
     // Create target directory before resolving URI so deltalake sees an existing path.
     if overwrite {
         if path.exists() {

--- a/tests/dataframe/test_issue_1524_delta_saveastable_empty.py
+++ b/tests/dataframe/test_issue_1524_delta_saveastable_empty.py
@@ -1,0 +1,37 @@
+import tempfile
+import uuid
+
+import pytest
+from sparkless.testing import create_session
+
+
+@pytest.mark.delta
+@pytest.mark.xdist_group(name="delta_serial")
+def test_issue_1524_delta_saveastable_empty_dataframe_creates_table_then_append_works():
+    warehouse_dir = tempfile.mkdtemp(prefix="sparkless_warehouse_")
+    try:
+        spark = create_session(
+            app_name="issue_1524_delta_saveastable_empty",
+            enable_delta=True,
+            **{"spark.sql.warehouse.dir": warehouse_dir},
+        )
+
+        schema = f"demo_{uuid.uuid4().hex[:8]}"
+        table = f"{schema}.delta_empty_table"
+        spark.sql(f"CREATE SCHEMA IF NOT EXISTS {schema}")
+
+        empty_df = spark.createDataFrame([], "id int, name string")
+
+        empty_df.write.format("delta").mode("overwrite").option(
+            "overwriteSchema", "true"
+        ).saveAsTable(table)
+        assert spark.table(table).count() == 0
+
+        df1 = spark.createDataFrame([(1, "a")], ["id", "name"])
+        df1.write.format("delta").mode("append").saveAsTable(table)
+        assert spark.table(table).count() == 1
+    finally:
+        try:
+            spark.stop()
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary
- remove the early return in Delta writes for empty DataFrames so `mode('overwrite').format('delta').saveAsTable(...)` can still initialize table metadata/log
- add a regression test that creates an empty Delta table via `saveAsTable`, asserts zero rows, then appends and verifies row count
- fixes the empty table bootstrap failure reported in #1524

## Test plan
- [x] `source .venv/bin/activate && python -m pytest -q tests/dataframe/test_issue_1524_delta_saveastable_empty.py -m delta`

Closes #1524.