### PR TITLE
Fix array cast to string (fixes #1594)

### DIFF
--- a/crates/robin-sparkless-polars/src/functions/rest.rs
+++ b/crates/robin-sparkless-polars/src/functions/rest.rs
@@ -1540,6 +1540,15 @@ fn cast_impl(column: &Column, type_name: &str, strict: bool) -> Result<Column, S
         );
         return Ok(Column::from_expr(expr.alias(&base_name), Some(base_name)));
     }
+    if dtype == DataType::String {
+        let expr = column.expr().clone().map(
+            move |col| {
+                crate::column::expect_col(crate::udfs::apply_cast_to_string(col, ansi_strict))
+            },
+            |_schema, field| Ok(Field::new(field.name().clone(), DataType::String)),
+        );
+        return Ok(Column::from_expr(expr.alias(&base_name), Some(base_name)));
+    }
     let expr = if ansi_strict {
         column.expr().clone().strict_cast(dtype)
     } else {

--- a/crates/robin-sparkless-polars/src/udfs/rest.rs
+++ b/crates/robin-sparkless-polars/src/udfs/rest.rs
@@ -5923,6 +5923,47 @@ pub fn apply_string_to_double(column: Column, strict: bool) -> PolarsResult<Opti
     Ok(Some(Column::new(name, out)))
 }
 
+/// Format one list row as PySpark's array-to-string cast (`[x, y]`).
+fn format_list_row_as_pyspark_string(inner: Series) -> PolarsResult<String> {
+    let inner = inner.cast(&DataType::String)?;
+    let ca = inner
+        .str()
+        .map_err(|e| compute_err("cast list element to string", e))?;
+    let parts: Vec<&str> = ca.into_iter().flatten().collect();
+    Ok(format!("[{}]", parts.join(", ")))
+}
+
+/// Cast column to string (PySpark parity). List columns stringify as `[elem1, elem2]` (#1594).
+pub fn apply_cast_to_string(column: Column, strict: bool) -> PolarsResult<Option<Column>> {
+    use polars::chunked_array::builder::StringChunkedBuilder;
+
+    let name = column.field().into_owned().name;
+    let series = column.take_materialized_series();
+    let out: Series = match series.dtype() {
+        DataType::List(_) => {
+            let list = series
+                .list()
+                .map_err(|e| compute_err("cast to string", e))?;
+            let mut builder = StringChunkedBuilder::new(name.as_str().into(), list.len());
+            for opt_inner in list.into_iter() {
+                match opt_inner {
+                    None => builder.append_null(),
+                    Some(inner) => builder.append_value(format_list_row_as_pyspark_string(inner)?),
+                }
+            }
+            builder.finish().into_series()
+        }
+        _ => {
+            if strict {
+                series.strict_cast(&DataType::String)?
+            } else {
+                series.cast(&DataType::String)?
+            }
+        }
+    };
+    Ok(Some(Column::new(name, out)))
+}
+
 /// Apply string-to-date cast. Handles string columns (accepts date and datetime strings, Spark parity); passes through date; casts datetime to date; others error (cast) or null (try_cast).
 pub fn apply_string_to_date(column: Column, strict: bool) -> PolarsResult<Option<Column>> {
     let name = column.field().into_owned().name;

--- a/tests/dataframe/test_issue_1594_array_cast_string.py
+++ b/tests/dataframe/test_issue_1594_array_cast_string.py
@@ -1,0 +1,61 @@
+"""
+Tests for issue #1594: cast ArrayType column to StringType.
+
+PySpark stringifies arrays as `[elem1, elem2]`; sparkless previously raised
+"cannot cast List type".
+"""
+
+from __future__ import annotations
+
+from sparkless.testing import get_imports
+
+F = get_imports().F
+ArrayType = get_imports().ArrayType
+IntegerType = get_imports().IntegerType
+StringType = get_imports().StringType
+StructField = get_imports().StructField
+StructType = get_imports().StructType
+
+
+def test_array_string_cast_to_string(spark) -> None:
+    """Exact scenario from issue #1594."""
+    df = spark.createDataFrame(
+        [("A", ["x", "y"]), ("B", ["z"])],
+        StructType(
+            [
+                StructField("COL1", StringType()),
+                StructField("COL2", ArrayType(StringType())),
+            ]
+        ),
+    )
+    result = df.withColumn("COL2_str", F.col("COL2").cast("string"))
+    rows = {r["COL1"]: r["COL2_str"] for r in result.collect()}
+    assert rows["A"] == "[x, y]"
+    assert rows["B"] == "[z]"
+
+
+def test_array_int_cast_to_string(spark) -> None:
+    """Numeric array elements stringify without extra quotes."""
+    df = spark.createDataFrame(
+        [(1, [1, 2]), (2, [])],
+        StructType(
+            [
+                StructField("id", IntegerType()),
+                StructField("nums", ArrayType(IntegerType())),
+            ]
+        ),
+    )
+    result = df.withColumn("nums_str", F.col("nums").cast("string"))
+    rows = {r["id"]: r["nums_str"] for r in result.collect()}
+    assert rows[1] == "[1, 2]"
+    assert rows[2] == "[]"
+
+
+def test_array_null_cast_to_string(spark) -> None:
+    """Null array values stay null when cast to string."""
+    df = spark.createDataFrame(
+        [(None,)],
+        StructType([StructField("arr", ArrayType(StringType()))]),
+    )
+    row = df.withColumn("arr_str", F.col("arr").cast("string")).collect()[0]
+    assert row["arr_str"] is None


### PR DESCRIPTION
## Summary
- Fixes `F.col("COL2").cast("string")` on `ArrayType` columns, which previously raised `cannot cast List type`
- Adds `apply_cast_to_string` UDF to format list values as PySpark-style strings (e.g. `[x, y]`, `[]`)
- Adds regression tests for string arrays, int arrays, and null arrays

## Test plan
- [x] `pytest tests/dataframe/test_issue_1594_array_cast_string.py`
- [x] `make check-full`

Fixes #1594