### PR TITLE
Accept Row as struct value in createDataFrame (fixes #1597)

### DIFF
--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -2787,6 +2787,42 @@ fn python_row_to_json(
     )))
 }
 
+/// Convert PySpark/sparkless Row (or similar) to JSON object for nested struct columns (#1597).
+fn py_row_like_to_json(py: Python<'_>, v: &Bound<'_, PyAny>) -> Option<PyResult<JsonValue>> {
+    if let Ok(as_dict) = v.getattr("asDict") {
+        if as_dict.is_callable() {
+            if let Ok(d) = as_dict.call0() {
+                if let Ok(dict) = d.cast::<PyDict>() {
+                    return Some((|| {
+                        let mut obj = serde_json::Map::new();
+                        for (k, val) in dict.iter() {
+                            let key = k.extract::<String>().unwrap_or_else(|_| k.to_string());
+                            obj.insert(key, py_any_to_json(py, &val)?);
+                        }
+                        Ok(JsonValue::Object(obj))
+                    })());
+                }
+            }
+        }
+    }
+    if let Ok(fields_attr) = v.getattr("_fields") {
+        if let Ok(fields_list) = fields_attr.cast::<PyList>() {
+            if !fields_list.is_empty() {
+                return Some((|| {
+                    let mut obj = serde_json::Map::new();
+                    for (i, field_py) in fields_list.iter().enumerate() {
+                        let key = field_py.extract::<String>()?;
+                        let val_py = v.get_item(i)?;
+                        obj.insert(key, py_any_to_json(py, &val_py)?);
+                    }
+                    Ok(JsonValue::Object(obj))
+                })());
+            }
+        }
+    }
+    None
+}
+
 fn py_any_to_json(_py: Python<'_>, v: &Bound<'_, PyAny>) -> PyResult<JsonValue> {
     if v.is_none() {
         return Ok(JsonValue::Null);
@@ -2858,6 +2894,16 @@ fn py_any_to_json(_py: Python<'_>, v: &Bound<'_, PyAny>) -> PyResult<JsonValue> 
             obj.insert(key, py_any_to_json(_py, &val)?);
         }
         return Ok(JsonValue::Object(obj));
+    }
+    if let Some(result) = py_row_like_to_json(_py, v) {
+        return result;
+    }
+    if let Ok(tup) = v.cast::<PyTuple>() {
+        let mut arr = Vec::with_capacity(tup.len());
+        for item in tup.iter() {
+            arr.push(py_any_to_json(_py, &item)?);
+        }
+        return Ok(JsonValue::Array(arr));
     }
     Ok(JsonValue::String(v.to_string()))
 }

--- a/tests/dataframe/test_issue_1597_row_struct_create_dataframe.py
+++ b/tests/dataframe/test_issue_1597_row_struct_create_dataframe.py
@@ -1,0 +1,81 @@
+"""
+Tests for issue #1597: Row as struct value in createDataFrame.
+
+PySpark accepts Row, dict, tuple, or list for nested struct columns; sparkless
+previously stringified Row and failed struct parsing.
+"""
+
+from __future__ import annotations
+
+from sparkless.testing import get_imports
+
+Row = get_imports().Row
+DoubleType = get_imports().DoubleType
+StringType = get_imports().StringType
+StructField = get_imports().StructField
+StructType = get_imports().StructType
+
+
+def test_create_dataframe_struct_value_from_row(spark) -> None:
+    """Exact scenario from issue #1597."""
+    inner_schema = StructType(
+        [
+            StructField("col1", StringType()),
+            StructField("col2", DoubleType()),
+        ]
+    )
+    schema = StructType(
+        [
+            StructField("col_a", StringType()),
+            StructField("col_b", inner_schema),
+        ]
+    )
+
+    nested = Row(col1="X", col2=0.95)
+    row = spark.createDataFrame([("A", nested)], schema).collect()[0]
+    assert row["col_a"] == "A"
+    assert row["col_b"]["col1"] == "X"
+    assert row["col_b"]["col2"] == 0.95
+
+
+def test_create_dataframe_struct_value_from_dict(spark) -> None:
+    """Dict struct values should continue to work."""
+    inner_schema = StructType(
+        [
+            StructField("col1", StringType()),
+            StructField("col2", DoubleType()),
+        ]
+    )
+    schema = StructType(
+        [
+            StructField("col_a", StringType()),
+            StructField("col_b", inner_schema),
+        ]
+    )
+
+    row = spark.createDataFrame(
+        [("A", {"col1": "X", "col2": 0.95})],
+        schema,
+    ).collect()[0]
+    assert row["col_b"]["col1"] == "X"
+    assert row["col_b"]["col2"] == 0.95
+
+
+def test_create_dataframe_struct_value_from_tuple(spark) -> None:
+    """Tuple struct values map by position."""
+    inner_schema = StructType(
+        [
+            StructField("col1", StringType()),
+            StructField("col2", DoubleType()),
+        ]
+    )
+    schema = StructType(
+        [
+            StructField("col_a", StringType()),
+            StructField("col_b", inner_schema),
+        ]
+    )
+
+    row = spark.createDataFrame([("A", ("X", 0.95))], schema).collect()[0]
+    assert row["col_b"]["col1"] == "X"
+    assert row["col_b"]["col2"] == 0.95


### PR DESCRIPTION
## Summary
- Fixes `createDataFrame` with nested `StructType` columns when struct values are PySpark/sparkless `Row` objects
- `py_any_to_json` converts Row via `asDict()` (or `_fields`) to a JSON object, and tuples to JSON arrays
- Previously Row values were stringified and rejected by struct column parsing

## Test plan
- [x] `pytest tests/dataframe/test_issue_1597_row_struct_create_dataframe.py`
- [x] `make check-full`

Fixes #1597