### PR TITLE
Fix SQL filter != for string vs numeric columns (fixes #1592)

### DIFF
--- a/crates/robin-sparkless-polars/src/sql/translator.rs
+++ b/crates/robin-sparkless-polars/src/sql/translator.rs
@@ -1221,7 +1221,7 @@ fn sql_expr_to_polars(
             let r = sql_expr_to_polars(right, session, df, having_agg_map, having_agg_list)?;
             match op {
                 BinaryOperator::Eq => Ok(l.eq(r)),
-                BinaryOperator::NotEq => Ok(l.eq(r).not()),
+                BinaryOperator::NotEq => Ok(l.neq(r)),
                 BinaryOperator::Gt => Ok(l.gt(r)),
                 BinaryOperator::GtEq => Ok(l.gt_eq(r)),
                 BinaryOperator::Lt => Ok(l.lt(r)),

--- a/tests/dataframe/test_issue_1592_sql_filter_col_col_neq.py
+++ b/tests/dataframe/test_issue_1592_sql_filter_col_col_neq.py
@@ -1,0 +1,32 @@
+"""
+Tests for issue #1592: SQL-style string filter col_a != col_b with mixed types.
+
+PySpark coerces string vs integer column comparisons in SQL-style filter strings.
+"""
+
+from __future__ import annotations
+
+from sparkless.testing import get_imports
+
+F = get_imports().F
+IntegerType = get_imports().IntegerType
+
+
+def test_sql_filter_string_neq_int_column(spark) -> None:
+    """Exact scenario from issue #1592."""
+    df = spark.createDataFrame([("1", 2), ("3", 3)], ["col_a", "col_b"])
+    df = df.withColumn("col_b", F.col("col_b").cast(IntegerType()))
+    rows = df.filter("col_a != col_b").collect()
+    assert len(rows) == 1
+    assert rows[0]["col_a"] == "1"
+    assert rows[0]["col_b"] == 2
+
+
+def test_sql_filter_string_eq_int_column(spark) -> None:
+    """SQL != fix should not regress == with mixed column types."""
+    df = spark.createDataFrame([("1", 2), ("3", 3)], ["col_a", "col_b"])
+    df = df.withColumn("col_b", F.col("col_b").cast(IntegerType()))
+    rows = df.filter("col_a == col_b").collect()
+    assert len(rows) == 1
+    assert rows[0]["col_a"] == "3"
+    assert rows[0]["col_b"] == 3


### PR DESCRIPTION
## Summary

- Fix `df.filter("col_a != col_b")` when `col_a` is string and `col_b` is integer raising `cannot compare string with numeric type (i32)`
- SQL `<>` / `!=` now lowers to `neq()` instead of `eq().not()`, so existing column-to-column comparison coercion in `filter()` applies (same as `F.col("col_a") != F.col("col_b")`)

## Test plan

- [x] `pytest tests/dataframe/test_issue_1592_sql_filter_col_col_neq.py -v`
- [x] `pytest tests/dataframe/test_issue_366_comparison_coercion_col_col.py tests/dataframe/test_issue_395_filter_and_string_expr.py -v`

Fixes #1592