### PR TITLE
Fix DDL decimal(p,s) parsing in createDataFrame (#1544)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **#1544 – DDL schema `decimal(p,s)` parsing** — `createDataFrame(..., schema="A decimal(38,0), B string")` preserves decimal types instead of treating them as string and failing schema inference.
+
 - **#1543 – concat_ws on list and string columns** — `concat_ws(sep, col)` no longer casts list columns directly to string; list elements are joined with `sep`, and string columns pass through unchanged.
 
 - **#1542 – createDataFrame with tuple or iterable of dict rows** — `createDataFrame(({"a": 1}, {"a": 2}))` and generator inputs now work like PySpark; previously raised `[CANNOT_ACCEPT_OBJECT_IN_TYPE]` for tuples.

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1970,9 +1970,7 @@ fn python_data_and_schema(
                 keys_py.append(k.as_str())?;
             }
             // Tuple/list rows cannot be dict()-normalized; batch dict helpers only apply to dict rows (#1544).
-            let all_dict_rows = list
-                .iter()
-                .all(|item| item.downcast::<PyDict>().is_ok());
+            let all_dict_rows = list.iter().all(|item| item.downcast::<PyDict>().is_ok());
             // Normalize to list of plain dicts so d.get(k) finds keys regardless of key type (#357, #1267).
             let data_for_batch: Bound<'_, PyList> = if all_dict_rows {
                 (|| {

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1479,21 +1479,27 @@ impl PyStorage {
 /// Map PySpark type name to our schema type string.
 /// Pass through array<...>, map<...>, struct<...> so createDataFrame preserves List/Map/Struct columns.
 fn simple_string_to_type(s: &str) -> String {
-    let lower = s.to_lowercase();
+    let trimmed = s.trim();
+    let lower = trimmed.to_lowercase();
+    // Pass through decimal(p,s) so explicit DDL schema is not re-inferred as all-string (#1544).
+    if lower.starts_with("decimal(") && lower.contains(')') {
+        return trimmed.to_string();
+    }
     match lower.as_str() {
         "string" | "str" => "string".to_string(),
         "int" | "integer" | "int32" => "int".to_string(),
         "bigint" | "long" | "int64" => "long".to_string(),
         "double" | "float64" => "double".to_string(),
         "float" | "float32" => "float".to_string(),
+        "decimal" => "decimal".to_string(),
         "boolean" | "bool" => "boolean".to_string(),
         "date" => "date".to_string(),
         "timestamp" => "timestamp".to_string(),
         "binary" => "binary".to_string(),
         "list" | "array" => lower,
-        _ if lower.starts_with("array<") && lower.ends_with('>') => s.to_string(),
-        _ if lower.starts_with("map<") && lower.ends_with('>') => s.to_string(),
-        _ if lower.starts_with("struct<") && lower.ends_with('>') => s.to_string(),
+        _ if lower.starts_with("array<") && lower.ends_with('>') => trimmed.to_string(),
+        _ if lower.starts_with("map<") && lower.ends_with('>') => trimmed.to_string(),
+        _ if lower.starts_with("struct<") && lower.ends_with('>') => trimmed.to_string(),
         _ => "string".to_string(),
     }
 }
@@ -1503,14 +1509,14 @@ fn parse_ddl_schema_string(ddl: &str) -> Vec<(String, String)> {
     fn split_top_level_commas(s: &str) -> Vec<String> {
         let mut parts: Vec<String> = Vec::new();
         let mut buf = String::new();
-        let mut depth: i32 = 0; // struct<...>, array<...>, map<...>
+        let mut depth: i32 = 0; // struct<...>, decimal(p,s), array<...>
         for ch in s.chars() {
             match ch {
-                '<' => {
+                '(' | '<' => {
                     depth += 1;
                     buf.push(ch);
                 }
-                '>' => {
+                ')' | '>' => {
                     depth = (depth - 1).max(0);
                     buf.push(ch);
                 }
@@ -1535,8 +1541,8 @@ fn parse_ddl_schema_string(ddl: &str) -> Vec<(String, String)> {
         let mut depth: i32 = 0;
         for (i, ch) in s.char_indices() {
             match ch {
-                '<' => depth += 1,
-                '>' => depth = (depth - 1).max(0),
+                '(' | '<' => depth += 1,
+                ')' | '>' => depth = (depth - 1).max(0),
                 _ => {}
             }
             if depth == 0 && ch == target {
@@ -1550,8 +1556,8 @@ fn parse_ddl_schema_string(ddl: &str) -> Vec<(String, String)> {
         let mut depth: i32 = 0;
         for (i, ch) in s.char_indices().rev() {
             match ch {
-                '>' => depth += 1,
-                '<' => depth = (depth - 1).max(0),
+                ')' | '>' => depth += 1,
+                '(' | '<' => depth = (depth - 1).max(0),
                 _ => {}
             }
             if depth == 0 && ch == ' ' {
@@ -1963,18 +1969,27 @@ fn python_data_and_schema(
             for k in keys {
                 keys_py.append(k.as_str())?;
             }
+            // Tuple/list rows cannot be dict()-normalized; batch dict helpers only apply to dict rows (#1544).
+            let all_dict_rows = list
+                .iter()
+                .all(|item| item.downcast::<PyDict>().is_ok());
             // Normalize to list of plain dicts so d.get(k) finds keys regardless of key type (#357, #1267).
-            let data_for_batch: Bound<'_, PyList> = (|| {
-                let out = PyList::empty_bound(py);
-                let builtins = py.import_bound("builtins").ok()?;
-                let dict_fn = builtins.getattr("dict").ok()?;
-                for item in list.iter() {
-                    let normalized = dict_fn.call1((item,)).ok()?;
-                    out.append(normalized).ok()?;
-                }
-                Some(out)
-            })()
-            .unwrap_or_else(|| list.clone());
+            let data_for_batch: Bound<'_, PyList> = if all_dict_rows {
+                (|| {
+                    let out = PyList::empty_bound(py);
+                    let builtins = py.import_bound("builtins").ok()?;
+                    let dict_fn = builtins.getattr("dict").ok()?;
+                    for item in list.iter() {
+                        let normalized = dict_fn.call1((item,)).ok()?;
+                        out.append(normalized).ok()?;
+                    }
+                    Some(out)
+                })()
+                .unwrap_or_else(|| list.clone())
+            } else {
+                list.clone()
+            };
+            let batch_dict_rows = all_dict_rows;
             // Prefer dict_rows_to_column_order from Python (load _cdf_helpers then get from sys.modules); then eval.
             let try_helper = || -> PyResult<Option<Bound<'_, PyList>>> {
                 let _ = py.import_bound("sparkless._cdf_helpers").ok(); // ensure loaded
@@ -2010,30 +2025,32 @@ fn python_data_and_schema(
                     .ok()?;
                 result.downcast_into::<PyList>().ok()
             });
-            if let Some(rows_py) = rows_py {
-                if rows_py.len() == list.len() {
-                    let mut parsed = Vec::with_capacity(rows_py.len());
-                    for row_py in rows_py.iter() {
-                        if let Ok(row_list) = row_py.downcast::<PyList>() {
-                            let mut row = Vec::with_capacity(row_list.len());
-                            for v in row_list.iter() {
-                                row.push(py_any_to_json(py, &v)?);
+            if batch_dict_rows {
+                if let Some(rows_py) = rows_py {
+                    if rows_py.len() == list.len() {
+                        let mut parsed = Vec::with_capacity(rows_py.len());
+                        for row_py in rows_py.iter() {
+                            if let Ok(row_list) = row_py.downcast::<PyList>() {
+                                let mut row = Vec::with_capacity(row_list.len());
+                                for v in row_list.iter() {
+                                    row.push(py_any_to_json(py, &v)?);
+                                }
+                                parsed.push(row);
+                            } else {
+                                break;
                             }
-                            parsed.push(row);
-                        } else {
-                            break;
                         }
-                    }
-                    // Only use batch result if first column is present (avoid wrong lookup from eval/helper).
-                    if parsed.len() == list.len()
-                        && parsed
-                            .first()
-                            .and_then(|r| r.first())
-                            .map(|v| !matches!(v, JsonValue::Null))
-                            .unwrap_or(false)
-                    {
-                        rows.extend(parsed);
-                        row_kind = Some("dict");
+                        // Only use batch result if first column is present (avoid wrong lookup from eval/helper).
+                        if parsed.len() == list.len()
+                            && parsed
+                                .first()
+                                .and_then(|r| r.first())
+                                .map(|v| !matches!(v, JsonValue::Null))
+                                .unwrap_or(false)
+                        {
+                            rows.extend(parsed);
+                            row_kind = Some("dict");
+                        }
                     }
                 }
             }
@@ -2317,6 +2334,31 @@ fn python_row_to_json(
 ) -> PyResult<Vec<JsonValue>> {
     // When column_order is given: use Python items() so key/value come from Python (#1267).
     if let Some(order) = column_order {
+        // Tuple/list rows map by position to schema columns (PySpark parity; #1544).
+        if let Ok(tup) = item.downcast::<pyo3::types::PyTuple>() {
+            let mut values = Vec::with_capacity(order.len());
+            for (i, _) in order.iter().enumerate() {
+                let v = tup
+                    .get_item(i)
+                    .ok()
+                    .and_then(|pv| py_any_to_json(py, &pv).ok())
+                    .unwrap_or(JsonValue::Null);
+                values.push(v);
+            }
+            return Ok(values);
+        }
+        if let Ok(seq) = item.downcast::<PyList>() {
+            let mut values = Vec::with_capacity(order.len());
+            for (i, _) in order.iter().enumerate() {
+                let v = seq
+                    .get_item(i)
+                    .ok()
+                    .and_then(|pv| py_any_to_json(py, &pv).ok())
+                    .unwrap_or(JsonValue::Null);
+                values.push(v);
+            }
+            return Ok(values);
+        }
         if let Ok(items_view) = item.call_method0("items") {
             if let Ok(list_fn) = py.import_bound("builtins").and_then(|b| b.getattr("list")) {
                 let list_result = list_fn.call1((items_view,));
@@ -2482,6 +2524,17 @@ fn py_any_to_json(_py: Python<'_>, v: &Bound<'_, PyAny>) -> PyResult<JsonValue> 
     if let Ok(f) = v.extract::<f64>() {
         if let Some(n) = serde_json::Number::from_f64(f) {
             return Ok(JsonValue::Number(n));
+        }
+    }
+    // decimal.Decimal -> number for createDataFrame tuple/list rows (#1544).
+    if let Ok(dec_mod) = _py.import_bound("decimal") {
+        if let Ok(dec_type) = dec_mod.getattr("Decimal") {
+            if v.is_instance(&dec_type)? {
+                let f: f64 = v.call_method0("__float__")?.extract()?;
+                if let Some(n) = serde_json::Number::from_f64(f) {
+                    return Ok(JsonValue::Number(n));
+                }
+            }
         }
     }
     if let Ok(bytes) = v.downcast::<PyBytes>() {

--- a/tests/dataframe/test_issue_1544_decimal_ddl_schema.py
+++ b/tests/dataframe/test_issue_1544_decimal_ddl_schema.py
@@ -1,0 +1,29 @@
+"""Tests for issue #1544: DDL schema decimal(p,s) token parsing."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+
+def test_create_dataframe_decimal_ddl_with_tuple_rows(spark) -> None:
+    """schema='A decimal(38,0), B string' with tuple rows (issue #1544 repro)."""
+    df = spark.createDataFrame(
+        [(Decimal(1), "ok")],
+        schema="A decimal(38,0), B string",
+    )
+    rows = df.collect()
+    assert len(rows) == 1
+    assert rows[0]["B"] == "ok"
+    val = rows[0]["A"]
+    assert isinstance(val, (Decimal, float, int))
+    assert float(val) == 1.0
+
+
+def test_create_dataframe_decimal_ddl_colon_syntax(spark) -> None:
+    """Colon DDL syntax: 'A: decimal(10,2), B: string'."""
+    df = spark.createDataFrame(
+        [{"A": Decimal("3.14"), "B": "x"}],
+        schema="A: decimal(10,2), B: string",
+    )
+    rows = df.collect()
+    assert float(rows[0]["A"]) == 3.14


### PR DESCRIPTION
## Summary

Fixes [#1544](https://github.com/eddiethedean/robin-sparkless/issues/1544): `createDataFrame` with a DDL schema using `decimal(p,s)` (e.g. `schema="A decimal(38,0), B string"`) now works with tuple rows and `decimal.Decimal` values.

- **DDL comma splitting** — Treat commas inside `()` (and `<>`) as part of the type token so `decimal(38,0)` is not split into bogus columns.
- **Type mapping** — Pass through `decimal(p,s)` in `simple_string_to_type` instead of coercing to `string`.
- **Tuple/list rows** — When an explicit column order is set, skip dict-only batch normalization for non-dict rows; map tuple/list values by position; convert `decimal.Decimal` to JSON numbers.

## Test plan

- [x] `pytest tests/dataframe/test_issue_1544_decimal_ddl_schema.py`
- [x] `pytest tests/dataframe/test_issue_371_decimal_type.py`
- [x] Issue repro: `createDataFrame([(Decimal(1), "ok")], schema="A decimal(38,0), B string").show()` returns one row with `A=1`, `B=ok`

Closes #1544