### PR TITLE
Fix: expose Catalog drop* APIs (#1537)

### DIFF
--- a/crates/robin-sparkless-polars/src/session/mod.rs
+++ b/crates/robin-sparkless-polars/src/session/mod.rs
@@ -1249,17 +1249,16 @@ impl SparkSession {
     }
 
     /// Drop a temporary view by name (PySpark: catalog.dropTempView).
-    /// No error if the view does not exist.
-    /// If the catalog lock is poisoned, the operation is best-effort and a message is emitted to stderr.
-    pub fn drop_temp_view(&self, name: &str) {
+    /// Returns true if a view was removed; false if not present.
+    /// If the catalog lock is poisoned, returns false and a message is emitted to stderr.
+    pub fn drop_temp_view(&self, name: &str) -> bool {
         match self.catalog.lock() {
-            Ok(mut m) => {
-                m.remove(name);
-            }
+            Ok(mut m) => m.remove(name).is_some(),
             Err(_) => {
                 eprintln!(
                     "robin-sparkless-polars: catalog lock poisoned, drop_temp_view may have failed"
                 );
+                false
             }
         }
     }

--- a/crates/robin-sparkless-polars/src/sql/translator.rs
+++ b/crates/robin-sparkless-polars/src/sql/translator.rs
@@ -213,7 +213,7 @@ pub fn translate(
                         session.drop_global_temp_view(suffix);
                     }
                 }
-                session.drop_temp_view(&name);
+                let _ = session.drop_temp_view(&name);
                 session.drop_table(&name);
             }
             Ok(DataFrame::from_polars_with_options(
@@ -256,7 +256,7 @@ pub fn translate(
                         session.drop_global_temp_view(suffix);
                     }
                 }
-                session.drop_temp_view(&name);
+                let _ = session.drop_temp_view(&name);
                 session.drop_table(&name);
             }
             Ok(DataFrame::from_polars_with_options(

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -947,8 +947,8 @@ impl PySparkSession {
             .create_or_replace_global_temp_view(name, df.inner.clone());
     }
 
-    fn drop_temp_view(&self, name: &str) {
-        self.inner.drop_temp_view(name);
+    fn drop_temp_view(&self, name: &str) -> bool {
+        self.inner.drop_temp_view(name)
     }
 
     fn table(&self, name: &str) -> PyResult<PyDataFrame> {
@@ -1265,15 +1265,36 @@ impl PyCatalog {
     }
 
     #[pyo3(name = "dropTempView")]
-    fn drop_temp_view(&self, py: Python<'_>, name: &str) -> PyResult<()> {
+    fn drop_temp_view(&self, py: Python<'_>, name: &str) -> PyResult<bool> {
         let session = self
             .session
             .bind(py)
             .downcast::<PySparkSession>()
             .map_err(|_| PyErr::new::<pyo3::exceptions::PyTypeError, _>("expected SparkSession"))?
             .borrow();
-        session.inner.drop_temp_view(name);
-        Ok(())
+        Ok(session.inner.drop_temp_view(name))
+    }
+
+    #[pyo3(name = "dropGlobalTempView")]
+    fn drop_global_temp_view(&self, py: Python<'_>, name: &str) -> PyResult<bool> {
+        let session = self
+            .session
+            .bind(py)
+            .downcast::<PySparkSession>()
+            .map_err(|_| PyErr::new::<pyo3::exceptions::PyTypeError, _>("expected SparkSession"))?
+            .borrow();
+        Ok(session.inner.drop_global_temp_view(name))
+    }
+
+    #[pyo3(name = "dropTable")]
+    fn drop_table(&self, py: Python<'_>, name: &str) -> PyResult<bool> {
+        let session = self
+            .session
+            .bind(py)
+            .downcast::<PySparkSession>()
+            .map_err(|_| PyErr::new::<pyo3::exceptions::PyTypeError, _>("expected SparkSession"))?
+            .borrow();
+        Ok(session.inner.drop_table(name))
     }
 
     #[pyo3(name = "listDatabases")]
@@ -3750,7 +3771,7 @@ impl PyDataFrame {
                     }
                 }
             }
-            session_ref.borrow().inner.drop_temp_view("__selectexpr_t");
+            let _ = session_ref.borrow().inner.drop_temp_view("__selectexpr_t");
             resolved
         } else {
             raw.into_iter()
@@ -3980,6 +4001,7 @@ impl PyDataFrame {
                 .borrow()
                 .inner
                 .drop_temp_view("__withcol_expr_t");
+            // Ignore boolean return; cleanup best-effort.
             let col = Column::from_expr(expr, None);
             let df = slf.inner.with_column(name, &col).map_err(|e| {
                 let msg = e.to_string();
@@ -5037,6 +5059,22 @@ impl PyDataFrame {
             .borrow()
             .inner
             .create_or_replace_temp_view(name, self.inner.clone());
+        Ok(())
+    }
+
+    #[pyo3(name = "createOrReplaceGlobalTempView")]
+    fn create_or_replace_global_temp_view_camel(&self, py: Python<'_>, name: &str) -> PyResult<()> {
+        let session = THREAD_ACTIVE_SESSIONS
+            .with(|cell| cell.borrow().last().map(|s| s.clone_ref(py)))
+            .ok_or_else(|| to_py_err("No active SparkSession for createOrReplaceGlobalTempView"))?;
+        let session_ref = session
+            .bind(py)
+            .downcast::<PySparkSession>()
+            .map_err(|_| PyErr::new::<pyo3::exceptions::PyTypeError, _>("expected SparkSession"))?;
+        session_ref
+            .borrow()
+            .inner
+            .create_or_replace_global_temp_view(name, self.inner.clone());
         Ok(())
     }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -84,7 +84,7 @@ impl SparkSession {
         self.0.create_or_replace_global_temp_view(name, df.0)
     }
 
-    pub fn drop_temp_view(&self, name: &str) {
+    pub fn drop_temp_view(&self, name: &str) -> bool {
         self.0.drop_temp_view(name)
     }
 

--- a/tests/parity/internal/test_issue_1537_catalog_drop_returns_bool.py
+++ b/tests/parity/internal/test_issue_1537_catalog_drop_returns_bool.py
@@ -12,7 +12,9 @@ def test_issue_1537_catalog_drop_temp_view_returns_bool(spark, spark_imports) ->
     assert spark.catalog.dropTempView("tmp_v") is False
 
 
-def test_issue_1537_catalog_drop_global_temp_view_returns_bool(spark, spark_imports) -> None:
+def test_issue_1537_catalog_drop_global_temp_view_returns_bool(
+    spark, spark_imports
+) -> None:
     _ = spark_imports
     df = spark.createDataFrame([(1,)], "v INT")
 
@@ -32,4 +34,3 @@ def test_issue_1537_catalog_drop_table_returns_bool(spark, spark_imports) -> Non
     df.write.saveAsTable("tbl_v")
     assert spark.catalog.dropTable("tbl_v") is True
     assert spark.catalog.dropTable("tbl_v") is False
-

--- a/tests/parity/internal/test_issue_1537_catalog_drop_returns_bool.py
+++ b/tests/parity/internal/test_issue_1537_catalog_drop_returns_bool.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+
+def test_issue_1537_catalog_drop_temp_view_returns_bool(spark, spark_imports) -> None:
+    _ = spark_imports
+    df = spark.createDataFrame([(1,)], "v INT")
+
+    assert spark.catalog.dropTempView("no_such_view") is False
+
+    df.createOrReplaceTempView("tmp_v")
+    assert spark.catalog.dropTempView("tmp_v") is True
+    assert spark.catalog.dropTempView("tmp_v") is False
+
+
+def test_issue_1537_catalog_drop_global_temp_view_returns_bool(spark, spark_imports) -> None:
+    _ = spark_imports
+    df = spark.createDataFrame([(1,)], "v INT")
+
+    assert spark.catalog.dropGlobalTempView("no_such_global_view") is False
+
+    df.createOrReplaceGlobalTempView("gtmp_v")
+    assert spark.catalog.dropGlobalTempView("gtmp_v") is True
+    assert spark.catalog.dropGlobalTempView("gtmp_v") is False
+
+
+def test_issue_1537_catalog_drop_table_returns_bool(spark, spark_imports) -> None:
+    _ = spark_imports
+    df = spark.createDataFrame([(1,)], "v INT")
+
+    assert spark.catalog.dropTable("no_such_table") is False
+
+    df.write.saveAsTable("tbl_v")
+    assert spark.catalog.dropTable("tbl_v") is True
+    assert spark.catalog.dropTable("tbl_v") is False
+


### PR DESCRIPTION
Fixes #1537.

## Summary
- Make `spark.catalog.dropTempView(name)` return `bool` (True if dropped, False if missing)
- Add missing `spark.catalog.dropTable(name) -> bool`
- Add missing `spark.catalog.dropGlobalTempView(name) -> bool`
- Add parity regression tests for all three behaviors

## Test plan
- `./.venv/bin/python -m pytest -q tests/parity/internal/test_issue_1537_catalog_drop_returns_bool.py`