### PR TITLE
Fix createDataFrame for tuple and iterable of dict rows (#1542)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-(none yet)
+- **#1542 – createDataFrame with tuple or iterable of dict rows** — `createDataFrame(({"a": 1}, {"a": 2}))` and generator inputs now work like PySpark; previously raised `[CANNOT_ACCEPT_OBJECT_IN_TYPE]` for tuples.
 
 ## [4.7.0] - 2026-05-21
 

--- a/docs/PYSPARK_DIFFERENCES.md
+++ b/docs/PYSPARK_DIFFERENCES.md
@@ -90,7 +90,7 @@ This document lists **intentional or known divergences** from PySpark semantics 
 - **Robin-sparkless (Rust)** — **`create_dataframe(data, column_names)`** accepts only 3-tuples `(i64, i64, String)` and three column names. For arbitrary schemas use **`create_dataframe_from_rows(rows, schema)`** (Rust).
 - **Column name case (#786, #785)**: Column names from the schema are preserved as returned by `columns()` and in collect row keys. Pass the exact case you need (e.g. `NaMe`) in the schema so `'NaMe' in df.columns` succeeds.
 - **Duplicate field names in StructType (#1347)**: PySpark allows duplicate field names in a schema (e.g. two fields both named `id`). Robin-sparkless **rejects** them and raises an error: `create_dataframe_from_rows: duplicate column name '…' in schema`. Use unique field names when creating DataFrames with an explicit schema so tests and pipelines work under both.
-- **Invalid data type (#1346)**: When `data` is not a list, RDD, or pandas DataFrame, robin-sparkless raises **SparklessError** (PySparkTypeError) with message `[CANNOT_ACCEPT_OBJECT_IN_TYPE] \`StructType\` can not accept object in type \`<type>\`.` to match PySpark.
+- **Invalid data type (#1346)**: When `data` is not a list, tuple, iterable of rows, RDD, or pandas DataFrame, robin-sparkless raises **SparklessError** (PySparkTypeError) with message `[CANNOT_ACCEPT_OBJECT_IN_TYPE] \`StructType\` can not accept object in type \`<type>\`.` to match PySpark. Tuples and generators of dict/tuple rows are accepted (#1542).
 - **Empty schema + empty rows (#1345, #1343)**: `createDataFrame([{}], StructType([]))` (or `[]` with empty schema) is supported: produces 1 row, 0 columns, matching PySpark.
 
 ## SparkSession type / engine detection (#1344)

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -7,7 +7,7 @@
 
 use pyo3::create_exception;
 use pyo3::prelude::*;
-use pyo3::types::{PyBytes, PyDict, PyList, PyTuple};
+use pyo3::types::{PyBytes, PyDict, PyList, PyString, PyTuple};
 use robin_sparkless::dataframe::{
     expr_contains_only_join_key_equalities, try_extract_join_eq_columns_all, JoinType,
     PivotedGroupedData, SaveMode, WriteFormat, WriteMode,
@@ -978,7 +978,7 @@ impl PySparkSession {
     }
 
     /// createDataFrame(data, schema=None, verify_schema=True, sampling_ratio=None).
-    /// data: list of dicts, list of tuples, or pandas.DataFrame.
+    /// data: list/tuple of dicts, list/tuple of row tuples, iterable of rows, or pandas.DataFrame.
     /// schema: optional list of (name, type_str) or list of column names (types inferred).
     /// verify_schema: when True, validate row values against schema types (PySpark parity).
     /// sampling_ratio: accepted for API parity; ignored for list/dict data.
@@ -1775,7 +1775,37 @@ fn normalize_create_dataframe_input<'py>(
     }
 
     // 3. Pandas DataFrame: to_dict("records"); preserve column order (#1151).
-    maybe_convert_pandas_to_list(py, data)
+    let (data, from_pandas, pandas_columns) = maybe_convert_pandas_to_list(py, data)?;
+    let data = coerce_create_dataframe_rows_to_list(py, &data)?;
+    Ok((data, from_pandas, pandas_columns))
+}
+
+/// Convert tuple or other row iterable to `list` for createDataFrame (PySpark parity; #1542).
+fn coerce_create_dataframe_rows_to_list<'py>(
+    py: Python<'py>,
+    data: &Bound<'py, PyAny>,
+) -> PyResult<Bound<'py, PyAny>> {
+    if data.downcast::<PyList>().is_ok() {
+        return Ok(data.clone());
+    }
+    if let Ok(tup) = data.downcast::<PyTuple>() {
+        let out = PyList::empty_bound(py);
+        for item in tup.iter() {
+            out.append(item)?;
+        }
+        return Ok(out.into_any());
+    }
+    // Generators and other iterables of rows; exclude str/bytes (iterable of chars).
+    if !data.is_instance_of::<PyString>() && !data.is_instance_of::<PyBytes>() {
+        if let Ok(iter) = data.iter() {
+            let out = PyList::empty_bound(py);
+            for item in iter {
+                out.append(item?)?;
+            }
+            return Ok(out.into_any());
+        }
+    }
+    Ok(data.clone())
 }
 
 /// If data is a pandas DataFrame, convert to list of dicts via to_dict("records").

--- a/tests/dataframe/test_issue_1542_create_dataframe_tuple_of_dicts.py
+++ b/tests/dataframe/test_issue_1542_create_dataframe_tuple_of_dicts.py
@@ -1,0 +1,35 @@
+"""Tests for issue #1542: createDataFrame accepts tuple (and iterable) of dict rows."""
+
+from __future__ import annotations
+
+
+def test_create_dataframe_tuple_of_dicts(spark) -> None:
+    """PySpark accepts a tuple of dicts like a list of dicts."""
+    rows = (
+        {"name": "Alice"},
+        {"name": "Bob"},
+    )
+    df = spark.createDataFrame(rows)
+    out = df.collect()
+    assert len(out) == 2
+    assert out[0]["name"] == "Alice"
+    assert out[1]["name"] == "Bob"
+
+
+def test_create_dataframe_generator_of_dicts(spark) -> None:
+    """PySpark accepts any iterable of dict rows."""
+
+    def row_iter():
+        yield {"name": "Alice"}
+        yield {"name": "Bob"}
+
+    df = spark.createDataFrame(row_iter())
+    out = df.collect()
+    assert len(out) == 2
+    assert {r["name"] for r in out} == {"Alice", "Bob"}
+
+
+def test_create_dataframe_list_of_dicts_still_works(spark) -> None:
+    """Regression: list of dicts unchanged."""
+    df = spark.createDataFrame([{"name": "Alice"}, {"name": "Bob"}])
+    assert len(df.collect()) == 2


### PR DESCRIPTION
## Summary

Fixes [#1542](https://github.com/eddiethedean/robin-sparkless/issues/1542): `spark.createDataFrame(tuple_of_dicts)` raised `[CANNOT_ACCEPT_OBJECT_IN_TYPE]` because only `list` was accepted as the row container. PySpark accepts any iterable of dict rows (list, tuple, generator).

- Add `coerce_create_dataframe_rows_to_list` in the PyO3 layer to normalize `tuple` and generic iterables (excluding `str`/`bytes`) to `list` before schema inference.
- Tests for tuple-of-dicts, generator-of-dicts, and regression on list + invalid-data error (#1346).

## Test plan

- [x] `pytest tests/dataframe/test_issue_1542_create_dataframe_tuple_of_dicts.py`
- [x] `pytest tests/dataframe/test_issue_1346_createDataFrame_invalid_data_error.py`