### PR TITLE
Fix percentile_approx string column name (fixes #1599)

### DIFF
--- a/python/sparkless/sparkless/sql/functions.py
+++ b/python/sparkless/sparkless/sql/functions.py
@@ -605,7 +605,9 @@ def broadcast(df):
     return df
 
 
-percentile_approx = _percentile_approx
+def percentile_approx(col_or_name, percentage, accuracy=None):
+    """Approximate percentile (PySpark percentile_approx). Accepts column name or Column."""
+    return _percentile_approx(_as_col(col_or_name), percentage, accuracy)
 
 
 # --- String functions (native-backed) ---

--- a/tests/dataframe/test_issue_1599_percentile_approx_string_col.py
+++ b/tests/dataframe/test_issue_1599_percentile_approx_string_col.py
@@ -1,0 +1,37 @@
+"""
+Tests for issue #1599: percentile_approx with string column name.
+
+PySpark accepts str or Column for the first argument; sparkless previously
+required PyColumn and raised TypeError for strings.
+"""
+
+from __future__ import annotations
+
+from sparkless.testing import get_imports
+
+F = get_imports().F
+
+
+def test_percentile_approx_string_column_name(spark) -> None:
+    """Exact scenario from issue #1599."""
+    df = spark.createDataFrame([(1, 10.0), (1, 20.0), (2, 30.0)], ["col1", "col2"])
+    rows = {
+        r["col1"]: r["col2_median"]
+        for r in df.groupBy("col1")
+        .agg(F.percentile_approx("col2", 0.5).alias("col2_median"))
+        .collect()
+    }
+    assert rows[1] == 15.0
+    assert rows[2] == 30.0
+
+
+def test_percentile_approx_column_object(spark) -> None:
+    """Column object argument should still work."""
+    df = spark.createDataFrame([(1, 10.0), (1, 20.0)], ["col1", "col2"])
+    rows = {
+        r["col1"]: r["col2_median"]
+        for r in df.groupBy("col1")
+        .agg(F.percentile_approx(F.col("col2"), 0.5).alias("col2_median"))
+        .collect()
+    }
+    assert rows[1] == 15.0


### PR DESCRIPTION
## Summary
- Fixes `F.percentile_approx("col2", 0.5)` raising `TypeError: argument 'col': 'str' object cannot be converted to 'PyColumn'`
- Wraps the native `percentile_approx` with `_as_col()` like `sum`, `avg`, and other aggregate functions

## Test plan
- [x] `pytest tests/dataframe/test_issue_1599_percentile_approx_string_col.py`
- [x] `make check-full`

Fixes #1599