### PR TITLE
Fix concat_ws for list and string columns (#1543)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **#1543 – concat_ws on list and string columns** — `concat_ws(sep, col)` no longer casts list columns directly to string; list elements are joined with `sep`, and string columns pass through unchanged.
+
 - **#1542 – createDataFrame with tuple or iterable of dict rows** — `createDataFrame(({"a": 1}, {"a": 2}))` and generator inputs now work like PySpark; previously raised `[CANNOT_ACCEPT_OBJECT_IN_TYPE]` for tuples.
 
 ## [4.7.0] - 2026-05-21

--- a/crates/robin-sparkless-polars/src/functions/rest.rs
+++ b/crates/robin-sparkless-polars/src/functions/rest.rs
@@ -2343,7 +2343,59 @@ pub fn concat(columns: &[&Column]) -> Column {
     crate::column::Column::from_expr(concat_str(&exprs, "", false), None)
 }
 
+/// Convert one concat_ws argument to Utf8: scalar columns are cast to string; list columns
+/// have elements stringified and joined with `separator` (PySpark parity; #1543).
+fn expr_for_concat_ws_part(expr: Expr, separator: &str) -> Expr {
+    use polars::prelude::*;
+    let sep = separator.to_string();
+    expr.map(
+        move |col| {
+            crate::column::expect_col(concat_ws_input_column_to_string(col, &sep))
+        },
+        |_schema, field| Ok(Field::new(field.name().clone(), DataType::String)),
+    )
+}
+
+fn concat_ws_input_column_to_string(
+    col: polars::prelude::Column,
+    separator: &str,
+) -> PolarsResult<Option<polars::prelude::Column>> {
+    let out = concat_ws_input_series_to_string(col.take_materialized_series(), separator)?;
+    Ok(Some(out.into_column()))
+}
+
+fn concat_ws_input_series_to_string(s: Series, separator: &str) -> PolarsResult<Series> {
+    use polars::chunked_array::builder::StringChunkedBuilder;
+    use polars::prelude::*;
+    if !matches!(s.dtype(), DataType::List(_)) {
+        return s.cast(&DataType::String);
+    }
+    let list = s.list()?;
+    let mut builder = StringChunkedBuilder::new(s.name().clone(), list.len());
+    for opt_inner in list.into_iter() {
+        let joined = match opt_inner {
+            None => None,
+            Some(inner) => {
+                let inner = inner.cast(&DataType::String)?;
+                let ca = inner.str()?;
+                let mut parts = Vec::new();
+                for v in ca.into_iter().flatten() {
+                    parts.push(v);
+                }
+                if parts.is_empty() {
+                    None
+                } else {
+                    Some(parts.join(separator))
+                }
+            }
+        };
+        builder.append_option(joined.as_deref());
+    }
+    Ok(builder.finish().into_series())
+}
+
 /// Concatenate columns as strings with separator (PySpark concat_ws). Numeric columns cast to string (#852).
+/// List/array columns are element-joined with `separator` first; string columns pass through (#1543).
 /// **Panics** if `columns` is empty.
 pub fn concat_ws(separator: &str, columns: &[&Column]) -> Column {
     use polars::prelude::*;
@@ -2352,7 +2404,7 @@ pub fn concat_ws(separator: &str, columns: &[&Column]) -> Column {
     }
     let exprs: Vec<Expr> = columns
         .iter()
-        .map(|c| c.expr().clone().cast(DataType::String))
+        .map(|c| expr_for_concat_ws_part(c.expr().clone(), separator))
         .collect();
     // PySpark semantics: concat_ws ignores nulls across all arguments, and returns
     // null only when all inputs are null. Polars' concat_str with ignore_nulls=true

--- a/crates/robin-sparkless-polars/src/functions/rest.rs
+++ b/crates/robin-sparkless-polars/src/functions/rest.rs
@@ -2349,9 +2349,7 @@ fn expr_for_concat_ws_part(expr: Expr, separator: &str) -> Expr {
     use polars::prelude::*;
     let sep = separator.to_string();
     expr.map(
-        move |col| {
-            crate::column::expect_col(concat_ws_input_column_to_string(col, &sep))
-        },
+        move |col| crate::column::expect_col(concat_ws_input_column_to_string(col, &sep)),
         |_schema, field| Ok(Field::new(field.name().clone(), DataType::String)),
     )
 }

--- a/tests/dataframe/test_issue_1543_concat_ws_list_column.py
+++ b/tests/dataframe/test_issue_1543_concat_ws_list_column.py
@@ -1,0 +1,29 @@
+"""Tests for issue #1543: concat_ws on list and string columns."""
+
+from __future__ import annotations
+
+from sparkless.testing import get_imports
+
+_imports = get_imports()
+F = _imports.F
+
+
+def test_concat_ws_on_list_column(spark) -> None:
+    """concat_ws(sep, array_col) joins list elements (issue #1543 repro)."""
+    df = spark.createDataFrame(
+        [["A", ["B", "C"]]],
+        ["D", "E"],
+    )
+    result = df.withColumn("E", F.concat_ws(", ", F.col("E")))
+    rows = result.collect()
+    assert len(rows) == 1
+    assert rows[0]["D"] == "A"
+    assert rows[0]["E"] == "B, C"
+
+
+def test_concat_ws_on_string_column_is_noop(spark) -> None:
+    """concat_ws(sep, string_col) returns the string unchanged (PySpark parity)."""
+    df = spark.createDataFrame([{"remarks": "hello"}], schema="remarks string")
+    result = df.withColumn("out", F.concat_ws(", ", F.col("remarks")))
+    rows = result.collect()
+    assert rows[0]["out"] == "hello"


### PR DESCRIPTION
## Summary

Fixes [#1543](https://github.com/eddiethedean/robin-sparkless/issues/1543): `concat_ws(sep, col)` failed with `cannot cast List type (inner: 'String', to: 'String')` when `col` was a list/array column.

- List columns: stringify elements and join with `sep` (PySpark `concat_ws` on array semantics).
- String columns: cast to Utf8 unchanged (single-arg `concat_ws` is a no-op on strings).

## Test plan

- [x] `tests/dataframe/test_issue_1543_concat_ws_list_column.py`
- [x] `tests/dataframe/test_issue_1395_string_concat_ws.py` (regression)