### PR TITLE
Fix expr() inside agg() for percentile_approx (fixes #1602)

### DIFF
--- a/crates/robin-sparkless-polars/src/dataframe/aggregations.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/aggregations.rs
@@ -829,6 +829,11 @@ impl GroupedData {
         &self.grouping_cols
     }
 
+    /// Input DataFrame before grouping (for expr() column resolution in agg).
+    pub fn input_dataframe(&self) -> DataFrame {
+        super::DataFrame::from_lazy_with_options(self.lf.clone(), self.case_sensitive)
+    }
+
     /// Pivot a column for pivot-table aggregation (PySpark: groupBy(...).pivot(pivot_col).sum(value_col)).
     /// Returns PivotedGroupedData; call .sum(column), .avg(column), etc. to run the aggregation.
     pub fn pivot(&self, pivot_col: &str, values: Option<Vec<String>>) -> PivotedGroupedData {
@@ -1345,6 +1350,11 @@ pub struct CubeRollupData {
 }
 
 impl CubeRollupData {
+    /// Input DataFrame before cube/rollup (for expr() column resolution in agg).
+    pub fn input_dataframe(&self) -> DataFrame {
+        super::DataFrame::from_lazy_with_options(self.lf.clone(), self.case_sensitive)
+    }
+
     /// Count rows per grouping set (PySpark cube/rollup .count()).
     pub fn count(&self) -> Result<DataFrame, PolarsError> {
         use polars::prelude::*;

--- a/crates/robin-sparkless-polars/src/sql/translator.rs
+++ b/crates/robin-sparkless-polars/src/sql/translator.rs
@@ -1468,6 +1468,20 @@ fn sql_function_to_expr(
 
     let case_sensitive = session.is_case_sensitive();
 
+    if matches!(
+        func_name.to_uppercase().as_str(),
+        "PERCENTILE_APPROX" | "APPROX_PERCENTILE"
+    ) && args.len() >= 2
+    {
+        let pct = sql_parse_f64_literal(sql_function_unnamed_expr(
+            function_args_slice(&func.args),
+            1,
+        )?)?;
+        return Ok(functions::approx_percentile(&args[0], pct, None)
+            .expr()
+            .clone());
+    }
+
     // Built-in scalar functions (single-column arg)
     if let Some(col) = args.first() {
         let builtin_expr = match func_name.to_uppercase().as_str() {
@@ -1622,6 +1636,27 @@ fn sql_parse_i64_literal(expr: &SqlExpr) -> Result<i64, PolarsError> {
         SqlExpr::Nested(inner) => sql_parse_i64_literal(inner.as_ref()),
         _ => Err(PolarsError::InvalidOperation(
             format!("SQL: expected integer literal, got {:?}", expr).into(),
+        )),
+    }
+}
+
+fn sql_parse_f64_literal(expr: &SqlExpr) -> Result<f64, PolarsError> {
+    use spark_sql_parser::ast::UnaryOperator;
+    match expr {
+        SqlExpr::Value(ValueWithSpan {
+            value: Value::Number(s, _),
+            ..
+        }) => match parse_sql_number_val(s, "float literal")? {
+            SqlNumberVal::Int(i) => Ok(i as f64),
+            SqlNumberVal::Float(f) => Ok(f),
+        },
+        SqlExpr::UnaryOp {
+            op: UnaryOperator::Minus,
+            expr: inner,
+        } => Ok(-sql_parse_f64_literal(inner)?),
+        SqlExpr::Nested(inner) => sql_parse_f64_literal(inner.as_ref()),
+        _ => Err(PolarsError::InvalidOperation(
+            format!("SQL: expected float literal, got {:?}", expr).into(),
         )),
     }
 }
@@ -2235,6 +2270,27 @@ fn push_agg_function(
                     "SQL: MAX requires one expression argument.".into(),
                 ));
             }
+        }
+        "PERCENTILE_APPROX" | "APPROX_PERCENTILE" => {
+            if args.len() < 2 {
+                return Err(PolarsError::InvalidOperation(
+                    "SQL: percentile_approx requires column and percentage arguments.".into(),
+                ));
+            }
+            let col_arg = sql_function_unnamed_expr(args, 0)?;
+            let inner = sql_expr_to_polars(col_arg, session, Some(df), None, None)?;
+            let pct = sql_parse_f64_literal(sql_function_unnamed_expr(args, 1)?)?;
+            let default = match col_arg {
+                SqlExpr::Identifier(ident) => {
+                    format!("percentile_approx({}, {})", ident.value, pct)
+                }
+                _ => format!("percentile_approx({pct})"),
+            };
+            let col = Column::from_expr(inner, None);
+            (
+                functions::approx_percentile(&col, pct, None).into_expr(),
+                default,
+            )
         }
         _ => {
             return Err(PolarsError::InvalidOperation(

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -8050,35 +8050,46 @@ impl PyCubeRollupData {
     }
 
     #[pyo3(signature = (*exprs))]
-    fn agg(&self, exprs: &Bound<'_, PyTuple>) -> PyResult<PyDataFrame> {
-        fn push_expr(
-            item: &Bound<'_, PyAny>,
-            out: &mut Vec<robin_sparkless::Expr>,
-        ) -> PyResult<()> {
-            if let Ok(c) = item.cast::<PyColumn>() {
-                out.push(c.borrow().inner.clone().into_expr());
-                return Ok(());
+    fn agg(&self, py: Python<'_>, exprs: &Bound<'_, PyTuple>) -> PyResult<PyDataFrame> {
+        let mut needs_expr_ctx = false;
+        for item in exprs.iter() {
+            if py_agg_item_contains_expr_str(&item)? {
+                needs_expr_ctx = true;
+                break;
             }
-            if let Ok(list) = item.cast::<PyList>() {
-                for sub in list.iter() {
-                    push_expr(&sub, out)?;
-                }
-                return Ok(());
-            }
-            if let Ok(tup) = item.cast::<PyTuple>() {
-                for sub in tup.iter() {
-                    push_expr(&sub, out)?;
-                }
-                return Ok(());
-            }
-            Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
-                "agg() expects Column expressions",
-            ))
         }
 
         let mut rust_exprs: Vec<robin_sparkless::Expr> = Vec::new();
-        for item in exprs.iter() {
-            push_expr(&item, &mut rust_exprs)?;
+        if needs_expr_ctx {
+            let session = THREAD_ACTIVE_SESSIONS
+                .with(|cell| cell.borrow().last().map(|s| s.clone_ref(py)))
+                .ok_or_else(|| {
+                    PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
+                        "agg() with expr() requires an active SparkSession",
+                    )
+                })?;
+            let session_ref = session.bind(py).cast::<PySparkSession>().map_err(|_| {
+                PyErr::new::<pyo3::exceptions::PyTypeError, _>("expected SparkSession")
+            })?;
+            let input_df = self.inner.input_dataframe();
+            session_ref
+                .borrow()
+                .inner
+                .create_or_replace_temp_view("__agg_expr_t", input_df.clone());
+            let expr_ctx = (session_ref.clone(), input_df);
+            for item in exprs.iter() {
+                py_agg_push_expr(
+                    &item,
+                    &mut rust_exprs,
+                    false,
+                    Some((&expr_ctx.0, &expr_ctx.1)),
+                )?;
+            }
+            let _ = session_ref.borrow().inner.drop_temp_view("__agg_expr_t");
+        } else {
+            for item in exprs.iter() {
+                py_agg_push_expr(&item, &mut rust_exprs, false, None)?;
+            }
         }
         self.inner
             .agg(rust_exprs)
@@ -8147,61 +8158,46 @@ impl PyGroupedData {
     }
 
     #[pyo3(signature = (*exprs))]
-    fn agg(&self, exprs: &Bound<'_, PyTuple>) -> PyResult<PyDataFrame> {
-        fn push_expr(
-            item: &Bound<'_, PyAny>,
-            out: &mut Vec<robin_sparkless::Expr>,
-        ) -> PyResult<()> {
-            if let Ok(c) = item.cast::<PyColumn>() {
-                out.push(c.borrow().inner.clone().into_expr());
-                return Ok(());
+    fn agg(&self, py: Python<'_>, exprs: &Bound<'_, PyTuple>) -> PyResult<PyDataFrame> {
+        let mut needs_expr_ctx = false;
+        for item in exprs.iter() {
+            if py_agg_item_contains_expr_str(&item)? {
+                needs_expr_ctx = true;
+                break;
             }
-            if let Ok(list) = item.cast::<PyList>() {
-                for sub in list.iter() {
-                    push_expr(&sub, out)?;
-                }
-                return Ok(());
-            }
-            if let Ok(tup) = item.cast::<PyTuple>() {
-                for sub in tup.iter() {
-                    push_expr(&sub, out)?;
-                }
-                return Ok(());
-            }
-            if let Ok(dict) = item.cast::<PyDict>() {
-                for (k, v) in dict.iter() {
-                    let col_name: String = k.extract().map_err(|_| {
-                        PyErr::new::<pyo3::exceptions::PyTypeError, _>("agg dict keys must be str")
-                    })?;
-                    let func_name: String = v.extract().map_err(|_| {
-                        PyErr::new::<pyo3::exceptions::PyTypeError, _>(
-                            "agg dict values must be str",
-                        )
-                    })?;
-                    let c = Column::new(col_name);
-                    let expr_col = match func_name.as_str() {
-                        "sum" => functions::sum(&c),
-                        "avg" | "mean" => functions::avg(&c),
-                        "min" => functions::min(&c),
-                        "max" => functions::max(&c),
-                        "count" => functions::count(&c),
-                        "first" => c, // best effort
-                        _ => {
-                            return Err(to_py_err(format!("unsupported agg function: {func_name}")))
-                        }
-                    };
-                    out.push(expr_col.into_expr());
-                }
-                return Ok(());
-            }
-            Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
-                "agg() expects Column expressions or dict",
-            ))
         }
 
         let mut rust_exprs: Vec<robin_sparkless::Expr> = Vec::new();
-        for item in exprs.iter() {
-            push_expr(&item, &mut rust_exprs)?;
+        if needs_expr_ctx {
+            let session = THREAD_ACTIVE_SESSIONS
+                .with(|cell| cell.borrow().last().map(|s| s.clone_ref(py)))
+                .ok_or_else(|| {
+                    PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
+                        "agg() with expr() requires an active SparkSession",
+                    )
+                })?;
+            let session_ref = session.bind(py).cast::<PySparkSession>().map_err(|_| {
+                PyErr::new::<pyo3::exceptions::PyTypeError, _>("expected SparkSession")
+            })?;
+            let input_df = self.inner.input_dataframe();
+            session_ref
+                .borrow()
+                .inner
+                .create_or_replace_temp_view("__agg_expr_t", input_df.clone());
+            let expr_ctx = (session_ref.clone(), input_df);
+            for item in exprs.iter() {
+                py_agg_push_expr(
+                    &item,
+                    &mut rust_exprs,
+                    true,
+                    Some((&expr_ctx.0, &expr_ctx.1)),
+                )?;
+            }
+            let _ = session_ref.borrow().inner.drop_temp_view("__agg_expr_t");
+        } else {
+            for item in exprs.iter() {
+                py_agg_push_expr(&item, &mut rust_exprs, true, None)?;
+            }
         }
         self.inner
             .agg(rust_exprs)
@@ -8715,6 +8711,96 @@ fn py_any_to_dataframe_column(col_any: &Bound<'_, PyAny>) -> PyResult<Option<Col
         ));
     }
     Ok(None)
+}
+
+fn py_agg_item_contains_expr_str(item: &Bound<'_, PyAny>) -> PyResult<bool> {
+    if item.cast::<PyExprStr>().is_ok() {
+        return Ok(true);
+    }
+    if let Ok(list) = item.cast::<PyList>() {
+        for sub in list.iter() {
+            if py_agg_item_contains_expr_str(&sub)? {
+                return Ok(true);
+            }
+        }
+    }
+    if let Ok(tup) = item.cast::<PyTuple>() {
+        for sub in tup.iter() {
+            if py_agg_item_contains_expr_str(&sub)? {
+                return Ok(true);
+            }
+        }
+    }
+    Ok(false)
+}
+
+fn py_agg_push_expr(
+    item: &Bound<'_, PyAny>,
+    out: &mut Vec<robin_sparkless::Expr>,
+    allow_dict: bool,
+    expr_ctx: Option<(&Bound<'_, PySparkSession>, &robin_sparkless::DataFrame)>,
+) -> PyResult<()> {
+    if let Ok(c) = item.cast::<PyColumn>() {
+        out.push(c.borrow().inner.clone().into_expr());
+        return Ok(());
+    }
+    if let Ok(py_expr_str) = item.cast::<PyExprStr>() {
+        let (session_ref, input_df) = expr_ctx.ok_or_else(|| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
+                "agg() with expr() requires an active SparkSession",
+            )
+        })?;
+        let expr = robin_sparkless::sql::expr_string_to_polars(
+            &py_expr_str.borrow().sql,
+            &session_ref.borrow().inner,
+            input_df,
+        )
+        .map_err(to_py_err)?;
+        out.push(expr);
+        return Ok(());
+    }
+    if let Ok(list) = item.cast::<PyList>() {
+        for sub in list.iter() {
+            py_agg_push_expr(&sub, out, allow_dict, expr_ctx)?;
+        }
+        return Ok(());
+    }
+    if let Ok(tup) = item.cast::<PyTuple>() {
+        for sub in tup.iter() {
+            py_agg_push_expr(&sub, out, allow_dict, expr_ctx)?;
+        }
+        return Ok(());
+    }
+    if allow_dict {
+        if let Ok(dict) = item.cast::<PyDict>() {
+            for (k, v) in dict.iter() {
+                let col_name: String = k.extract().map_err(|_| {
+                    PyErr::new::<pyo3::exceptions::PyTypeError, _>("agg dict keys must be str")
+                })?;
+                let func_name: String = v.extract().map_err(|_| {
+                    PyErr::new::<pyo3::exceptions::PyTypeError, _>("agg dict values must be str")
+                })?;
+                let c = Column::new(col_name);
+                let expr_col = match func_name.as_str() {
+                    "sum" => functions::sum(&c),
+                    "avg" | "mean" => functions::avg(&c),
+                    "min" => functions::min(&c),
+                    "max" => functions::max(&c),
+                    "count" => functions::count(&c),
+                    "first" => c, // best effort
+                    _ => return Err(to_py_err(format!("unsupported agg function: {func_name}"))),
+                };
+                out.push(expr_col.into_expr());
+            }
+            return Ok(());
+        }
+    }
+    let msg = if allow_dict {
+        "agg() expects Column expressions or dict"
+    } else {
+        "agg() expects Column expressions"
+    };
+    Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(msg))
 }
 
 #[pyfunction]

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -865,6 +865,11 @@ impl GroupedData {
     pub fn pivot(&self, pivot_col: &str, values: Option<Vec<String>>) -> PivotedGroupedData {
         PivotedGroupedData(self.0.pivot(pivot_col, values))
     }
+
+    /// Input DataFrame before grouping (for expr() column resolution in agg).
+    pub fn input_dataframe(&self) -> DataFrame {
+        DataFrame(self.0.input_dataframe())
+    }
 }
 
 impl CubeRollupData {
@@ -890,6 +895,11 @@ impl CubeRollupData {
 
     pub fn agg(&self, exprs: Vec<Expr>) -> Result<DataFrame, PolarsError> {
         self.0.agg(exprs).map(DataFrame)
+    }
+
+    /// Input DataFrame before cube/rollup (for expr() column resolution in agg).
+    pub fn input_dataframe(&self) -> DataFrame {
+        DataFrame(self.0.input_dataframe())
     }
 }
 

--- a/tests/dataframe/test_issue_1602_expr_in_agg.py
+++ b/tests/dataframe/test_issue_1602_expr_in_agg.py
@@ -1,0 +1,25 @@
+"""
+Tests for issue #1602: expr() inside agg().
+
+PySpark accepts F.expr() SQL strings as aggregation expressions; sparkless
+previously raised TypeError: agg() expects Column expressions or dict.
+"""
+
+from __future__ import annotations
+
+from sparkless.testing import get_imports
+
+F = get_imports().F
+
+
+def test_expr_percentile_approx_in_groupby_agg(spark) -> None:
+    """Exact scenario from issue #1602."""
+    df = spark.createDataFrame([(1, 10.0), (1, 20.0), (2, 30.0)], ["col1", "col2"])
+    rows = {
+        r["col1"]: r["col2_median"]
+        for r in df.groupBy("col1")
+        .agg(F.expr("percentile_approx(col2, 0.5)").alias("col2_median"))
+        .collect()
+    }
+    assert rows[1] == 15.0
+    assert rows[2] == 30.0


### PR DESCRIPTION
## Summary
- Accept `F.expr()` (`PyExprStr`) in `groupBy().agg()` and `cube()`/`rollup().agg()`, resolving SQL expressions via a temp view like `select()` and `withColumn()` do
- Add SQL translator support for `percentile_approx` / `approx_percentile` in expression and GROUP BY aggregation paths
- Add regression test reproducing the exact scenario from #1602

## Test plan
- [x] `pytest tests/dataframe/test_issue_1602_expr_in_agg.py`
- [x] `make check-full`

Fixes #1602