### PR TITLE
Add regression test for SQL filter string vs double (fixes #1593)

### DIFF
--- a/tests/dataframe/test_issue_1592_sql_filter_col_col_neq.py
+++ b/tests/dataframe/test_issue_1592_sql_filter_col_col_neq.py
@@ -1,7 +1,7 @@
 """
-Tests for issue #1592: SQL-style string filter col_a != col_b with mixed types.
+Tests for issue #1592 / #1593: SQL-style string filter col_a != col_b with mixed types.
 
-PySpark coerces string vs integer column comparisons in SQL-style filter strings.
+PySpark coerces string vs numeric column comparisons in SQL-style filter strings.
 """
 
 from __future__ import annotations
@@ -30,3 +30,12 @@ def test_sql_filter_string_eq_int_column(spark) -> None:
     assert len(rows) == 1
     assert rows[0]["col_a"] == "3"
     assert rows[0]["col_b"] == 3
+
+
+def test_sql_filter_string_neq_double_column(spark) -> None:
+    """Exact scenario from issue #1593 (string vs f64)."""
+    df = spark.createDataFrame([("1.5", 2.0), ("3.0", 3.0)], ["col_a", "col_b"])
+    rows = df.filter("col_a != col_b").collect()
+    assert len(rows) == 1
+    assert rows[0]["col_a"] == "1.5"
+    assert rows[0]["col_b"] == 2.0


### PR DESCRIPTION
## Summary

- Add regression test for `df.filter("col_a != col_b")` when `col_a` is string and `col_b` is double (issue #1593)
- No code change: behavior was already fixed on `main` by #1607 (#1592), which lowered SQL `!=` to `neq()` so column-to-column string/numeric coercion applies

## Test plan

- [x] `pytest tests/dataframe/test_issue_1592_sql_filter_col_col_neq.py -v`

Fixes #1593