### PR TITLE
Fix createDataFrame DDL schema with all-null columns (fixes #1603)

### DIFF
--- a/crates/robin-sparkless-polars/src/session/mod.rs
+++ b/crates/robin-sparkless-polars/src/session/mod.rs
@@ -2189,7 +2189,9 @@ impl SparkSession {
         }
         // #624: When schema is only column names (all "string"), infer from data (PySpark parity).
         // #731, #769, #772: createDataFrame(rows, ["name", "age"]) yields int/double/bool columns.
-        let schema_inferred_in_rust = !schema.is_empty()
+        // Only when Python did not pass explicit types (#1603: DDL "col1 string, col2 string" must not re-infer).
+        let schema_inferred_in_rust = schema_was_inferred
+            && !schema.is_empty()
             && !rows.is_empty()
             && schema
                 .iter()

--- a/tests/dataframe/test_issue_1603_ddl_schema_null_values.py
+++ b/tests/dataframe/test_issue_1603_ddl_schema_null_values.py
@@ -1,0 +1,37 @@
+"""
+Tests for issue #1603: createDataFrame with DDL schema and None values.
+
+PySpark uses the provided DDL schema and does not attempt type inference when
+a column is all null; sparkless previously raised ValueError.
+"""
+
+from __future__ import annotations
+
+
+def test_ddl_schema_with_all_null_column(spark) -> None:
+    """Exact scenario from issue #1603."""
+    schema = "col1 string, col2 string"
+    df = spark.createDataFrame([("A", None), ("B", None)], schema)
+    rows = df.collect()
+    assert len(rows) == 2
+    assert rows[0]["col1"] == "A"
+    assert rows[0]["col2"] is None
+    assert rows[1]["col1"] == "B"
+    assert rows[1]["col2"] is None
+
+
+def test_ddl_schema_colon_syntax_with_nulls(spark) -> None:
+    """DDL with colon separator should also respect explicit types."""
+    schema = "col1: string, col2: int"
+    df = spark.createDataFrame([("A", None), ("B", None)], schema)
+    rows = df.collect()
+    assert rows[0]["col1"] == "A"
+    assert rows[0]["col2"] is None
+
+
+def test_explicit_name_type_pairs_with_nulls(spark) -> None:
+    """List of (name, type) pairs is explicit schema, not names-only inference."""
+    schema = [("col1", "string"), ("col2", "string")]
+    df = spark.createDataFrame([("A", None), ("B", None)], schema)
+    rows = df.collect()
+    assert rows[0]["col2"] is None


### PR DESCRIPTION
## Summary
- When `createDataFrame` receives an explicit schema (DDL string or `(name, type)` pairs), do not re-infer types from data or reject all-null columns
- Names-only schema lists (`["col1", "col2"]`) still infer types and validate all-null columns as before

## Test plan
- [x] `pytest tests/dataframe/test_issue_1603_ddl_schema_null_values.py`
- [x] `make check-full`

Fixes #1603