### PR TITLE
Fix join on list of boolean conditions (#1554)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 (none yet)
 
+## [4.7.1] - 2026-05-26
+
+### Fixed
+
+- **#1554 – Join on list of boolean conditions** — `join(on=[left.a == right.a, left.b >= right.b, ...])` ANDs the conditions and uses the expression join path instead of treating `"<expr>"` as column names (fixes `unresolved_column: column '<expr>' not found`).
+
+### Changed
+
+- **Release metadata** — Version 4.7.1 across the Rust crates and the Python `sparkless` package.
+
 ## [4.7.0] - 2026-05-21
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/robin-sparkless-core", "crates/robin-sparkless-polars", "crat
 
 [package]
 name = "robin-sparkless"
-version = "4.7.0"
+version = "4.7.1"
 edition = "2024"
 description = "PySpark-like DataFrame API in Rust on Polars; no JVM."
 readme = "README.md"
@@ -36,8 +36,8 @@ jdbc_db2 = ["robin-sparkless-polars/jdbc_db2"]
 sqlite = ["robin-sparkless-polars/sqlite"]
 
 [dependencies]
-robin-sparkless-core = { version = "4.7.0", path = "crates/robin-sparkless-core" }
-robin-sparkless-polars = { version = "4.7.0", path = "crates/robin-sparkless-polars" }
+robin-sparkless-core = { version = "4.7.1", path = "crates/robin-sparkless-core" }
+robin-sparkless-polars = { version = "4.7.1", path = "crates/robin-sparkless-polars" }
 serde_json = "1.0"
 
 # Use git sources when crates.io/cache is broken (e.g. "no targets specified" in manifest,

--- a/crates/robin-sparkless-core/Cargo.toml
+++ b/crates/robin-sparkless-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "robin-sparkless-core"
-version = "4.7.0"
+version = "4.7.1"
 edition = "2024"
 description = "Shared types, config, and error for robin-sparkless (no Polars)."
 license = "MIT"

--- a/crates/robin-sparkless-polars/Cargo.toml
+++ b/crates/robin-sparkless-polars/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "robin-sparkless-polars"
-version = "4.7.0"
+version = "4.7.1"
 edition = "2024"
 description = "Polars-backed DataFrame, Session, and expression layer for robin-sparkless."
 license = "MIT"
@@ -19,7 +19,7 @@ jdbc_db2 = ["dep:odbc-api"]
 sqlite = ["dep:rusqlite"]
 
 [dependencies]
-robin-sparkless-core = { version = "4.7.0", path = "../robin-sparkless-core" }
+robin-sparkless-core = { version = "4.7.1", path = "../robin-sparkless-core" }
 polars = { version = "0.53", features = ["lazy", "csv", "parquet", "json", "temporal", "strings", "concat_str", "regex", "round_series", "abs", "dtype-categorical", "dtype-date", "dtype-datetime", "dtype-duration", "dtype-time", "rank", "is_in", "list_eval", "list_drop_nulls", "list_any_all", "cum_agg", "string_pad", "string_reverse", "repeat_by", "log", "month_end", "describe", "cross_join", "semi_anti_join", "extract_jsonpath", "dtype-struct", "random", "product", "moment", "rolling_window"] }
 polars-plan = "0.53"
 serde = { version = "1.0", features = ["derive"] }

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sparkless-native"
-version = "4.7.0"
+version = "4.7.1"
 edition = "2021"
 description = "Native extension for sparkless Python package (robin-sparkless backend)."
 readme = "README.md"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sparkless"
-version = "4.7.0"
+version = "4.7.1"
 description = "PySpark-like DataFrame API in Python—no JVM. Uses robin-sparkless (Rust/Polars) as the execution engine."
 readme = "README.md"
 license = { text = "MIT" }

--- a/python/sparkless/sparkless/__init__.py
+++ b/python/sparkless/sparkless/__init__.py
@@ -20,7 +20,7 @@ from typing import Dict, List, Sequence, Tuple, Union, cast as _cast
 
 from sparkless._native import PyColumn as _ColumnType
 
-__version__ = "4.7.0"
+__version__ = "4.7.1"
 
 
 _mod = __import__(

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -2859,6 +2859,64 @@ fn py_join_on_to_vec(on: &Bound<'_, PyAny>) -> PyResult<Vec<String>> {
     ))
 }
 
+/// PySpark allows `join(other, [cond1, cond2, ...])` where each condition is a boolean Column.
+/// Combine them with AND. Returns `Some(expr)` when any element is a complex expression (name
+/// `"<expr>"`). Returns `None` for column-name lists (all strings) or simple same-name keys.
+fn try_combine_join_condition_list(on: &Bound<'_, PyAny>) -> PyResult<Option<robin_sparkless::Expr>> {
+    use robin_sparkless::Expr as RsExpr;
+
+    let items: Vec<Bound<'_, PyAny>> = if let Ok(list) = on.downcast::<PyList>() {
+        list.iter().collect()
+    } else if let Ok(tup) = on.downcast::<PyTuple>() {
+        tup.iter().collect()
+    } else {
+        return Ok(None);
+    };
+
+    if items.is_empty() {
+        return Ok(None);
+    }
+
+    let mut condition_exprs: Vec<RsExpr> = Vec::new();
+    let mut saw_string = false;
+
+    for item in items {
+        if item.extract::<String>().is_ok() {
+            saw_string = true;
+            continue;
+        }
+        if let Ok(c) = item.downcast::<PyColumn>() {
+            let col = c.borrow();
+            if col.inner.name() == "<expr>" {
+                condition_exprs.push(col.inner.clone().into_expr());
+            }
+        } else {
+            return Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+                "join(on=...) list elements must be str or Column",
+            ));
+        }
+    }
+
+    if saw_string {
+        if !condition_exprs.is_empty() {
+            return Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+                "join(on=...) cannot mix str column names and Column expressions",
+            ));
+        }
+        return Ok(None);
+    }
+
+    if condition_exprs.is_empty() {
+        return Ok(None);
+    }
+
+    let mut combined = condition_exprs.remove(0);
+    for e in condition_exprs {
+        combined = combined.and(e);
+    }
+    Ok(Some(combined))
+}
+
 #[pyclass]
 struct PyDataFrameReader {
     session: Py<PyAny>,
@@ -4892,8 +4950,13 @@ impl PyDataFrame {
                 }
             }
             // Complex expression (e.g. left.dept_id == right.dept_id): try key-based join first (#1049, #1148).
-            if let Ok(condition) = on_arg.downcast::<PyColumn>() {
-                let expr = condition.borrow().inner.clone().into_expr();
+            // PySpark also accepts a list of boolean conditions ANDed together (#1554).
+            let join_condition_expr = if let Ok(condition) = on_arg.downcast::<PyColumn>() {
+                Some(condition.borrow().inner.clone().into_expr())
+            } else {
+                try_combine_join_condition_list(on_arg)?
+            };
+            if let Some(expr) = join_condition_expr {
                 let pairs = try_extract_join_eq_columns_all(&expr);
                 if !pairs.is_empty() {
                     let left_cols: std::collections::HashSet<String> = self
@@ -5055,6 +5118,7 @@ impl PyDataFrame {
                 }
                 return Ok(PyDataFrame::wrap(filtered));
             }
+            // Column-name list/tuple (no complex expressions): join on those keys.
             let on_vec = py_join_on_to_vec(on_arg)?;
             let on_refs: Vec<&str> = on_vec.iter().map(|s| s.as_str()).collect();
             self.inner

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -2862,7 +2862,9 @@ fn py_join_on_to_vec(on: &Bound<'_, PyAny>) -> PyResult<Vec<String>> {
 /// PySpark allows `join(other, [cond1, cond2, ...])` where each condition is a boolean Column.
 /// Combine them with AND. Returns `Some(expr)` when any element is a complex expression (name
 /// `"<expr>"`). Returns `None` for column-name lists (all strings) or simple same-name keys.
-fn try_combine_join_condition_list(on: &Bound<'_, PyAny>) -> PyResult<Option<robin_sparkless::Expr>> {
+fn try_combine_join_condition_list(
+    on: &Bound<'_, PyAny>,
+) -> PyResult<Option<robin_sparkless::Expr>> {
     use robin_sparkless::Expr as RsExpr;
 
     let items: Vec<Bound<'_, PyAny>> = if let Ok(list) = on.downcast::<PyList>() {

--- a/tests/dataframe/test_issue_1554_join_list_range_conditions.py
+++ b/tests/dataframe/test_issue_1554_join_list_range_conditions.py
@@ -1,0 +1,51 @@
+"""#1554: join(on=[eq, range, ...]) must AND conditions, not treat '<expr>' as column names."""
+
+from __future__ import annotations
+
+from datetime import date
+
+from sparkless.testing import get_imports
+
+_imports = get_imports()
+
+
+def test_issue_1554_join_list_with_range_predicates(spark) -> None:
+    """List join conditions with >= / < must not resolve '<expr>' as a column name."""
+    left = spark.createDataFrame(
+        [("A", date(2024, 3, 1)), ("B", date(2024, 6, 1))],
+        ["CA", "CB"],
+    )
+    right = spark.createDataFrame(
+        [("A", 99, date(2024, 1, 1), date(2024, 12, 31))],
+        ["CA", "CC", "CD", "CE"],
+    )
+    join_cond = [
+        right.CA == left.CA,
+        left.CB >= right.CD,
+        left.CB < right.CE,
+    ]
+    # Previously raised: unresolved_column: column '<expr>' not found (#1554).
+    result = left.join(right, join_cond, "left").select(left.CA, left.CB, right.CC)
+    rows = result.collect()
+    assert len(rows) >= 1
+    matched = [r for r in rows if r["CA"] == "A"]
+    assert len(matched) == 1
+    assert matched[0]["CC"] == 99
+
+
+def test_issue_1554_join_list_multiple_equalities(spark) -> None:
+    """List of equality conditions is equivalent to ANDing them (#353-style)."""
+    left = spark.createDataFrame([{"a": 1, "b": 2, "v": 10}], ["a", "b", "v"])
+    right = spark.createDataFrame([{"a": 1, "b": 2, "w": 20}], ["a", "b", "w"])
+    from tests.utils import _row_to_dict, assert_rows_equal
+
+    result = left.join(
+        right,
+        [left["a"] == right["a"], left["b"] == right["b"]],
+        "inner",
+    ).collect()
+    assert_rows_equal(
+        [_row_to_dict(r) for r in result],
+        [{"a": 1, "b": 2, "v": 10, "w": 20}],
+        order_matters=True,
+    )


### PR DESCRIPTION
## Summary

Fixes [#1554](https://github.com/eddiethedean/robin-sparkless/issues/1554).

When `join(on=...)` is passed a **list of boolean Column conditions** (e.g. equality plus range predicates like `>=` / `<`), sparkless previously extracted each condition’s display name (`"<expr>"`) and attempted a key-based join on those names, causing:

```
SparklessError: unresolved_column: cannot be resolved: column '<expr>' not found
```

This change detects list/tuple join conditions that contain complex expressions, **ANDs them together**, and routes through the existing single-expression join path (key-based join + filter when applicable).

## Test plan

- [x] `pytest tests/dataframe/test_issue_1554_join_list_range_conditions.py -v`
- [x] `pytest tests/dataframe/test_issue_353_join_on_accept_column.py -v`
- [x] Manual repro from issue: `left.join(right, join_cond, "left").select(...)` completes without error