### PR TITLE
Fix Row integer indexing via head() (fixes #1600)

### DIFF
--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -5026,24 +5026,19 @@ impl PyDataFrame {
         self.inner.count().map_err(to_py_err)
     }
 
-    /// PySpark parity: head() returns a DataFrame (so .collect() works); head(n) returns list of Row.
-    /// (issue #413/#1077, #1109 delta schema evolution tests)
+    /// PySpark parity: head() returns the first Row (or None if empty); head(n) returns a list of Row.
     #[pyo3(signature = (n=None))]
     fn head(&self, py: Python<'_>, n: Option<usize>) -> PyResult<PyObject> {
         let k = n.unwrap_or(1);
         let limited = self.inner.limit(k).map_err(to_py_err)?;
+        let limited_py = PyDataFrame::wrap(limited);
+        let rows = limited_py.collect(py)?;
         match n {
-            Some(_) => {
-                // head(n) -> list of Row (PySpark parity for upstream tests e.g. test_delta_lake_schema_evolution)
-                let limited_py = PyDataFrame::wrap(limited);
-                let rows = limited_py.collect(py)?;
-                Ok(PyList::new(py, rows)?.into_py_any(py)?)
-            }
-            None => {
-                // head() -> DataFrame so .collect() can be called (issue #413)
-                let limited_py = PyDataFrame::wrap(limited);
-                Ok(limited_py.into_py_any(py)?)
-            }
+            Some(_) => Ok(PyList::new(py, rows)?.into_py_any(py)?),
+            None => Ok(rows
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| py.None().into_any())),
         }
     }
 

--- a/tests/dataframe/test_issue_1600_row_integer_index.py
+++ b/tests/dataframe/test_issue_1600_row_integer_index.py
@@ -1,0 +1,35 @@
+"""
+Tests for issue #1600: Row integer indexing after head()/collect().
+
+PySpark Row supports row[0] positional access; sparkless head() previously
+returned a DataFrame so head()[0] failed with a TypeError.
+"""
+
+from __future__ import annotations
+
+from sparkless.testing import get_imports
+
+F = get_imports().F
+Row = get_imports().Row
+
+
+def test_head_row_integer_index(spark) -> None:
+    """Exact scenario from issue #1600."""
+    result = spark.range(1).select(F.lit("hello").alias("col1")).head()[0]
+    assert result == "hello"
+
+
+def test_collect_row_integer_index(spark) -> None:
+    """collect()[0] positional access on Row."""
+    row = spark.createDataFrame([("A", 1), ("B", 2)], ["name", "value"]).collect()[0]
+    assert isinstance(row, Row)
+    assert row[0] == "A"
+    assert row[1] == 1
+
+
+def test_head_returns_row_not_dataframe(spark) -> None:
+    """head() without n returns a Row (PySpark parity)."""
+    row = spark.createDataFrame([{"x": 1}, {"x": 2}]).head()
+    assert isinstance(row, Row)
+    assert row["x"] == 1
+    assert row[0] == 1

--- a/tests/dataframe/test_issue_413_head.py
+++ b/tests/dataframe/test_issue_413_head.py
@@ -7,10 +7,14 @@ from __future__ import annotations
 
 def test_head_default_one_row(spark) -> None:
     """df.head() returns first row (default n=1)."""
+    from sparkless.testing import get_imports
+
+    Row = get_imports().Row
     df = spark.createDataFrame([{"x": 1}, {"x": 2}, {"x": 3}])
     row = df.head()
-    assert row is not None
+    assert isinstance(row, Row)
     assert row["x"] == 1
+    assert row[0] == 1
 
 
 def test_head_n(spark) -> None:


### PR DESCRIPTION
## Summary
- Fixes `df.head()[0]` raising `TypeError: __getitem__ expects a column name (str)`
- `head()` now returns the first `Row` (or `None` if empty), matching PySpark — previously it returned a limited `DataFrame`, so `[0]` hit DataFrame column indexing instead of Row positional indexing
- Row integer indexing via `collect()[0][0]` already worked; this aligns `head()` with `first()` and PySpark

## Test plan
- [x] `pytest tests/dataframe/test_issue_1600_row_integer_index.py tests/dataframe/test_issue_413_head.py`
- [x] `make check-full`

Fixes #1600