### PR TITLE
fix: to_date format literal in spark.sql (#1562)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.10.0] - 2026-06-02
 
-(none yet)
+### Fixed
+
+- **#1562 – `to_date` format string in `spark.sql`** — Double-quoted format literals (e.g. `to_date(B, "yyyy/MM/dd HH:mm:ss")`) are parsed as string constants, not column names; `TO_DATE` is supported as a SQL built-in.
 
 ## [4.9.0] - 2026-05-29
 

--- a/crates/robin-sparkless-polars/src/sql/mod.rs
+++ b/crates/robin-sparkless-polars/src/sql/mod.rs
@@ -512,6 +512,31 @@ mod tests {
         );
     }
 
+    /// Issue #1562: double-quoted format literal in spark.sql to_date().
+    #[test]
+    fn test_sql_to_date_double_quoted_format() {
+        use serde_json::json;
+        let spark = SparkSession::builder().app_name("test").get_or_create();
+        let schema = vec![
+            ("A".to_string(), "string".to_string()),
+            ("B".to_string(), "string".to_string()),
+        ];
+        let rows = vec![vec![json!("1"), json!("2024/01/15 10:30:00")]];
+        let df = spark
+            .create_dataframe_from_rows(rows, schema, false, false)
+            .unwrap();
+        spark.create_or_replace_temp_view("temp_table", df);
+        let result = spark
+            .sql(r#"SELECT A, to_date(B, "yyyy/MM/dd HH:mm:ss") AS parsed_date FROM temp_table"#)
+            .unwrap();
+        let rows = result.collect_as_json_rows().unwrap();
+        assert_eq!(rows[0].get("A").and_then(|v| v.as_str()), Some("1"));
+        assert_eq!(
+            rows[0].get("parsed_date").and_then(|v| v.as_str()),
+            Some("2024-01-15")
+        );
+    }
+
     #[test]
     fn test_sql_from_global_temp_view() {
         let spark = SparkSession::builder().app_name("test").get_or_create();

--- a/crates/robin-sparkless-polars/src/sql/translator.rs
+++ b/crates/robin-sparkless-polars/src/sql/translator.rs
@@ -1322,6 +1322,11 @@ fn sql_function_to_expr(
         .and_then(|p| p.as_ident())
         .map(|i| i.value.as_str())
         .unwrap_or("");
+
+    if func_name.eq_ignore_ascii_case("TO_DATE") {
+        return sql_to_date_from_function(func, session, df);
+    }
+
     let args = sql_function_args_to_columns(func, session, df)?;
 
     let case_sensitive = session.is_case_sensitive();
@@ -1421,9 +1426,53 @@ fn sql_expr_to_string_literal(expr: &SqlExpr) -> Result<String, PolarsError> {
             ..
         }) => Ok(s.clone()),
         _ => Err(PolarsError::InvalidOperation(
-            format!("SQL: LIKE pattern must be a string literal, got {:?}", expr).into(),
+            format!("SQL: expected a string literal, got {:?}", expr).into(),
         )),
     }
+}
+
+fn sql_function_unnamed_expr<'a>(
+    args: &'a [FunctionArg],
+    index: usize,
+) -> Result<&'a SqlExpr, PolarsError> {
+    let arg = args.get(index).ok_or_else(|| {
+        PolarsError::InvalidOperation(
+            format!("SQL: function expected argument at index {index}").into(),
+        )
+    })?;
+    match arg {
+        FunctionArg::Unnamed(FunctionArgExpr::Expr(expr)) => Ok(expr),
+        _ => Err(PolarsError::InvalidOperation(
+            "SQL: only positional function arguments supported.".into(),
+        )),
+    }
+}
+
+/// PySpark `to_date(column[, format])` in SQL (issue #1562).
+fn sql_to_date_from_function(
+    func: &Function,
+    session: &SparkSession,
+    df: Option<&DataFrame>,
+) -> Result<Expr, PolarsError> {
+    let args = function_args_slice(&func.args);
+    if args.is_empty() || args.len() > 2 {
+        return Err(PolarsError::InvalidOperation(
+            "SQL: to_date(column[, format]) expects 1 or 2 arguments.".into(),
+        ));
+    }
+    let col_expr = sql_function_unnamed_expr(args, 0)?;
+    let e = sql_expr_to_polars(col_expr, session, df, None, None)?;
+    let col = Column::from_expr(e, None);
+    let format = if args.len() == 2 {
+        Some(sql_expr_to_string_literal(sql_function_unnamed_expr(
+            args, 1,
+        )?)?)
+    } else {
+        None
+    };
+    let result = functions::to_date(&col, format.as_deref())
+        .map_err(|s| PolarsError::InvalidOperation(s.into()))?;
+    Ok(result.expr().clone())
 }
 
 /// Projection item: either a plain Expr (built-in, Rust UDF, identifier) or Python UDF Column.
@@ -1652,9 +1701,15 @@ fn projection_function_to_item(
         .and_then(|p| p.as_ident())
         .map(|i| i.value.as_str())
         .unwrap_or("");
-    let args = sql_function_args_to_columns(func, session, df)?;
     let case_sensitive = session.is_case_sensitive();
     let alias = sql_function_alias(func);
+
+    if func_name.eq_ignore_ascii_case("TO_DATE") {
+        let e = sql_to_date_from_function(func, session, df)?;
+        return Ok(ProjItem::Expr(e.alias(&alias), alias));
+    }
+
+    let args = sql_function_args_to_columns(func, session, df)?;
 
     // Built-ins
     if let Some(col) = args.first() {

--- a/crates/spark-sql-parser/src/lib.rs
+++ b/crates/spark-sql-parser/src/lib.rs
@@ -8,7 +8,8 @@
 //!
 //! Any statement that [sqlparser] parses as a `Query` (e.g. `SELECT`, `WITH ... SELECT`)
 //! is accepted. Clause support is determined by [sqlparser] and the dialect in use
-//! (this crate uses [GenericDialect](sqlparser::dialect::GenericDialect)).
+//! (this crate uses [MySqlDialect](sqlparser::dialect::MySqlDialect) so double-quoted
+//! strings are string literals, matching PySpark/Spark SQL — see issue #1541, #1562).
 //!
 //! ## Known gaps
 //!
@@ -63,7 +64,9 @@ pub enum SparkStatement {
 }
 
 fn parse_one_statement_raw(query: &str) -> Result<Statement, ParseError> {
-    parse_one_statement_with_dialect(query, &GenericDialect {})
+    // PySpark/Spark SQL treat double-quoted tokens as string literals in SQL (issues #1541, #1562).
+    // GenericDialect treats `"` as delimited identifiers; MySQL dialect treats them as literals.
+    parse_one_statement_with_dialect(query, &MySqlDialect {})
 }
 
 fn parse_one_statement_with_dialect(
@@ -489,7 +492,10 @@ pub fn parse_sql(query: &str) -> Result<Statement, ParseError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sqlparser::ast::{ObjectType, Statement};
+    use sqlparser::ast::{
+        FunctionArg, FunctionArgExpr, FunctionArguments, ObjectType, Statement, Value,
+        ValueWithSpan,
+    };
 
     /// Assert that `sql` parses to the given statement variant.
     fn assert_parses_to<F>(sql: &str, check: F)
@@ -1226,6 +1232,45 @@ mod tests {
                 assert!(matches!(stmt.as_ref(), Statement::CreateTable(_)));
             }
             other => panic!("expected Sqlparser(CreateTable), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn spark_parse_spark_sql_to_date_double_quoted_format_literal() {
+        // Issue #1562: PySpark treats double-quoted format as string literal in spark.sql().
+        let sql = r#"SELECT to_date(B, "yyyy/MM/dd HH:mm:ss") AS parsed_date FROM t"#;
+        let s = parse_spark_sql(sql).unwrap();
+        let stmt = match s {
+            SparkStatement::Sqlparser(stmt) => stmt,
+            other => panic!("expected Sqlparser, got {other:?}"),
+        };
+        let query = match stmt.as_ref() {
+            Statement::Query(q) => q,
+            other => panic!("expected Query, got {other:?}"),
+        };
+        let select = match query.body.as_ref() {
+            SetExpr::Select(s) => s,
+            other => panic!("expected Select, got {other:?}"),
+        };
+        let item = select.projection.first().expect("one select item");
+        let func = match item {
+            SelectItem::ExprWithAlias {
+                expr: SqlExpr::Function(f),
+                ..
+            } => f,
+            other => panic!("expected aliased function, got {other:?}"),
+        };
+        let args = match &func.args {
+            FunctionArguments::List(list) => &list.args,
+            other => panic!("expected arg list, got {other:?}"),
+        };
+        assert_eq!(args.len(), 2);
+        match &args[1] {
+            FunctionArg::Unnamed(FunctionArgExpr::Expr(SqlExpr::Value(ValueWithSpan {
+                value: Value::DoubleQuotedString(fmt),
+                ..
+            }))) => assert_eq!(fmt, "yyyy/MM/dd HH:mm:ss"),
+            other => panic!("expected double-quoted format literal, got {other:?}"),
         }
     }
 }

--- a/tests/sql/test_issue_1562_to_date_format_literal.py
+++ b/tests/sql/test_issue_1562_to_date_format_literal.py
@@ -1,0 +1,26 @@
+"""Tests for issue #1562: to_date format string in spark.sql with double-quoted literal."""
+
+from __future__ import annotations
+
+
+def test_sql_to_date_double_quoted_format_literal(spark) -> None:
+    """PySpark parses the format argument as a string, not a column reference."""
+    df = spark.createDataFrame(
+        [("1", "2024/01/15 10:30:00")],
+        "A STRING, B STRING",
+    )
+    df.createOrReplaceTempView("temp_table")
+
+    result = spark.sql(
+        """
+        SELECT
+            A,
+            to_date(B, "yyyy/MM/dd HH:mm:ss") AS parsed_date
+        FROM temp_table
+        """
+    )
+    rows = result.collect()
+
+    assert len(rows) == 1
+    assert rows[0]["A"] == "1"
+    assert str(rows[0]["parsed_date"]) == "2024-01-15"


### PR DESCRIPTION
## Summary

Fixes [#1562](https://github.com/eddiethedean/robin-sparkless/issues/1562): `spark.sql()` treated the `to_date` format argument `"yyyy/MM/dd HH:mm:ss"` as a column name instead of a string literal.

- Parse full SQL statements with **MySQL dialect** (double-quoted strings are literals), matching PySpark/Spark SQL and the existing `#1541` fix for `filter()` / `expr()` strings.
- Add **`TO_DATE`** as a SQL built-in in the translator (column + optional format literal).

## Test plan

- [x] `cargo test -p spark-sql-parser spark_parse_spark_sql_to_date`
- [x] `cargo test -p robin-sparkless-polars test_sql_to_date_double_quoted --features sql`
- [x] `pytest tests/sql/test_issue_1562_to_date_format_literal.py`