### PR TITLE
Support SQL subqueries in FROM clause (fixes #1595)

### DIFF
--- a/crates/robin-sparkless-polars/src/sql/translator.rs
+++ b/crates/robin-sparkless-polars/src/sql/translator.rs
@@ -917,14 +917,18 @@ fn translate_select_from(
     let mut df = resolve_table_factor(session, &first_tj.relation)?;
     let left_alias_opt = table_alias_from_factor(&first_tj.relation);
     if let Some(ref prefix) = left_alias_opt {
-        df = df_prefix_columns(&df, prefix)?;
+        if should_prefix_columns(&first_tj.relation) {
+            df = df_prefix_columns(&df, prefix)?;
+        }
     }
     let current_left_alias = left_alias_opt.as_deref();
     for join_spec in &first_tj.joins {
         let mut right_df = resolve_table_factor(session, &join_spec.relation)?;
         let right_alias_opt = table_alias_from_factor(&join_spec.relation);
         if let Some(ref prefix) = right_alias_opt {
-            right_df = df_prefix_columns(&right_df, prefix)?;
+            if should_prefix_columns(&join_spec.relation) {
+                right_df = df_prefix_columns(&right_df, prefix)?;
+            }
         }
         let right_alias_ref = right_alias_opt.as_deref();
         match &join_spec.join_operator {
@@ -1026,8 +1030,20 @@ fn table_alias_from_factor(factor: &TableFactor) -> Option<String> {
             if a == table_name { None } else { Some(a) }
         }
         TableFactor::Table { alias: None, .. } => None,
+        TableFactor::Derived {
+            alias: Some(TableAlias {
+                name: alias_name, ..
+            }),
+            ..
+        } => Some(alias_name.value.clone()),
+        TableFactor::Derived { alias: None, .. } => None,
         _ => None,
     }
+}
+
+/// Derived tables keep inner column names; plain tables with aliases are prefixed (#152).
+fn should_prefix_columns(factor: &TableFactor) -> bool {
+    !matches!(factor, TableFactor::Derived { .. })
 }
 
 /// Prefix all column names with "prefix_". Used when FROM has alias so qualified refs (e.name) become e_name.
@@ -1049,6 +1065,12 @@ fn resolve_table_factor(
             let table_name = table_name_from_object_name(name);
             session.table(&table_name)
         }
+        TableFactor::Derived {
+            lateral: true, ..
+        } => Err(PolarsError::InvalidOperation(
+            "SQL: LATERAL derived tables in FROM are not yet supported.".into(),
+        )),
+        TableFactor::Derived { subquery, .. } => translate_query(session, subquery.as_ref()),
         _ => Err(PolarsError::InvalidOperation(
             "SQL: only plain table names are supported in FROM (no subqueries, derived tables). Register with create_or_replace_temp_view.".into(),
         )),

--- a/tests/dataframe/test_issue_1595_sql_from_subquery.py
+++ b/tests/dataframe/test_issue_1595_sql_from_subquery.py
@@ -1,0 +1,68 @@
+"""
+Tests for issue #1595: SQL subqueries in FROM clause.
+
+PySpark supports derived tables like `FROM (SELECT ...) alias`; sparkless
+previously rejected them with "only plain table names are supported in FROM".
+"""
+
+from __future__ import annotations
+
+from sparkless.testing import get_imports
+
+F = get_imports().F
+
+
+def test_sql_from_subquery_with_alias_filter(spark) -> None:
+    """Exact scenario from issue #1595."""
+    df = spark.createDataFrame([("A", 1), ("B", 2)], ["name", "value"])
+    df.createOrReplaceTempView("items")
+
+    result = spark.sql(
+        """
+        SELECT name, value
+        FROM (SELECT name, value FROM items WHERE value > 0) sub
+        WHERE sub.value < 10
+        """
+    )
+    rows = sorted(result.collect(), key=lambda r: r["name"])
+    assert len(rows) == 2
+    assert rows[0]["name"] == "A" and rows[0]["value"] == 1
+    assert rows[1]["name"] == "B" and rows[1]["value"] == 2
+
+
+def test_sql_from_subquery_filters_rows(spark) -> None:
+    """Derived table projection plus outer filter."""
+    df = spark.createDataFrame(
+        [("A", 1), ("B", 2), ("C", 20)],
+        ["name", "value"],
+    )
+    df.createOrReplaceTempView("items")
+
+    result = spark.sql(
+        """
+        SELECT name, value
+        FROM (SELECT name, value FROM items WHERE value > 1) sub
+        WHERE sub.value < 10
+        """
+    )
+    rows = result.collect()
+    assert len(rows) == 1
+    assert rows[0]["name"] == "B"
+    assert rows[0]["value"] == 2
+
+
+def test_sql_from_subquery_unqualified_columns(spark) -> None:
+    """Columns from a derived table can be referenced without the alias."""
+    df = spark.createDataFrame([("A", 1), ("B", 2)], ["name", "value"])
+    df.createOrReplaceTempView("items")
+
+    result = spark.sql(
+        """
+        SELECT name
+        FROM (SELECT name, value FROM items) sub
+        WHERE value = 2
+        """
+    )
+    rows = result.collect()
+    assert len(rows) == 1
+    assert rows[0]["name"] == "B"


### PR DESCRIPTION
## Summary
- Fixes `spark.sql()` queries with derived tables in `FROM`, e.g. `FROM (SELECT ...) sub`
- Translates `TableFactor::Derived` subqueries via the existing SQL query translator
- Keeps inner column names on derived tables (no alias prefixing) so `SELECT name` and `WHERE sub.value` both resolve like PySpark

## Test plan
- [x] `pytest tests/dataframe/test_issue_1595_sql_from_subquery.py`
- [x] `make check-full`

Fixes #1595