### PR TITLE
Fix json_tuple in withColumn (fixes #1601)

### DIFF
--- a/python/sparkless/sparkless/sql/functions.py
+++ b/python/sparkless/sparkless/sql/functions.py
@@ -1451,10 +1451,14 @@ def get_json_object(column, path):
     return _get_json_object(_as_col(column), path)
 
 
-def json_tuple(column: ColumnOrName, *keys: str) -> Tuple[_ColumnType, ...]:
+def json_tuple(
+    column: ColumnOrName, *keys: str
+) -> Union[_ColumnType, Tuple[_ColumnType, ...]]:
     """Extract keys from JSON as columns (PySpark json_tuple).
 
     Returns one string column per key, named c0, c1, ... in the order of keys.
+    With a single key, returns one Column (for withColumn); multiple keys return a tuple
+    that select() flattens into separate columns.
     """
     if not keys:
         raise ValueError("json_tuple requires at least one key")
@@ -1467,6 +1471,8 @@ def json_tuple(column: ColumnOrName, *keys: str) -> Tuple[_ColumnType, ...]:
         # the expected unnamed columns.
         c = tcast(_ColumnType, get_json_object(column, f"$.{key}"))
         cols.append(c.alias(f"c{idx}"))
+    if len(cols) == 1:
+        return cols[0]
     # df.select() flattens tuples/lists of Columns, so returning a tuple here
     # produces multiple top-level columns matching PySpark's json_tuple behavior.
     return tuple(cols)

--- a/tests/dataframe/test_issue_1601_json_tuple_withcolumn.py
+++ b/tests/dataframe/test_issue_1601_json_tuple_withcolumn.py
@@ -1,0 +1,43 @@
+"""
+Tests for issue #1601: json_tuple in withColumn.
+
+PySpark accepts json_tuple with a single key in withColumn; sparkless previously
+returned a tuple and raised TypeError in withColumn.
+"""
+
+from __future__ import annotations
+
+from sparkless.testing import get_imports
+
+F = get_imports().F
+
+
+def test_json_tuple_with_column_single_key(spark) -> None:
+    """Exact scenario from issue #1601."""
+    df = spark.createDataFrame(
+        [('{"col1": "100", "col2": "200"}',)],
+        ["col_json"],
+    )
+    row = df.withColumn("col_val", F.json_tuple(F.col("col_json"), "col1")).collect()[0]
+    assert row["col_val"] == "100"
+
+
+def test_json_tuple_select_multiple_keys(spark) -> None:
+    """Multi-key json_tuple still expands in select."""
+    df = spark.createDataFrame(
+        [('{"name": "Alice", "age": "25"}',)],
+        ["j"],
+    )
+    row = df.select(F.json_tuple("j", "name", "age")).collect()[0]
+    assert row["c0"] == "Alice"
+    assert row["c1"] == "25"
+
+
+def test_json_tuple_select_single_key(spark) -> None:
+    """Single-key json_tuple in select still works."""
+    df = spark.createDataFrame(
+        [('{"col1": "100"}',)],
+        ["col_json"],
+    )
+    row = df.select(F.json_tuple("col_json", "col1")).collect()[0]
+    assert row["c0"] == "100"


### PR DESCRIPTION
## Summary
- Fixes `df.withColumn("col_val", F.json_tuple(F.col("col_json"), "col1"))` raising `TypeError: withColumn expects a Column or expr() result`
- `json_tuple` with a single key now returns a `Column` instead of a 1-tuple; multiple keys still return a tuple for `select()` flattening

## Test plan
- [x] `pytest tests/dataframe/test_issue_1601_json_tuple_withcolumn.py`
- [x] `make check-full`

Fixes #1601