### PR TITLE
Add StructType __iter__ and __len__ (#1548)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **#1548 – StructType iteration** — `StructType` implements `__iter__` and `__len__` delegating to `.fields`, so `list(df.schema)` and `for f in df.schema` work like PySpark.
+
 - **#1545 – String literal coercion under logical OR in filter** — `(col("A") == "123") | (col("A") == "123")` on an integer column no longer raises `cannot compare string with numeric type (i32)`; Column `|` uses logical `or_()` (like `&` uses `and_()`) so comparison coercion applies to each operand. Tuple/list rows with an explicit schema again raise `LENGTH_SHOULD_BE_THE_SAME` when row length does not match field count (#270).
 
 - **#1544 – DDL schema `decimal(p,s)` parsing** — `createDataFrame(..., schema="A decimal(38,0), B string")` preserves decimal types instead of treating them as string and failing schema inference.

--- a/python/sparkless/sparkless/sql/types.py
+++ b/python/sparkless/sparkless/sql/types.py
@@ -224,6 +224,13 @@ class StructType(DataType):
     def __init__(self, fields: Optional[List[StructField]] = None) -> None:
         self.fields = list(fields or [])
 
+    def __iter__(self) -> Iterator[StructField]:
+        """PySpark parity (#1548): iterate StructField entries like the internal fields list."""
+        return iter(self.fields)
+
+    def __len__(self) -> int:
+        return len(self.fields)
+
     def fieldNames(self) -> List[str]:
         """PySpark parity: returns all field names in a list."""
         return [f.name for f in self.fields]

--- a/tests/dataframe/test_issue_1548_struct_type_iter.py
+++ b/tests/dataframe/test_issue_1548_struct_type_iter.py
@@ -1,0 +1,29 @@
+"""Tests for issue #1548: StructType __iter__ and __len__ (PySpark parity)."""
+
+from __future__ import annotations
+
+
+def test_dataframe_schema_is_iterable(spark) -> None:
+    """list(df.schema) and for f in df.schema work like PySpark."""
+    df = spark.createDataFrame([("Alice", 1)], ["name", "age"])
+    schema = df.schema
+    fields = list(schema)
+    assert len(fields) == 2
+    assert len(schema) == 2
+    assert [f.name for f in fields] == ["name", "age"]
+    assert [f.name for f in schema] == ["name", "age"]
+
+
+def test_struct_type_iter_and_len_direct() -> None:
+    """StructType constructed directly supports iteration and len."""
+    from sparkless.testing import get_imports
+
+    T = get_imports()
+    schema = T.StructType(
+        [
+            T.StructField("name", T.StringType(), True),
+            T.StructField("age", T.IntegerType(), True),
+        ]
+    )
+    assert len(schema) == 2
+    assert [f.name for f in schema] == ["name", "age"]


### PR DESCRIPTION
## Summary

Fixes [#1548](https://github.com/eddiethedean/robin-sparkless/issues/1548): `StructType` now implements `__iter__` and `__len__` by delegating to `.fields`, matching PySpark so `list(df.schema)` and `for f in df.schema` work.

## Test plan

- [x] `pytest tests/dataframe/test_issue_1548_struct_type_iter.py`
- [x] Issue repro: `fields = list(df.schema)` returns `StructField` list for `name` and `age`

Closes #1548