### PR TITLE
fix: withColumn(explode(split(...))) (#1570)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`withColumn(explode(split(...)))` (#1570)** — Frame-level explode for list expressions (e.g. `withColumn('name', explode(split(name, ' ')))`); no longer explodes the raw string column when the argument is `split(...)`.
+
 - **SQL `date_add(unit, quantity, start)` (#1569)** — Recognize unit keywords (`MONTH`, `DAY`, …) in three-argument `date_add`; support `current_date()` / `current_timestamp()` as zero-arg SQL functions in SELECT.
 
 - **Performance regression 4.9 → 4.10 (#1568)** — Keep `select` lazy on eager inputs (avoid materializing every transform step); apply frame-level `explode` for list expressions only when sibling columns need replication; map `INSERT … SELECT` columns lazily instead of round-tripping through JSON rows.

--- a/crates/robin-sparkless-polars/src/dataframe/transformations.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/transformations.rs
@@ -47,6 +47,33 @@ fn expr_refs_column(expr: &Expr, column_name: &str) -> bool {
     expr_referenced_columns(expr).contains(column_name)
 }
 
+/// Unwrap `Alias` and return the inner `Explode` input and options, if present.
+fn explode_expr_parts(expr: &Expr) -> Option<(Arc<Expr>, polars::prelude::ExplodeOptions)> {
+    let inner = match expr {
+        Expr::Alias(e, _) => e.as_ref(),
+        e => e,
+    };
+    match inner {
+        Expr::Explode { input, options } => Some((input.clone(), *options)),
+        _ => None,
+    }
+}
+
+/// Materialize a list-producing expression into `column_name`, then frame-level explode (#1563, #1570).
+fn lazy_frame_explode_list_expr(
+    lf: polars::prelude::LazyFrame,
+    column_name: &str,
+    list_expr: Expr,
+    options: polars::prelude::ExplodeOptions,
+) -> polars::prelude::LazyFrame {
+    let lf = lf.with_column(list_expr.alias(column_name));
+    let selector = Selector::ByName {
+        names: Arc::from([PlSmallStr::from(column_name)]),
+        strict: true,
+    };
+    lf.explode(selector, options)
+}
+
 /// True when the select list references at least one input-frame column besides explode outputs.
 /// Frame-level explode is only required in that case (PySpark sibling replication, #1563).
 fn select_has_sibling_frame_columns(
@@ -922,25 +949,23 @@ pub fn with_column(
         let all = df.columns()?;
         let existing_str = existing.as_str();
         if expr_refs_column(&expr, existing_str) {
-            let inner = match &expr {
-                Expr::Alias(e, _) => e.as_ref(),
-                e => e,
-            };
-            // Use LazyFrame.explode() when replacing a column with explode(that column) so other columns replicate.
-            let refs = expr_referenced_columns(inner);
-            let use_frame_explode = refs.len() == 1
-                && refs.contains(existing_str)
-                && matches!(inner, Expr::Explode { .. });
-            if use_frame_explode {
-                let options = match inner {
-                    Expr::Explode { options, .. } => *options,
-                    _ => unreachable!(),
-                };
-                let selector = Selector::ByName {
-                    names: Arc::from([PlSmallStr::from(existing_str)]),
-                    strict: true,
-                };
-                lf.explode(selector, options)
+            if let Some((input, options)) = explode_expr_parts(&expr) {
+                // explode(existing list column) in place — not explode(split(existing)) (#1570).
+                let explode_existing_list_col = matches!(input.as_ref(), Expr::Column(c) if c.as_str() == existing_str);
+                if explode_existing_list_col {
+                    let selector = Selector::ByName {
+                        names: Arc::from([PlSmallStr::from(existing_str)]),
+                        strict: true,
+                    };
+                    lf.explode(selector, options)
+                } else {
+                    lazy_frame_explode_list_expr(
+                        lf,
+                        column_name,
+                        input.as_ref().clone(),
+                        options,
+                    )
+                }
             } else {
                 // Replace in one shot: select all columns but use expr for the replaced name.
                 let select_exprs: Vec<Expr> = all
@@ -964,38 +989,44 @@ pub fn with_column(
             lf.select(&to_keep).with_column(expr.alias(column_name))
         }
     } else {
-        // Adding a new column. If expr is explode(some_column), use frame-level explode so row count matches (PySpark parity).
-        // Preserve the original list column: add a copy with column_name, then explode it (so Name/Value stay, ExplodedValue expands).
-        let inner = match &expr {
-            Expr::Alias(e, _) => e.as_ref(),
-            e => e,
-        };
-        if let Expr::Explode {
-            input,
-            options: explode_opts,
-        } = inner
-        {
+        // Adding a new column. If expr is explode(list_col or list expr), use frame-level explode (PySpark parity).
+        if let Some((input, explode_opts)) = explode_expr_parts(&expr) {
             if let Expr::Column(explode_col) = input.as_ref() {
-                let refs = expr_referenced_columns(inner);
+                let refs = expr_referenced_columns(input.as_ref());
                 if refs.len() == 1 {
                     let explode_col_str = explode_col.as_str();
                     if df.resolve_column_name(explode_col_str).is_ok() {
-                        // Add new column as copy of list, then explode it so original column is preserved.
+                        // Preserve the original list column: copy then explode the copy (#1054).
                         let lf_with_copy =
                             lf.with_column(col(explode_col.as_str()).alias(column_name));
                         let selector = Selector::ByName {
                             names: Arc::from([PlSmallStr::from(column_name)]),
                             strict: true,
                         };
-                        lf_with_copy.explode(selector, *explode_opts)
+                        lf_with_copy.explode(selector, explode_opts)
                     } else {
-                        lf.with_column(expr.alias(column_name))
+                        lazy_frame_explode_list_expr(
+                            lf,
+                            column_name,
+                            input.as_ref().clone(),
+                            explode_opts,
+                        )
                     }
                 } else {
-                    lf.with_column(expr.alias(column_name))
+                    lazy_frame_explode_list_expr(
+                        lf,
+                        column_name,
+                        input.as_ref().clone(),
+                        explode_opts,
+                    )
                 }
             } else {
-                lf.with_column(expr.alias(column_name))
+                lazy_frame_explode_list_expr(
+                    lf,
+                    column_name,
+                    input.as_ref().clone(),
+                    explode_opts,
+                )
             }
         } else {
             lf.with_column(expr.alias(column_name))

--- a/tests/dataframe/test_issue_1570_explode_split_withcolumn.py
+++ b/tests/dataframe/test_issue_1570_explode_split_withcolumn.py
@@ -1,0 +1,30 @@
+"""Regression tests for issue #1570: withColumn(explode(split(...))) on a string column."""
+
+from __future__ import annotations
+
+from sparkless.testing import get_imports
+
+_imports = get_imports()
+F = _imports.F
+
+
+def test_withcolumn_explode_split_replaces_name(spark) -> None:
+    """PySpark: withColumn('name', explode(split(name, ' '))) expands into multiple rows."""
+    df = spark.createDataFrame([{"name": "john doe"}])
+    result = df.withColumn("name", F.explode(F.split(F.col("name"), " ")))
+    rows = result.collect()
+
+    assert len(rows) == 2
+    words = sorted(r["name"] for r in rows)
+    assert words == ["doe", "john"]
+
+
+def test_withcolumn_explode_split_preserves_other_columns(spark) -> None:
+    """Sibling columns replicate when exploding split into a new column."""
+    df = spark.createDataFrame([{"id": 1, "name": "a b"}])
+    result = df.withColumn("word", F.explode(F.split(F.col("name"), " ")))
+    rows = result.collect()
+
+    assert len(rows) == 2
+    assert all(r["id"] == 1 for r in rows)
+    assert sorted(r["word"] for r in rows) == ["a", "b"]


### PR DESCRIPTION
## Summary

Fixes [#1570](https://github.com/eddiethedean/robin-sparkless/issues/1570).

`df.withColumn("name", F.explode(F.split(F.col("name"), " ")))` failed with ``explode` operation not supported for dtype `str`` because Sparkless treated any `explode(...)` that referenced the replaced column as “explode that column in place,” even when the argument was `split(...)` (still a string at the column level).

- Only use in-place frame explode when the inner input is `explode(col("that_column"))` on a list column
- For `explode(split(...))` and similar, materialize the list expression then `LazyFrame.explode` (same pattern as #1563 `select`)

## Test plan

- [x] `pytest tests/dataframe/test_issue_1570_explode_split_withcolumn.py -v`
- [x] `pytest tests/dataframe/test_issue_1563_explode_split_select.py -v` (regression)