### PR TITLE
Add DataType.typeName() for PySpark parity (#1572)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`DataType.typeName()` (#1572)** — PySpark-style `sf.dataType.typeName()` (e.g. `StringType` → `"string"`, `IntegerType` → `"integer"`) on `sparkless.sql.types` classes.
+
 - **`filter(~(col == numeric))` on string columns (#1571)** — Nested comparisons under logical NOT (`~`) now coerce string–numeric operands when literals are wrapped in `Alias` (Python `Column` RHS); fixes `cannot compare string with numeric type (i32)` for e.g. `df.filter(~(F.col("A") == 1))`.
 
 - **`withColumn(explode(split(...)))` (#1570)** — Frame-level explode for list expressions (e.g. `withColumn('name', explode(split(name, ' ')))`); no longer explodes the raw string column when the argument is `split(...)`.

--- a/python/sparkless/sparkless/sql/types.py
+++ b/python/sparkless/sparkless/sql/types.py
@@ -25,6 +25,18 @@ RowGetItemReturn = Union[RowValue, Tuple[RowValue, ...]]
 
 
 class DataType:
+    @classmethod
+    def typeName(cls) -> str:
+        """PySpark parity: stable type identifier (e.g. ``string`` for ``StringType``).
+
+        Distinct from :meth:`simpleString` for some types (e.g. ``IntegerType`` →
+        ``integer`` here vs ``int`` in ``simpleString``).
+        """
+        name = cls.__name__
+        if name.endswith("Type"):
+            return name[:-4].lower()
+        return name.lower()
+
     def simpleString(self) -> str:
         return "string"
 

--- a/tests/dataframe/test_issue_1572_datatype_type_name.py
+++ b/tests/dataframe/test_issue_1572_datatype_type_name.py
@@ -1,0 +1,29 @@
+"""Issue #1572: DataType.typeName() PySpark parity."""
+
+from __future__ import annotations
+
+from sparkless.testing import get_imports
+
+_imports = get_imports()
+
+
+def test_schema_field_datatype_type_name(spark) -> None:
+    df = spark.createDataFrame([{"name": "Alice"}])
+    types = [sf.dataType.typeName() for sf in df.schema]
+    assert types == ["string"]
+
+
+def test_string_type_type_name() -> None:
+    assert _imports.StringType().typeName() == "string"
+
+
+def test_integer_type_name_differs_from_simple_string() -> None:
+    it = _imports.IntegerType()
+    assert it.typeName() == "integer"
+    assert it.simpleString() == "int"
+
+
+def test_long_type_name_differs_from_simple_string() -> None:
+    lt = _imports.LongType()
+    assert lt.typeName() == "long"
+    assert lt.simpleString() == "bigint"


### PR DESCRIPTION
## Summary

- Fixes [#1572](https://github.com/eddiethedean/robin-sparkless/issues/1572): `sf.dataType.typeName()` on schema fields (e.g. `StringType` → `"string"`).
- Adds PySpark-compatible `DataType.typeName()` classmethod on `sparkless.sql.types` (same `ClassName` minus `Type` rule as [PySpark](https://github.com/apache/spark/blob/master/python/pyspark/sql/types.py)).

## Test plan

- [x] `pytest tests/dataframe/test_issue_1572_datatype_type_name.py`