### PR TITLE
fix: 4.10 performance regression (#1568)

### DIFF
--- a/.github/workflows/pyspark4-oracle.yml
+++ b/.github/workflows/pyspark4-oracle.yml
@@ -53,6 +53,7 @@ jobs:
           rustup component remove rustfmt clippy --toolchain 1.93.1 2>/dev/null || true
           rustup component add rustfmt clippy --toolchain 1.93.1
           cd python && ../.venv/bin/maturin develop
+          cd ..
           .venv/bin/pip install -r tests/requirements-pyspark4.txt pytest pytest-xdist pytest-timeout
         working-directory: ${{ github.workspace }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Performance regression 4.9 → 4.10 (#1568)** — Keep `select` lazy on eager inputs (avoid materializing every transform step); apply frame-level `explode` for list expressions only when sibling columns need replication; map `INSERT … SELECT` columns lazily instead of round-tripping through JSON rows.
+
 - **Join dedup path** — Replace `.unwrap()` with `PolarsError` when deduplicating duplicate join column names (#1165 path).
 - **`F.sumDistinct`** — Implement `sum_distinct` in Rust/PyO3; wire Python `F.sumDistinct` (was `_ni()` stub).
 

--- a/crates/robin-sparkless-polars/src/dataframe/transformations.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/transformations.rs
@@ -47,6 +47,20 @@ fn expr_refs_column(expr: &Expr, column_name: &str) -> bool {
     expr_referenced_columns(expr).contains(column_name)
 }
 
+/// True when the select list references at least one input-frame column besides explode outputs.
+/// Frame-level explode is only required in that case (PySpark sibling replication, #1563).
+fn select_has_sibling_frame_columns(
+    exprs: &[Expr],
+    df_columns: &HashSet<String>,
+    ignore_output_names: &HashSet<String>,
+) -> bool {
+    exprs.iter().any(|e| {
+        expr_referenced_columns(e)
+            .iter()
+            .any(|c| df_columns.contains(c) && !ignore_output_names.contains(c))
+    })
+}
+
 /// If the expression contains an Explode node, return its input and options (for posexplode detection).
 fn find_explode_in_expr(expr: &Expr) -> Option<(Arc<Expr>, polars::prelude::ExplodeOptions)> {
     if let Expr::Explode { input, options } = expr {
@@ -259,6 +273,7 @@ pub fn select_with_exprs(
         Option<Expr>,
     );
     let mut explode_targets: Vec<ExplodeTarget> = Vec::new();
+    let exprs_before_explode_rewrite = exprs.clone();
     let exprs: Vec<Expr> = exprs
         .into_iter()
         .enumerate()
@@ -332,19 +347,29 @@ pub fn select_with_exprs(
                         } else {
                             // explode(list_expr) e.g. explode(split(col("name"), " ")) (#1563)
                             let out_col = name.clone();
-                            let already = explode_targets.iter().any(|(_, a, o, _)| {
-                                a.as_ref().map(|x| x.as_str()) == Some(out_col.as_str())
-                                    && *o == options
-                            });
-                            if !already {
-                                explode_targets.push((
-                                    out_col.clone(),
-                                    Some(out_col.clone()),
-                                    options,
-                                    Some(input.as_ref().clone()),
-                                ));
+                            let ignore = HashSet::from([out_col.to_string()]);
+                            let needs_frame = select_has_sibling_frame_columns(
+                                &exprs_before_explode_rewrite,
+                                &df_columns,
+                                &ignore,
+                            );
+                            if needs_frame {
+                                let already = explode_targets.iter().any(|(_, a, o, _)| {
+                                    a.as_ref().map(|x| x.as_str()) == Some(out_col.as_str())
+                                        && *o == options
+                                });
+                                if !already {
+                                    explode_targets.push((
+                                        out_col.clone(),
+                                        Some(out_col.clone()),
+                                        options,
+                                        Some(input.as_ref().clone()),
+                                    ));
+                                }
+                                Expr::Alias(Arc::new(Expr::Column(out_col)), name)
+                            } else {
+                                Expr::Alias(inner, name)
                             }
-                            Expr::Alias(Arc::new(Expr::Column(out_col)), name)
                         }
                     } else {
                         Expr::Alias(inner, name)
@@ -361,18 +386,28 @@ pub fn select_with_exprs(
                         Expr::Column(col_name.clone())
                     } else {
                         let temp = PlSmallStr::from(format!("__explode_{}", explode_targets.len()));
-                        let already = explode_targets.iter().any(|(c, a, o, _)| {
-                            c.as_str() == temp.as_str() && a.is_none() && *o == options
-                        });
-                        if !already {
-                            explode_targets.push((
-                                temp.clone(),
-                                Some(temp.clone()),
-                                options,
-                                Some(input.as_ref().clone()),
-                            ));
+                        let ignore = HashSet::from([temp.to_string()]);
+                        let needs_frame = select_has_sibling_frame_columns(
+                            &exprs_before_explode_rewrite,
+                            &df_columns,
+                            &ignore,
+                        );
+                        if needs_frame {
+                            let already = explode_targets.iter().any(|(c, a, o, _)| {
+                                c.as_str() == temp.as_str() && a.is_none() && *o == options
+                            });
+                            if !already {
+                                explode_targets.push((
+                                    temp.clone(),
+                                    Some(temp.clone()),
+                                    options,
+                                    Some(input.as_ref().clone()),
+                                ));
+                            }
+                            Expr::Column(temp)
+                        } else {
+                            Expr::Explode { input, options }
                         }
-                        Expr::Column(temp)
                     }
                 }
                 other => other,
@@ -466,27 +501,15 @@ pub fn select_with_exprs(
     } else {
         lf.select(&exprs)
     };
-    // When input is Eager (e.g. createDataFrame), return Eager result so collect() uses
-    // schema order that matches columns (#1267). List-of-dicts createDataFrame first column
-    // null is fixed in Python binding (python_row_to_json).
-    if df.is_eager() {
-        let pre = df.lazy_frame();
-        let pl_df = lf.collect()?;
-        Ok(super::DataFrame::from_eager_after_select(
-            pl_df,
-            case_sensitive,
-            pre,
-            exprs.clone(),
-        ))
-    } else {
-        let pre = df.lazy_frame();
-        Ok(super::DataFrame::from_lazy_after_select(
-            lf,
-            case_sensitive,
-            pre,
-            exprs.clone(),
-        ))
-    }
+    // Stay lazy after select so transform chains do not materialize on every step (#1568).
+    // collect() / show() materialize once; plan schema preserves column order (#1267).
+    let pre = df.lazy_frame();
+    Ok(super::DataFrame::from_lazy_after_select(
+        lf,
+        case_sensitive,
+        pre,
+        exprs.clone(),
+    ))
 }
 
 /// Select item: either a column name (str) or an expression (PySpark parity: select("a", col("b").alias("x"))).
@@ -2907,6 +2930,34 @@ mod tests {
         assert_eq!(rows.len(), 2);
         assert_eq!(rows[0].get("Size").and_then(|v| v.as_str()), Some("Small"));
         assert_eq!(rows[1].get("Size").and_then(|v| v.as_str()), Some("Large"));
+    }
+
+    /// Issue #1568: select on eager createDataFrame input must not materialize every step.
+    #[test]
+    fn select_on_eager_input_stays_lazy() {
+        use serde_json::json;
+        let spark = SparkSession::builder()
+            .app_name("select_eager_lazy")
+            .get_or_create();
+        let df = spark
+            .create_dataframe_from_rows(
+                vec![vec![json!(1), json!("a")]],
+                vec![
+                    ("id".to_string(), "long".to_string()),
+                    ("name".to_string(), "string".to_string()),
+                ],
+                false,
+                false,
+            )
+            .unwrap();
+        assert!(df.is_eager());
+        let out = select_items(
+            &df,
+            vec![SelectItem::ColumnName("id")],
+            false,
+        )
+        .unwrap();
+        assert!(!out.is_eager());
     }
 
     /// Issue #1563: select(id, explode(split(name, " ")).alias("word")) replicates id per exploded row.

--- a/crates/robin-sparkless-polars/src/sql/translator.rs
+++ b/crates/robin-sparkless-polars/src/sql/translator.rs
@@ -278,13 +278,15 @@ pub fn translate(
 
 /// Map INSERT ... SELECT output onto the target table schema (respect column list, NULL-fill omitted columns).
 fn align_insert_select_to_target(
-    session: &SparkSession,
-    select_df: DataFrame,
+    select_df: &DataFrame,
     target_schema: &StructType,
     target_cols: &[String],
     index_map: &[usize],
     insert_col_count: usize,
 ) -> Result<DataFrame, PolarsError> {
+    use crate::schema_conv::data_type_to_polars_type;
+    use polars::prelude::DataType as PlDataType;
+
     let select_schema = select_df.schema()?;
     let select_fields = select_schema.fields();
     if select_fields.len() != insert_col_count {
@@ -297,22 +299,24 @@ fn align_insert_select_to_target(
         ));
     }
     let select_col_names: Vec<String> = select_fields.iter().map(|f| f.name.clone()).collect();
-    let select_rows = select_df.collect_as_json_rows()?;
-    let mut rows: Vec<Vec<JsonValue>> = Vec::with_capacity(select_rows.len());
-    for select_row in select_rows {
-        let mut row: Vec<JsonValue> = vec![JsonValue::Null; target_cols.len()];
-        for (val_pos, &target_idx) in index_map.iter().enumerate() {
-            let col_name = &select_col_names[val_pos];
-            row[target_idx] = select_row.get(col_name).cloned().unwrap_or(JsonValue::Null);
+    let case_sensitive = select_df.case_sensitive;
+    let mut exprs: Vec<Expr> = Vec::with_capacity(target_cols.len());
+    for (target_idx, target_name) in target_cols.iter().enumerate() {
+        if let Some(val_pos) = index_map.iter().position(|&tidx| tidx == target_idx) {
+            let src = &select_col_names[val_pos];
+            let resolved = select_df.resolve_column_name(src)?;
+            exprs.push(col(resolved.as_str()).alias(target_name.as_str()));
+        } else {
+            let pl_ty = data_type_to_polars_type(&target_schema.fields()[target_idx].data_type);
+            let null_expr = match pl_ty {
+                PlDataType::String => lit(polars::prelude::NULL).cast(PlDataType::String),
+                other => lit(polars::prelude::NULL).cast(other),
+            };
+            exprs.push(null_expr.alias(target_name.as_str()));
         }
-        rows.push(row);
     }
-    let schema: Vec<(String, String)> = target_schema
-        .fields()
-        .iter()
-        .map(|f| (f.name.clone(), core_data_type_to_str(&f.data_type)))
-        .collect();
-    session.create_dataframe_from_rows(rows, schema, false, false)
+    let lf = select_df.lazy_frame().select(exprs);
+    Ok(DataFrame::from_lazy_with_options(lf, case_sensitive))
 }
 
 /// Translate INSERT INTO table [(col1, col2, ...)] {VALUES (...), (...)} or
@@ -402,8 +406,7 @@ fn translate_insert(
             _ => {
                 let select_df = translate_query(session, query.as_ref())?;
                 align_insert_select_to_target(
-                    session,
-                    select_df,
+                    &select_df,
                     &target_schema,
                     &target_cols,
                     &index_map,


### PR DESCRIPTION
## Summary

Fixes [#1568](https://github.com/eddiethedean/robin-sparkless/issues/1568) — reported slowdown and memory growth after upgrading from 4.9.0 to 4.10.0.

- **Lazy `select` on eager inputs** — `createDataFrame` pipelines no longer call `collect()` on every `select`; materialization happens on actions (`collect`, `show`, etc.) only. This was the main source of extra CPU and RAM on multi-step transforms.
- **Scoped frame-level `explode`** — Expression-based `explode` (e.g. `explode(split(...))`) still uses frame-level explode when sibling columns must replicate (#1563), but single-column explode selects stay in-plan to avoid extra `with_column` + `explode` + eager materialization.
- **Lazy `INSERT … SELECT` alignment** — Replaces JSON row round-trip with a lazy `select` projection when mapping INSERT columns onto the target schema.

## Root cause

4.10.0 added correct frame-level `explode` for `explode(split(...))` with sibling columns (#1563), but combined with the existing eager `select` path this forced a full materialization after every `select` on `createDataFrame` data. Long pipelines doubled work and held multiple full copies in memory (matching ~2.4GB → 24GB reports under heavy test suites).

## Test plan

- [x] `cargo test -p robin-sparkless-polars select_on_eager_input_stays_lazy`
- [x] `cargo test -p robin-sparkless-polars select_explode_split_expression`
- [x] `cargo test -p robin-sparkless-polars --features sql test_sql_union`
- [x] `pytest tests/dataframe/test_issue_1563_explode_split_select.py`
- [x] `pytest tests/dataframe/test_issue_1564_groupby_string_numeric.py`