### PR TITLE
Fix DataFrame __getitem__ for list column selection (#1558)

### DIFF
--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -4267,11 +4267,46 @@ impl PyDataFrame {
     }
 
     #[pyo3(name = "__getitem__")]
-    fn get_item(&self, name: &str) -> PyResult<PyColumn> {
-        self.inner
-            .column(name)
-            .map(|c| PyColumn { inner: c })
-            .map_err(to_py_err)
+    fn get_item(&self, py: Python<'_>, key: &Bound<'_, PyAny>) -> PyResult<PyObject> {
+        // PySpark: df["col"] -> Column; df[["a","b"]] -> DataFrame selecting those columns.
+        // Sparkless parity: accept list/tuple of str for projection.
+        if let Ok(name) = key.extract::<String>() {
+            let col = self
+                .inner
+                .column(&name)
+                .map(|c| PyColumn { inner: c })
+                .map_err(to_py_err)?;
+            return Ok(col.into_py(py));
+        }
+        if let Ok(list) = key.downcast::<PyList>() {
+            let mut names: Vec<String> = Vec::with_capacity(list.len());
+            for item in list.iter() {
+                names.push(item.extract::<String>()?);
+            }
+            let refs: Vec<&str> = names.iter().map(|s| s.as_str()).collect();
+            let df = self
+                .inner
+                .select(refs)
+                .map(PyDataFrame::wrap)
+                .map_err(to_py_err)?;
+            return Ok(df.into_py(py));
+        }
+        if let Ok(tup) = key.downcast::<PyTuple>() {
+            let mut names: Vec<String> = Vec::with_capacity(tup.len());
+            for item in tup.iter() {
+                names.push(item.extract::<String>()?);
+            }
+            let refs: Vec<&str> = names.iter().map(|s| s.as_str()).collect();
+            let df = self
+                .inner
+                .select(refs)
+                .map(PyDataFrame::wrap)
+                .map_err(to_py_err)?;
+            return Ok(df.into_py(py));
+        }
+        Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+            "__getitem__ expects a column name (str) or list/tuple of column names",
+        ))
     }
 
     fn __getattr__(&self, name: &str) -> PyResult<PyColumn> {

--- a/tests/dataframe/test_issue_1558_getitem_list_columns.py
+++ b/tests/dataframe/test_issue_1558_getitem_list_columns.py
@@ -1,0 +1,28 @@
+"""Tests for issue #1558: DataFrame __getitem__ supports list/tuple of column names."""
+
+from __future__ import annotations
+
+from sparkless.testing import get_imports
+
+_imports = get_imports()
+SparkSession = _imports.SparkSession
+
+
+def test_getitem_list_of_column_names_returns_dataframe() -> None:
+    spark = SparkSession.builder.appName("issue_1558").get_or_create()
+    df = spark.createDataFrame([("Alice", 1, "A")], ["CA", "CB", "CC"])
+    out = df[["CA", "CB"]]
+    assert out.columns == ["CA", "CB"]
+    rows = out.collect()
+    assert rows[0]["CA"] == "Alice"
+    assert rows[0]["CB"] == 1
+
+
+def test_getitem_tuple_of_column_names_returns_dataframe() -> None:
+    spark = SparkSession.builder.appName("issue_1558_tup").get_or_create()
+    df = spark.createDataFrame([("Alice", 1, "A")], ["CA", "CB", "CC"])
+    out = df[("CB", "CC")]
+    assert out.columns == ["CB", "CC"]
+    rows = out.collect()
+    assert rows[0]["CB"] == 1
+    assert rows[0]["CC"] == "A"


### PR DESCRIPTION
## Summary

Fixes [#1558](https://github.com/eddiethedean/robin-sparkless/issues/1558).

`DataFrame.__getitem__` only accepted a single string and the binding signature forced a `PyString`, so `df[["CA", "CB"]]` raised:

```
TypeError: argument 'name': 'list' object cannot be converted to 'PyString'
```

This PR updates the binding so:
- `df["col"]` returns a `Column` (unchanged)
- `df[["a", "b"]]` and `df[("a", "b")]` return a `DataFrame` selecting those columns

## Test plan

- [x] `pytest tests/dataframe/test_issue_1558_getitem_list_columns.py`