### PR TITLE
Fix isin() with string list on integer column (fixes #1588)

### DIFF
--- a/crates/robin-sparkless-polars/src/functions/rest.rs
+++ b/crates/robin-sparkless-polars/src/functions/rest.rs
@@ -3160,9 +3160,17 @@ pub fn isin_i64(column: &Column, values: &[i64]) -> Column {
 }
 
 /// Check if column values are in the given string slice (PySpark isin with literal list).
+/// #1588: Cast column to string so int column isin(["1", "2"]) works (PySpark parity).
 pub fn isin_str(column: &Column, values: &[&str]) -> Column {
     let s: Series = Series::from_iter(values.iter().copied());
-    Column::from_expr(column.expr().clone().is_in(lit(s).implode(), false), None)
+    Column::from_expr(
+        column
+            .expr()
+            .clone()
+            .cast(DataType::String)
+            .is_in(lit(s).implode(), false),
+        None,
+    )
 }
 
 /// Percent-decode URL-encoded string (PySpark url_decode).

--- a/tests/dataframe/test_issue_1588_isin_string_list_int_column.py
+++ b/tests/dataframe/test_issue_1588_isin_string_list_int_column.py
@@ -1,0 +1,29 @@
+"""
+Tests for issue #1588: isin() with string list on integer column.
+
+PySpark auto-casts string literals to match the column type; sparkless must not
+raise when filtering e.g. col("example1").isin(["1", "2"]) on an int column.
+"""
+
+from __future__ import annotations
+
+from sparkless.testing import get_imports
+
+F = get_imports().F
+
+
+def test_isin_string_list_on_int_column(spark) -> None:
+    """Exact scenario from issue #1588."""
+    df = spark.createDataFrame([(1, "A"), (2, "B"), (3, "C")], ["example1", "example2"])
+    rows = df.filter(F.col("example1").isin(["1", "2"])).collect()
+    assert len(rows) == 2
+    assert {r["example1"] for r in rows} == {1, 2}
+    assert {r["example2"] for r in rows} == {"A", "B"}
+
+
+def test_isin_string_list_on_int_column_variadic(spark) -> None:
+    """Variadic isin with string args on int column."""
+    df = spark.createDataFrame([(119, "x"), (120, "y"), (121, "z")], ["id", "label"])
+    rows = df.filter(F.col("id").isin("119", "120")).collect()
+    assert len(rows) == 2
+    assert {r["id"] for r in rows} == {119, 120}


### PR DESCRIPTION
## Summary

- Fix `col("example1").isin(["1", "2"])` on integer columns raising `'is_in' cannot check for List(String) values in Int64 data`
- Cast the column to string in `isin_str`, matching the existing `isin_i64` / plan-expression behavior for PySpark parity
- Add regression tests for list and variadic string arguments on int columns

## Test plan

- [x] `pytest tests/dataframe/test_issue_1588_isin_string_list_int_column.py -v`
- [x] `pytest tests/dataframe/test_issue_244_column_isin.py tests/dataframe/test_issue_369_isin_negation.py -v`

Fixes #1588