### PR TITLE
ci(release): retry PyPI musllinux aarch64 publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -391,6 +391,16 @@ jobs:
         with:
           python-version: "3.8"
       - name: Publish to PyPI (maturin)
+        continue-on-error: true
+        uses: messense/maturin-action@v1
+        env:
+          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        with:
+          target: aarch64-unknown-linux-musl
+          command: publish
+          args: --manifest-path python/Cargo.toml -i 3.8 --zig --compatibility musllinux_1_2 --skip-existing
+      - name: Retry publish to PyPI (maturin)
+        if: failure()
         uses: messense/maturin-action@v1
         env:
           MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## What failed
Release run `https://github.com/eddiethedean/robin-sparkless/actions/runs/25444878500` failed only on **PyPI musllinux aarch64** with a transient PyPI `500 Internal Server Error` while uploading `sparkless-4.6.0-...musllinux_1_2_aarch64.whl`.

## Fix
Add a second publish attempt for the musllinux aarch64 job when the first attempt fails.

`--skip-existing` keeps reruns safe.