### PR TITLE
Fix CI: aggregate cast-to-string column names

### DIFF
--- a/crates/robin-sparkless-polars/src/functions/rest.rs
+++ b/crates/robin-sparkless-polars/src/functions/rest.rs
@@ -1541,6 +1541,13 @@ fn cast_impl(column: &Column, type_name: &str, strict: bool) -> Result<Column, S
         return Ok(Column::from_expr(expr.alias(&base_name), Some(base_name)));
     }
     if dtype == DataType::String {
+        // Use strict_cast when expr is not a plain column (e.g. aggregate) so we get a Cast node
+        // and PySpark-style column name "CAST(avg(value) AS STRING)" in groupby agg (issue #1255, #265).
+        let is_plain_column = matches!(column.expr(), Expr::Column(_));
+        if !is_plain_column {
+            let expr = column.expr().clone().strict_cast(dtype);
+            return Ok(Column::from_expr(expr, Some(base_name)));
+        }
         let expr = column.expr().clone().map(
             move |col| {
                 crate::column::expect_col(crate::udfs::apply_cast_to_string(col, ansi_strict))


### PR DESCRIPTION
## Summary
- Fix failing `test_aggregate_cast_parity` CI tests caused by aggregate `.cast("string")` using a Map UDF instead of `Expr::Cast`
- Non-plain-column string casts now use `strict_cast`, matching the existing int/long aggregate cast path so groupBy agg columns are named `CAST(avg(value) AS STRING)` per PySpark parity (#265, #1255)

## Test plan
- [x] `pytest tests/parity/functions/test_aggregate_cast_parity.py`
- [x] `make check-full`