### PR TITLE
Fix double-quoted string literals in filter expressions (#1541)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.7.0] - 2026-05-21
 
+### Fixed
+
+- **#1541 – Double-quoted string literals in filter expressions** — `df.filter('status == "Y"')` now treats `"Y"` as a string literal (PySpark parity); previously parsed as a column reference.
+
 ### Changed
 
 - **Release metadata** — Version bump to 4.7.0 across the Rust crates and the Python package.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 (none yet)
 
+## [4.7.0] - 2026-05-21
+
+### Changed
+
+- **Release metadata** — Version bump to 4.7.0 across the Rust crates and the Python package.
+
 ## [4.6.0] - 2026-05-06
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/robin-sparkless-core", "crates/robin-sparkless-polars", "crat
 
 [package]
 name = "robin-sparkless"
-version = "4.6.0"
+version = "4.7.0"
 edition = "2024"
 description = "PySpark-like DataFrame API in Rust on Polars; no JVM."
 readme = "README.md"
@@ -36,8 +36,8 @@ jdbc_db2 = ["robin-sparkless-polars/jdbc_db2"]
 sqlite = ["robin-sparkless-polars/sqlite"]
 
 [dependencies]
-robin-sparkless-core = { version = "4.6.0", path = "crates/robin-sparkless-core" }
-robin-sparkless-polars = { version = "4.6.0", path = "crates/robin-sparkless-polars" }
+robin-sparkless-core = { version = "4.7.0", path = "crates/robin-sparkless-core" }
+robin-sparkless-polars = { version = "4.7.0", path = "crates/robin-sparkless-polars" }
 serde_json = "1.0"
 
 # Use git sources when crates.io/cache is broken (e.g. "no targets specified" in manifest,

--- a/crates/robin-sparkless-core/Cargo.toml
+++ b/crates/robin-sparkless-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "robin-sparkless-core"
-version = "4.6.0"
+version = "4.7.0"
 edition = "2024"
 description = "Shared types, config, and error for robin-sparkless (no Polars)."
 license = "MIT"

--- a/crates/robin-sparkless-polars/Cargo.toml
+++ b/crates/robin-sparkless-polars/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "robin-sparkless-polars"
-version = "4.6.0"
+version = "4.7.0"
 edition = "2024"
 description = "Polars-backed DataFrame, Session, and expression layer for robin-sparkless."
 license = "MIT"
@@ -19,7 +19,7 @@ jdbc_db2 = ["dep:odbc-api"]
 sqlite = ["dep:rusqlite"]
 
 [dependencies]
-robin-sparkless-core = { version = "4.6.0", path = "../robin-sparkless-core" }
+robin-sparkless-core = { version = "4.7.0", path = "../robin-sparkless-core" }
 polars = { version = "0.53", features = ["lazy", "csv", "parquet", "json", "temporal", "strings", "concat_str", "regex", "round_series", "abs", "dtype-categorical", "dtype-date", "dtype-datetime", "dtype-duration", "dtype-time", "rank", "is_in", "list_eval", "list_drop_nulls", "list_any_all", "cum_agg", "string_pad", "string_reverse", "repeat_by", "log", "month_end", "describe", "cross_join", "semi_anti_join", "extract_jsonpath", "dtype-struct", "random", "product", "moment", "rolling_window"] }
 polars-plan = "0.53"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/robin-sparkless-polars/src/sql/translator.rs
+++ b/crates/robin-sparkless-polars/src/sql/translator.rs
@@ -1137,7 +1137,11 @@ fn sql_expr_to_polars(
         SqlExpr::Value(ValueWithSpan { value: Value::Number(s, _), .. }) => {
             parse_sql_number_expr(s)
         }
-        SqlExpr::Value(ValueWithSpan { value: Value::SingleQuotedString(s), .. }) => Ok(lit(s.as_str())),
+        SqlExpr::Value(ValueWithSpan { value: Value::SingleQuotedString(s), .. })
+        | SqlExpr::Value(ValueWithSpan {
+            value: Value::DoubleQuotedString(s),
+            ..
+        }) => Ok(lit(s.as_str())),
         SqlExpr::Value(ValueWithSpan { value: Value::Boolean(b), .. }) => Ok(lit(*b)),
         SqlExpr::Value(ValueWithSpan { value: Value::Null, .. }) => Ok(lit(polars::prelude::NULL)),
         SqlExpr::BinaryOp { left, op, right } => {
@@ -1226,7 +1230,7 @@ fn sql_expr_to_polars(
             let pattern_str = sql_expr_to_string_literal(pattern.as_ref())?;
             let col_col = crate::column::Column::from_expr(col_expr, None);
             let escape: Option<char> = escape_char.as_ref().and_then(|v| match v {
-                Value::SingleQuotedString(s) => s.chars().next(),
+                Value::SingleQuotedString(s) | Value::DoubleQuotedString(s) => s.chars().next(),
                 _ => None,
             });
             let like_expr = col_col.like(&pattern_str, escape).into_expr();
@@ -1413,7 +1417,7 @@ fn sql_expr_to_qualified_col_name(
 fn sql_expr_to_string_literal(expr: &SqlExpr) -> Result<String, PolarsError> {
     match expr {
         SqlExpr::Value(ValueWithSpan {
-            value: Value::SingleQuotedString(s),
+            value: Value::SingleQuotedString(s) | Value::DoubleQuotedString(s),
             ..
         }) => Ok(s.clone()),
         _ => Err(PolarsError::InvalidOperation(

--- a/crates/spark-sql-parser/src/lib.rs
+++ b/crates/spark-sql-parser/src/lib.rs
@@ -20,7 +20,7 @@
 use sqlparser::ast::{
     Expr as SqlExpr, Ident, ObjectName, Query, Select, SelectItem, SetExpr, Statement,
 };
-use sqlparser::dialect::GenericDialect;
+use sqlparser::dialect::{GenericDialect, MySqlDialect};
 use sqlparser::parser::Parser;
 use thiserror::Error;
 
@@ -63,8 +63,14 @@ pub enum SparkStatement {
 }
 
 fn parse_one_statement_raw(query: &str) -> Result<Statement, ParseError> {
-    let dialect = GenericDialect {};
-    let stmts = Parser::parse_sql(&dialect, query).map_err(|e| {
+    parse_one_statement_with_dialect(query, &GenericDialect {})
+}
+
+fn parse_one_statement_with_dialect(
+    query: &str,
+    dialect: &dyn sqlparser::dialect::Dialect,
+) -> Result<Statement, ParseError> {
+    let stmts = Parser::parse_sql(dialect, query).map_err(|e| {
         ParseError(format!(
             "SQL parse error: {}. Hint: supported statements include SELECT, CREATE TABLE/VIEW/FUNCTION/SCHEMA/DATABASE, DROP TABLE/VIEW/SCHEMA.",
             e
@@ -405,7 +411,9 @@ pub fn parse_select_expr(expr_str: &str) -> Result<(SqlExpr, Option<Ident>), Par
     // Parse by embedding into a query; keep the hack local to this crate.
     const TMP_TABLE: &str = "__spark_sql_parser_expr_t";
     let query = format!("SELECT {e} FROM {TMP_TABLE}");
-    let stmt = parse_one_statement_raw(&query)?;
+    // PySpark filter/expr strings accept double-quoted string literals (issue #1541).
+    // GenericDialect treats `"` as delimited identifiers; MySQL treats them as literals.
+    let stmt = parse_one_statement_with_dialect(&query, &MySqlDialect {})?;
     let query_ast: &Query = match &stmt {
         Statement::Query(q) => q.as_ref(),
         other => {
@@ -1053,6 +1061,22 @@ mod tests {
     fn parse_select_expr_literal_string() {
         let (e, _) = parse_select_expr("'hello'").unwrap();
         assert!(matches!(e, SqlExpr::Value(_)));
+    }
+
+    #[test]
+    fn parse_select_expr_double_quoted_string_literal() {
+        // PySpark accepts "Y" as a string literal in filter strings (issue #1541).
+        let (e, _) = parse_select_expr(r#"status == "Y""#).unwrap();
+        match e {
+            SqlExpr::BinaryOp { right, .. } => match right.as_ref() {
+                SqlExpr::Value(sqlparser::ast::ValueWithSpan {
+                    value: sqlparser::ast::Value::DoubleQuotedString(s),
+                    ..
+                }) => assert_eq!(s, "Y"),
+                other => panic!("expected double-quoted string literal, got {other:?}"),
+            },
+            other => panic!("expected binary op, got {other:?}"),
+        }
     }
 
     #[test]

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sparkless-native"
-version = "4.6.0"
+version = "4.7.0"
 edition = "2021"
 description = "Native extension for sparkless Python package (robin-sparkless backend)."
 readme = "README.md"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sparkless"
-version = "4.6.0"
+version = "4.7.0"
 description = "PySpark-like DataFrame API in Python—no JVM. Uses robin-sparkless (Rust/Polars) as the execution engine."
 readme = "README.md"
 license = { text = "MIT" }

--- a/python/sparkless/sparkless/__init__.py
+++ b/python/sparkless/sparkless/__init__.py
@@ -20,7 +20,7 @@ from typing import Dict, List, Sequence, Tuple, Union, cast as _cast
 
 from sparkless._native import PyColumn as _ColumnType
 
-__version__ = "4.6.0"
+__version__ = "4.7.0"
 
 
 _mod = __import__(

--- a/tests/dataframe/test_issue_1541_filter_double_quoted_string.py
+++ b/tests/dataframe/test_issue_1541_filter_double_quoted_string.py
@@ -1,0 +1,30 @@
+"""Tests for issue #1541: filter string expressions with double-quoted literals."""
+
+from __future__ import annotations
+
+
+def test_filter_double_quoted_string_literal(spark) -> None:
+    """PySpark accepts both 'Y' and "Y" as string literals in filter strings."""
+    schema = "status string, value string"
+    data = [("Y", "keep"), ("N", "drop")]
+    df = spark.createDataFrame(data, schema=schema)
+
+    result = df.filter('status == "Y"')
+    rows = result.collect()
+
+    assert len(rows) == 1
+    assert rows[0]["status"] == "Y"
+    assert rows[0]["value"] == "keep"
+
+
+def test_filter_single_quoted_string_literal_still_works(spark) -> None:
+    """Single-quoted literals remain supported."""
+    schema = "status string, value string"
+    data = [("Y", "keep"), ("N", "drop")]
+    df = spark.createDataFrame(data, schema=schema)
+
+    result = df.filter("status == 'Y'")
+    rows = result.collect()
+
+    assert len(rows) == 1
+    assert rows[0]["status"] == "Y"


### PR DESCRIPTION
## Summary

Fixes [#1541](https://github.com/eddiethedean/robin-sparkless/issues/1541): PySpark accepts both `'Y'` and `"Y"` as string literals in `DataFrame.filter()` SQL strings, but Sparkless treated `"Y"` as a column reference (`cannot resolve: column 'Y' not found`).

- Parse `filter` / `expr` / `selectExpr` expression strings with **MySQL dialect** so `"..."` tokenizes as `DoubleQuotedString` (GenericDialect treats `"` as delimited identifiers).
- Translate `DoubleQuotedString` in `sql_expr_to_polars` (and LIKE pattern / escape handling) the same as single-quoted literals.

## Test plan

- [x] `cargo test -p spark-sql-parser`
- [x] `tests/dataframe/test_issue_1541_filter_double_quoted_string.py` (double-quoted and single-quoted filters)