### PR TITLE
fix: string vs int comparison in groupBy().agg() (#1564)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **#1564 – string vs numeric comparison in `groupBy().agg()`** — Apply PySpark-style string–numeric coercion to aggregation expressions (e.g. `F.col("C") == 1` inside `F.when`).
+
 - **#1563 – `explode(split(...))` in `select`** — Frame-level explode now applies when the list comes from an expression (e.g. `F.explode(F.split(F.col("name"), " "))`), so sibling columns replicate per exploded row.
 
 - **#1562 – `to_date` format string in `spark.sql`** — Double-quoted format literals (e.g. `to_date(B, "yyyy/MM/dd HH:mm:ss")`) are parsed as string constants, not column names; `TO_DATE` is supported as a SQL built-in.

--- a/crates/robin-sparkless-polars/src/dataframe/aggregations.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/aggregations.rs
@@ -805,9 +805,13 @@ impl GroupedData {
     /// Column names in expressions are resolved case-insensitively when spark.sql.caseSensitive is false.
     pub fn agg(&self, aggregations: Vec<Expr>) -> Result<DataFrame, PolarsError> {
         let schema = self.lf.clone().collect_schema()?;
+        let df = super::DataFrame::from_lazy_with_options(self.lf.clone(), self.case_sensitive);
         let resolved: Vec<Expr> = aggregations
             .into_iter()
-            .map(|e| self.resolve_expr_column_names_with_schema(e, &schema))
+            .map(|e| {
+                let resolved = self.resolve_expr_column_names_with_schema(e, &schema)?;
+                df.coerce_string_numeric_comparisons(resolved)
+            })
             .collect::<Result<Vec<_>, _>>()?;
         let disambiguated = disambiguate_agg_output_names(resolved);
         use polars::prelude::*;

--- a/crates/robin-sparkless-polars/src/dataframe/mod.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/mod.rs
@@ -1731,7 +1731,10 @@ impl DataFrame {
     pub fn agg(&self, aggregations: Vec<Expr>) -> Result<DataFrame, PolarsError> {
         let resolved: Vec<Expr> = aggregations
             .into_iter()
-            .map(|e| self.resolve_expr_column_names(e))
+            .map(|e| {
+                let resolved = self.resolve_expr_column_names(e)?;
+                self.coerce_string_numeric_comparisons(resolved)
+            })
             .collect::<Result<Vec<_>, _>>()?;
         let disambiguated = disambiguate_agg_output_names(resolved);
         let pl_df = self.lazy_frame().select(disambiguated).collect()?;

--- a/tests/dataframe/test_issue_1564_groupby_string_numeric.py
+++ b/tests/dataframe/test_issue_1564_groupby_string_numeric.py
@@ -1,0 +1,25 @@
+"""Tests for issue #1564: string column vs numeric literal in groupBy().agg()."""
+
+from __future__ import annotations
+
+from sparkless.testing import get_imports
+
+_imports = get_imports()
+F = _imports.F
+
+
+def test_groupby_agg_when_string_column_eq_int_literal(spark) -> None:
+    """PySpark casts string C to int for comparison with lit(1)."""
+    df = spark.createDataFrame(
+        [("A", "C", "1", 100.0)],
+        "A STRING, B STRING, C STRING, D DOUBLE",
+    )
+    condition = (F.col("B") == "C") & (F.col("C") == 1)
+    result = df.groupby("A").agg(
+        F.sum(F.when(condition, F.col("D")).otherwise(F.lit(0))).alias("Result")
+    )
+    rows = result.collect()
+
+    assert len(rows) == 1
+    assert rows[0]["A"] == "A"
+    assert rows[0]["Result"] == 100.0


### PR DESCRIPTION
## Summary

Fixes [#1564](https://github.com/eddiethedean/robin-sparkless/issues/1564): `groupBy().agg(F.sum(F.when((F.col("B") == "C") & (F.col("C") == 1), ...)))` failed with `cannot compare string with numeric type (i32)` because aggregation expressions did not go through the same string–numeric coercion used in `filter()` and `select()`.

- Run `coerce_string_numeric_comparisons` on each expr in `GroupedData::agg()` (and global `DataFrame::agg()` for consistency).

## Test plan

- [x] Repro from issue (Python)
- [x] `pytest tests/dataframe/test_issue_1564_groupby_string_numeric.py`
- [x] `cargo test -p robin-sparkless-polars --lib`