### PR TITLE
ci: fix rustfmt install cargo-fmt conflict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,7 @@ jobs:
           # Work around rare rustup component install conflict where `cargo-fmt`
           # already exists but is not owned by the toolchain (observed in CI).
           rm -f ~/.cargo/bin/cargo-fmt
+          rm -f ~/.rustup/toolchains/*/bin/cargo-fmt
           cd python && ../.venv/bin/maturin develop
           ../.venv/bin/python -c "from sparkless.sql import SparkSession; from sparkless.sql.functions import col, lit_i64; s = SparkSession.builder.app_name('ci').get_or_create(); df = s.create_dataframe([(1, 2, 'a')], ['x', 'y', 'z']); assert df.count() == 1; print('sparkless OK')"
       - name: Install pytest and run tests (fast subset)


### PR DESCRIPTION
## Summary
- Fix CI flake where `maturin develop` triggers rustup component install and fails with `detected conflict: 'bin/cargo-fmt'`.
- Remove `cargo-fmt` from both `~/.cargo/bin` and any rustup toolchain bins before running maturin.

## Context
The failing run: `https://github.com/eddiethedean/robin-sparkless/actions/runs/25441805824`.

## Test plan
- CI should pass (Python job no longer fails installing rustfmt).