### PR TITLE
Fix to_timestamp fractional seconds (#1578)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`to_timestamp` with fractional seconds (#1578)** — Default-format parsing (no format string) now accepts sub-second precision (e.g. `2026-06-04 12:34:56.78`) via flexible timestamp parsing instead of returning null.
+
 - **`to_timestamp(F.expr(...))` (#1574)** — `F.expr()` results compose inside `to_timestamp` / `to_date`; SQL `expr()` parsing supports `substring`, `regexp_replace`, and `to_timestamp` for `withColumn` expressions.
 
 - **`F.when(cond, None).otherwise(...)` (#1573)** — Two-argument `when` with Python `None` as the then-value now builds a `PyThenBuilder` (null literal) so `.otherwise()` chains work in `withColumn` / `select`.

--- a/crates/robin-sparkless-polars/src/udfs/rest.rs
+++ b/crates/robin-sparkless-polars/src/udfs/rest.rs
@@ -4312,14 +4312,23 @@ pub fn apply_to_timestamp_format(
                 if strict_iso_no_fraction && (s.len() != 19 || s.contains('.')) {
                     return None;
                 }
-                let ndt = NaiveDateTime::parse_from_str(s, &chrono_fmt)
+                let utc_micros = NaiveDateTime::parse_from_str(s, &chrono_fmt)
                     .or_else(|_| NaiveDateTime::parse_from_str(s, &chrono_fmt_alt))
-                    .ok()?;
-                let parsed_utc = ndt.and_utc();
+                    .ok()
+                    .map(|ndt| ndt.and_utc().timestamp_micros())
+                    .or_else(|| {
+                        // PySpark default to_timestamp accepts fractional seconds (#1578).
+                        if format.is_none() {
+                            parse_timestamp_string_flexible_with_tz(s, None)
+                        } else {
+                            None
+                        }
+                    })?;
+                let parsed_utc = chrono::DateTime::from_timestamp_micros(utc_micros)?;
                 if use_recent_null && parsed_utc >= recent_cutoff && parsed_utc <= ref_ts {
                     return None;
                 }
-                Some(parsed_utc.timestamp_micros())
+                Some(utc_micros)
             })
         }),
     );

--- a/tests/dataframe/test_issue_1578_to_timestamp_fractional.py
+++ b/tests/dataframe/test_issue_1578_to_timestamp_fractional.py
@@ -1,0 +1,36 @@
+"""Issue #1578: to_timestamp on strings with fractional seconds (default format)."""
+
+from __future__ import annotations
+
+from sparkless.testing import get_imports
+
+_imports = get_imports()
+SparkSession = _imports.SparkSession
+F = _imports.F
+
+
+def test_to_timestamp_default_format_fractional_seconds() -> None:
+    spark = SparkSession.builder.appName("issue_1578").get_or_create()
+    row = (
+        spark.range(1)
+        .select(F.to_timestamp(F.lit("2026-06-04 12:34:56.78")).alias("ts"))
+        .collect()[0]
+    )
+    assert row["ts"] is not None
+    assert "2026-06-04" in str(row["ts"])
+    assert "12:34:56" in str(row["ts"])
+
+
+def test_create_dataframe_after_fractional_to_timestamp() -> None:
+    """Null timestamp from failed parse blocked schema inference; must parse successfully."""
+    spark = SparkSession.builder.appName("issue_1578_cascade").get_or_create()
+    result = (
+        spark.range(1)
+        .select(F.to_timestamp(F.lit("2026-06-04 12:34:56.78")).alias("ts"))
+        .collect()[0]["ts"]
+    )
+    assert result is not None
+    df = spark.createDataFrame([(result, "hello")], ["col_ts", "col_str"])
+    rows = df.collect()
+    assert len(rows) == 1
+    assert rows[0]["col_str"] == "hello"


### PR DESCRIPTION
## Summary

- Fixes [#1578](https://github.com/eddiethedean/robin-sparkless/issues/1578): `F.to_timestamp(F.lit("2026-06-04 12:34:56.78"))` no longer returns null when no format is specified.
- Root cause: default format `%Y-%m-%d %H:%M:%S` rejects sub-second precision; null then broke `createDataFrame` schema inference.
- Fix: when `format` is `None`, fall back to existing `parse_timestamp_string_flexible_with_tz` after strict parse fails.

## Test plan

- [x] `pytest tests/dataframe/test_issue_1578_to_timestamp_fractional.py`