### PR TITLE
Fix DataFrame.drop() to accept Column arguments (#1557)

### DIFF
--- a/crates/robin-sparkless-polars/src/dataframe/mod.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/mod.rs
@@ -14,8 +14,8 @@ pub use joins::{
 pub use stats::DataFrameStat;
 pub(crate) use transformations::literal_value_to_serde_value;
 pub use transformations::{
-    DataFrameNa, SelectItem, filter, order_by, order_by_exprs, select, select_items,
-    select_with_exprs, with_column,
+    DataFrameNa, DropColumnSpec, SelectItem, filter, order_by, order_by_exprs, select,
+    select_items, select_with_exprs, with_column,
 };
 
 use crate::column::Column;
@@ -1810,6 +1810,14 @@ impl DataFrame {
     /// Drop one or more columns.
     pub fn drop(&self, columns: Vec<&str>) -> Result<DataFrame, PolarsError> {
         transformations::drop(self, columns, self.case_sensitive)
+    }
+
+    /// Drop columns from string names and/or Column references (PySpark `drop(col)` parity).
+    pub fn drop_specs(
+        &self,
+        specs: Vec<transformations::DropColumnSpec>,
+    ) -> Result<DataFrame, PolarsError> {
+        transformations::drop_specs(self, specs, self.case_sensitive)
     }
 
     /// Drop rows with nulls. PySpark na.drop(subset, how, thresh).

--- a/crates/robin-sparkless-polars/src/dataframe/transformations.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/transformations.rs
@@ -1299,26 +1299,90 @@ pub fn distinct(
     Ok(super::DataFrame::from_lazy_with_options(lf, case_sensitive))
 }
 
-/// Drop one or more columns.
+/// One column to drop: a string name or a Column reference (PySpark `drop(col)`).
+#[derive(Debug, Clone)]
+pub struct DropColumnSpec {
+    pub name: String,
+    /// True when the caller passed a Column (e.g. `joined.drop(right.A)`), not a bare string.
+    pub from_column_ref: bool,
+}
+
+/// Resolve which physical column to drop for a drop target (PySpark parity #1557).
+fn resolve_drop_target(
+    df: &DataFrame,
+    spec: &DropColumnSpec,
+) -> Result<Option<String>, PolarsError> {
+    let name = spec.name.as_str();
+    if spec.from_column_ref {
+        let right_suffixed = format!("{name}_right");
+        if let Ok(resolved) = df.resolve_column_name(&right_suffixed) {
+            return Ok(Some(resolved));
+        }
+        // Coalesced join key: one physical column, ambiguous logical refs — drop(right.key) is a no-op.
+        if let Some(ref ambig) = df.ambiguous_columns {
+            let is_ambiguous_key = if df.case_sensitive {
+                ambig.contains(name)
+            } else {
+                let name_lower = name.to_lowercase();
+                ambig.iter().any(|a| a.to_lowercase() == name_lower)
+            };
+            if is_ambiguous_key {
+                let all_names = df.columns()?;
+                let matches: Vec<&String> = if df.case_sensitive {
+                    all_names.iter().filter(|n| n.as_str() == name).collect()
+                } else {
+                    let name_lower = name.to_lowercase();
+                    all_names
+                        .iter()
+                        .filter(|n| n.to_lowercase() == name_lower)
+                        .collect()
+                };
+                if matches.len() == 1 {
+                    return Ok(None);
+                }
+            }
+        }
+    }
+    match df.resolve_column_name(name) {
+        Ok(resolved) => Ok(Some(resolved)),
+        Err(PolarsError::ColumnNotFound(msg)) => {
+            if msg.contains("AMBIGUOUS_REFERENCE") {
+                return Err(PolarsError::ColumnNotFound(msg));
+            }
+            Ok(None)
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// Drop one or more columns (string names only).
 pub fn drop(
     df: &DataFrame,
     columns: Vec<&str>,
     case_sensitive: bool,
 ) -> Result<DataFrame, PolarsError> {
+    let specs: Vec<DropColumnSpec> = columns
+        .into_iter()
+        .map(|c| DropColumnSpec {
+            name: c.to_string(),
+            from_column_ref: false,
+        })
+        .collect();
+    drop_specs(df, specs, case_sensitive)
+}
+
+/// Drop columns from string names and/or Column references (#1557).
+pub fn drop_specs(
+    df: &DataFrame,
+    specs: Vec<DropColumnSpec>,
+    case_sensitive: bool,
+) -> Result<DataFrame, PolarsError> {
     // PySpark behavior: dropping a non-existent column is a no-op (idempotent).
     // Keep unresolved_column errors for truly ambiguous references.
-    let mut resolved: Vec<String> = Vec::with_capacity(columns.len());
-    for c in &columns {
-        match df.resolve_column_name(c) {
-            Ok(name) => resolved.push(name),
-            Err(PolarsError::ColumnNotFound(msg)) => {
-                // If the reference is ambiguous, keep failing (PySpark parity).
-                if msg.contains("AMBIGUOUS_REFERENCE") {
-                    return Err(PolarsError::ColumnNotFound(msg));
-                }
-                // Otherwise, ignore missing columns (idempotent drop).
-            }
-            Err(e) => return Err(e),
+    let mut resolved: Vec<String> = Vec::with_capacity(specs.len());
+    for spec in &specs {
+        if let Some(name) = resolve_drop_target(df, spec)? {
+            resolved.push(name);
         }
     }
     let all_names = df.columns()?;
@@ -2460,8 +2524,8 @@ pub fn intersect_all(
 #[cfg(test)]
 mod tests {
     use super::{
-        SelectItem, distinct, drop, dropna, filter, first, head, limit, offset, order_by,
-        select_items, union, union_by_name, with_column,
+        DropColumnSpec, SelectItem, distinct, drop, drop_specs, dropna, filter, first, head, limit,
+        offset, order_by, select_items, union, union_by_name, with_column,
     };
     use crate::column::Column;
     use crate::functions;
@@ -2915,6 +2979,31 @@ mod tests {
         let cols = out.columns().unwrap();
         assert!(!cols.contains(&"v".to_string()));
         assert_eq!(out.count().unwrap(), 3);
+    }
+
+    /// #1557: drop(Column) on coalesced join key is a no-op; drop("name") still drops.
+    #[test]
+    fn drop_column_ref_coalesced_join_key_is_noop() {
+        let df = test_df();
+        let mut ambig = std::collections::HashSet::new();
+        ambig.insert("n".to_string());
+        let df = super::super::DataFrame::from_lazy_with_options_and_ambiguous(
+            df.lazy_frame().clone(),
+            false,
+            Some(ambig),
+        );
+        let out = drop_specs(
+            &df,
+            vec![DropColumnSpec {
+                name: "n".to_string(),
+                from_column_ref: true,
+            }],
+            false,
+        )
+        .unwrap();
+        assert_eq!(out.columns().unwrap(), df.columns().unwrap());
+        let out2 = drop(&df, vec!["v"], false).unwrap();
+        assert!(!out2.columns().unwrap().contains(&"v".to_string()));
     }
 
     /// #681: union (same column order) with Int64 vs String in same position coerces to common type.

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -2653,6 +2653,62 @@ fn infer_type_from_py_value(v: &Bound<'_, PyAny>) -> String {
     "string".to_string()
 }
 
+/// PySpark drop(*cols): str or Column (or list/tuple of those).
+fn py_tuple_or_single_to_drop_specs(
+    tup: &Bound<'_, PyTuple>,
+) -> PyResult<Vec<robin_sparkless::DropColumnSpec>> {
+    use robin_sparkless::DropColumnSpec;
+
+    fn push_item(item: &Bound<'_, PyAny>, out: &mut Vec<DropColumnSpec>) -> PyResult<()> {
+        if let Ok(py_col) = item.downcast::<PyColumn>() {
+            out.push(DropColumnSpec {
+                name: py_col.borrow().inner.name().to_string(),
+                from_column_ref: true,
+            });
+            return Ok(());
+        }
+        if let Ok(s) = item.extract::<String>() {
+            out.push(DropColumnSpec {
+                name: s,
+                from_column_ref: false,
+            });
+            return Ok(());
+        }
+        Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+            "drop() expects column names as str or Column",
+        ))
+    }
+
+    if tup.len() == 0 {
+        return Ok(Vec::new());
+    }
+    if tup.len() == 1 {
+        let item = tup.get_item(0)?;
+        if let Ok(list) = item.downcast::<PyList>() {
+            let mut out = Vec::with_capacity(list.len());
+            for x in list.iter() {
+                push_item(&x, &mut out)?;
+            }
+            return Ok(out);
+        }
+        if let Ok(inner_tup) = item.downcast::<PyTuple>() {
+            let mut out = Vec::with_capacity(inner_tup.len());
+            for x in inner_tup.iter() {
+                push_item(&x, &mut out)?;
+            }
+            return Ok(out);
+        }
+        let mut out = Vec::new();
+        push_item(&item, &mut out)?;
+        return Ok(out);
+    }
+    let mut out = Vec::with_capacity(tup.len());
+    for item in tup.iter() {
+        push_item(&item, &mut out)?;
+    }
+    Ok(out)
+}
+
 /// PySpark drop(*cols): single str or list of str -> Vec<String>
 fn py_tuple_or_single_to_vec_string(tup: &Bound<'_, PyTuple>) -> PyResult<Vec<String>> {
     if tup.len() == 0 {
@@ -4865,10 +4921,9 @@ impl PyDataFrame {
 
     #[pyo3(signature = (*columns))]
     fn drop(&self, columns: &Bound<'_, PyTuple>) -> PyResult<PyDataFrame> {
-        let col_names = py_tuple_or_single_to_vec_string(columns)?;
-        let refs: Vec<&str> = col_names.iter().map(|s| s.as_str()).collect();
+        let specs = py_tuple_or_single_to_drop_specs(columns)?;
         self.inner
-            .drop(refs)
+            .drop_specs(specs)
             .map(PyDataFrame::wrap)
             .map_err(to_py_err)
     }

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -370,6 +370,13 @@ impl DataFrame {
         self.0.drop(columns).map(DataFrame)
     }
 
+    pub fn drop_specs(
+        &self,
+        specs: Vec<robin_sparkless_polars::dataframe::DropColumnSpec>,
+    ) -> Result<DataFrame, PolarsError> {
+        self.0.drop_specs(specs).map(DataFrame)
+    }
+
     pub fn dropna(
         &self,
         subset: Option<Vec<&str>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,7 @@ pub use dataframe::{
     expr_contains_only_join_key_equalities, try_extract_join_eq_columns,
     try_extract_join_eq_columns_all,
 };
+pub use robin_sparkless_polars::dataframe::DropColumnSpec;
 pub use session::{DataFrameReader, SparkSession, SparkSessionBuilder};
 
 // Root-owned traits (work with root DataFrame/SparkSession); plan re-export.

--- a/tests/dataframe/test_issue_1557_drop_column_arg.py
+++ b/tests/dataframe/test_issue_1557_drop_column_arg.py
@@ -34,6 +34,8 @@ def test_drop_string_still_drops_column() -> None:
 
 def test_drop_list_of_columns_mixed() -> None:
     spark = SparkSession.builder.appName("issue_1557_list").get_or_create()
-    df = spark.createDataFrame([("1", "Alice", "x", "y")], ["A", "name", "extra", "tail"])
+    df = spark.createDataFrame(
+        [("1", "Alice", "x", "y")], ["A", "name", "extra", "tail"]
+    )
     out = df.drop(["extra", F.col("tail")])
     assert out.columns == ["A", "name"]

--- a/tests/dataframe/test_issue_1557_drop_column_arg.py
+++ b/tests/dataframe/test_issue_1557_drop_column_arg.py
@@ -1,0 +1,39 @@
+"""Tests for issue #1557: DataFrame.drop() accepts Column arguments (PySpark parity)."""
+
+from __future__ import annotations
+
+from sparkless.testing import get_imports
+
+_imports = get_imports()
+SparkSession = _imports.SparkSession
+F = _imports.F
+
+
+def test_drop_column_after_join_on_expression() -> None:
+    """joined.drop(right.A) after join on (left.A == right.A) — coalesced key is a no-op."""
+    spark = SparkSession.builder.appName("issue_1557").get_or_create()
+    left = spark.createDataFrame([("1", "Alice")], ["A", "name"])
+    right = spark.createDataFrame([("1", "active")], ["A", "B"])
+    joined = left.join(right, on=(left.A == right.A), how="inner")
+
+    out = joined.drop(right.A)
+    rows = out.collect()
+    assert out.columns == ["A", "name", "B"]
+    assert len(rows) == 1
+    assert rows[0]["A"] == "1"
+    assert rows[0]["name"] == "Alice"
+    assert rows[0]["B"] == "active"
+
+
+def test_drop_string_still_drops_column() -> None:
+    spark = SparkSession.builder.appName("issue_1557_str").get_or_create()
+    df = spark.createDataFrame([("1", "Alice", "x")], ["A", "name", "extra"])
+    out = df.drop("extra")
+    assert out.columns == ["A", "name"]
+
+
+def test_drop_list_of_columns_mixed() -> None:
+    spark = SparkSession.builder.appName("issue_1557_list").get_or_create()
+    df = spark.createDataFrame([("1", "Alice", "x", "y")], ["A", "name", "extra", "tail"])
+    out = df.drop(["extra", F.col("tail")])
+    assert out.columns == ["A", "name"]


### PR DESCRIPTION
## Summary

Fixes [#1557](https://github.com/eddiethedean/robin-sparkless/issues/1557).

`DataFrame.drop()` only accepted string column names. PySpark also accepts `Column` references (e.g. `joined.drop(right.A)` after a join). That raised:

```
TypeError: 'PyColumn' object cannot be converted to 'PyString'
```

This PR:
- Accepts `str` or `Column` (and lists/tuples of either) in `drop()`
- For Column refs: drops `{name}_right` when present (suffixed join keys)
- For coalesced join keys (single physical column, ambiguous logical ref): `drop(right.A)` is a no-op, matching PySpark
- String `drop("col")` behavior unchanged

## Test plan

- [x] `pytest tests/dataframe/test_issue_1557_drop_column_arg.py`
- [x] `cargo test -p robin-sparkless-polars drop_column`