### PR TITLE
Fix unionByName with ArrayType vs lit(None) (fixes #1590)

### DIFF
--- a/crates/robin-sparkless-polars/src/type_coercion.rs
+++ b/crates/robin-sparkless-polars/src/type_coercion.rs
@@ -35,6 +35,14 @@ fn dtype_to_precedence(dtype: &DataType) -> Option<TypePrecedence> {
 /// Returns the tightest (highest precedence) common type that both can be coerced to.
 /// #681: Unknown dtype is treated as String so join/union with Int64 vs Unknown coerce to String (PySpark parity).
 pub fn find_common_type(left: &DataType, right: &DataType) -> Result<DataType, PolarsError> {
+    // #1590: untyped null adopts the other side's type (unionByName with lit(None) vs array).
+    if left == &DataType::Null {
+        return Ok(right.clone());
+    }
+    if right == &DataType::Null {
+        return Ok(left.clone());
+    }
+
     let left_norm = if matches!(left, DataType::Unknown(_)) {
         DataType::String
     } else {
@@ -485,6 +493,14 @@ pub fn coerce_for_pyspark_arithmetic(
 mod tests {
     use super::*;
     use polars::prelude::{IntoLazy, df};
+
+    #[test]
+    fn find_common_type_null_adopts_other_type() -> Result<(), PolarsError> {
+        let list_str = DataType::List(Box::new(DataType::String));
+        assert_eq!(find_common_type(&DataType::Null, &list_str)?, list_str);
+        assert_eq!(find_common_type(&list_str, &DataType::Null)?, list_str);
+        Ok(())
+    }
 
     #[test]
     fn numeric_numeric_uses_standard_coercion() -> Result<(), PolarsError> {

--- a/tests/dataframe/test_issue_1590_union_by_name_array_null.py
+++ b/tests/dataframe/test_issue_1590_union_by_name_array_null.py
@@ -1,0 +1,51 @@
+"""
+Tests for issue #1590: unionByName with ArrayType vs lit(None).
+
+PySpark treats untyped null as compatible with the other side's array type.
+"""
+
+from __future__ import annotations
+
+from sparkless.testing import get_imports
+
+F = get_imports().F
+ArrayType = get_imports().ArrayType
+StringType = get_imports().StringType
+StructField = get_imports().StructField
+StructType = get_imports().StructType
+
+
+def test_union_by_name_array_vs_lit_none(spark) -> None:
+    """Exact scenario from issue #1590."""
+    schema_with_array = StructType(
+        [
+            StructField("A", StringType()),
+            StructField("B", ArrayType(StringType())),
+        ]
+    )
+    df1 = spark.createDataFrame([("A", ["x", "y"])], schema_with_array)
+    df2 = spark.createDataFrame([("B",)], ["A"]).withColumn("B", F.lit(None))
+
+    rows = df1.unionByName(df2).collect()
+    assert len(rows) == 2
+    by_a = {r["A"]: r["B"] for r in rows}
+    assert by_a["A"] == ["x", "y"]
+    assert by_a["B"] is None
+
+
+def test_union_array_vs_lit_none(spark) -> None:
+    """Regular union() should also accept array vs untyped null."""
+    schema_with_array = StructType(
+        [
+            StructField("A", StringType()),
+            StructField("B", ArrayType(StringType())),
+        ]
+    )
+    df1 = spark.createDataFrame([("A", ["x"])], schema_with_array)
+    df2 = spark.createDataFrame([("B",)], ["A"]).withColumn("B", F.lit(None))
+
+    rows = df1.union(df2).collect()
+    assert len(rows) == 2
+    by_a = {r["A"]: r["B"] for r in rows}
+    assert by_a["A"] == ["x"]
+    assert by_a["B"] is None


### PR DESCRIPTION
## Summary

- Fix `unionByName` failing when one DataFrame has an `ArrayType` column and the other has `lit(None)` (untyped null) for the same column
- In `find_common_type`, treat `Null` as adopting the other side's type (PySpark parity for filling missing rows before union)

## Test plan

- [x] `cargo test -p robin-sparkless-polars find_common_type_null`
- [x] `pytest tests/dataframe/test_issue_1590_union_by_name_array_null.py -v`
- [x] `pytest tests/unit/dataframe/test_union_type_coercion.py -q`

Fixes #1590