### PR TITLE
Fix join on TimestampType vs DateType (fixes #1596)

### DIFF
--- a/crates/robin-sparkless-polars/src/type_coercion.rs
+++ b/crates/robin-sparkless-polars/src/type_coercion.rs
@@ -43,6 +43,17 @@ pub fn find_common_type(left: &DataType, right: &DataType) -> Result<DataType, P
         return Ok(left.clone());
     }
 
+    // #615 / #1596: Date vs Datetime — cast date to datetime (start-of-day) for join/compare parity.
+    let date_vs_datetime = (left == &DataType::Date && matches!(right, DataType::Datetime(_, _)))
+        || (matches!(left, DataType::Datetime(_, _)) && right == &DataType::Date);
+    if date_vs_datetime {
+        return Ok(if matches!(left, DataType::Datetime(_, _)) {
+            left.clone()
+        } else {
+            right.clone()
+        });
+    }
+
     let left_norm = if matches!(left, DataType::Unknown(_)) {
         DataType::String
     } else {
@@ -499,6 +510,14 @@ mod tests {
         let list_str = DataType::List(Box::new(DataType::String));
         assert_eq!(find_common_type(&DataType::Null, &list_str)?, list_str);
         assert_eq!(find_common_type(&list_str, &DataType::Null)?, list_str);
+        Ok(())
+    }
+
+    #[test]
+    fn find_common_type_date_datetime_prefers_datetime() -> Result<(), PolarsError> {
+        let ts = DataType::Datetime(TimeUnit::Microseconds, None);
+        assert_eq!(find_common_type(&DataType::Date, &ts)?, ts);
+        assert_eq!(find_common_type(&ts, &DataType::Date)?, ts);
         Ok(())
     }
 

--- a/tests/dataframe/test_issue_1596_join_timestamp_date.py
+++ b/tests/dataframe/test_issue_1596_join_timestamp_date.py
@@ -1,0 +1,70 @@
+"""
+Tests for issue #1596: join on TimestampType vs DateType.
+
+PySpark coerces date join keys to timestamp; sparkless previously raised
+"cannot find common type for Datetime and Date".
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+
+from sparkless.testing import get_imports
+
+DateType = get_imports().DateType
+IntegerType = get_imports().IntegerType
+StructField = get_imports().StructField
+StructType = get_imports().StructType
+TimestampType = get_imports().TimestampType
+
+
+def test_join_timestamp_left_date_right(spark) -> None:
+    """Exact scenario from issue #1596."""
+    schema_ts = StructType([StructField("col1", TimestampType())])
+    schema_dt = StructType(
+        [
+            StructField("col1", DateType()),
+            StructField("col2", IntegerType()),
+        ]
+    )
+
+    df_a = spark.createDataFrame(
+        [(datetime(2025, 1, 1),), (datetime(2025, 1, 2),)],
+        schema_ts,
+    )
+    df_b = spark.createDataFrame([(date(2025, 1, 1), 100)], schema_dt)
+
+    rows = sorted(
+        df_a.join(df_b, "col1", "left").collect(),
+        key=lambda r: r["col1"],
+    )
+    assert len(rows) == 2
+
+    matched = rows[0]
+    assert matched["col1"] == datetime(2025, 1, 1)
+    assert matched["col2"] == 100
+
+    unmatched = rows[1]
+    assert unmatched["col1"] == datetime(2025, 1, 2)
+    assert unmatched["col2"] is None
+
+
+def test_join_date_left_timestamp_right(spark) -> None:
+    """Join with date on the left and timestamp on the right."""
+    schema_dt = StructType([StructField("col1", DateType())])
+    schema_ts = StructType(
+        [
+            StructField("col1", TimestampType()),
+            StructField("col2", IntegerType()),
+        ]
+    )
+
+    df_a = spark.createDataFrame([(date(2025, 1, 1),)], schema_dt)
+    df_b = spark.createDataFrame(
+        [(datetime(2025, 1, 1), 42), (datetime(2025, 1, 2), 99)],
+        schema_ts,
+    )
+
+    row = df_a.join(df_b, "col1", "inner").collect()[0]
+    assert row["col1"] in (date(2025, 1, 1), datetime(2025, 1, 1))
+    assert row["col2"] == 42


### PR DESCRIPTION
## Summary
- Fixes joins where one side has `TimestampType` and the other has `DateType`
- Extends `find_common_type` to promote `Date` vs `Datetime` to timestamp (same rule as comparison coercion in #615)
- Join keys are coerced before matching, so `df_ts.join(df_date, "col1", "left")` works like PySpark

## Test plan
- [x] `pytest tests/dataframe/test_issue_1596_join_timestamp_date.py`
- [x] `cargo test -p robin-sparkless-polars find_common_type_date_datetime`
- [x] `make check-full`

Fixes #1596