### PR TITLE
Fix CI: preserve #1603 fix and Rust schema inference

### DIFF
--- a/crates/robin-sparkless-polars/src/session/mod.rs
+++ b/crates/robin-sparkless-polars/src/session/mod.rs
@@ -2189,9 +2189,7 @@ impl SparkSession {
         }
         // #624: When schema is only column names (all "string"), infer from data (PySpark parity).
         // #731, #769, #772: createDataFrame(rows, ["name", "age"]) yields int/double/bool columns.
-        // Only when Python did not pass explicit types (#1603: DDL "col1 string, col2 string" must not re-infer).
-        let schema_inferred_in_rust = schema_was_inferred
-            && !schema.is_empty()
+        let schema_inferred_in_rust = !schema.is_empty()
             && !rows.is_empty()
             && schema
                 .iter()

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1802,6 +1802,15 @@ fn simple_string_to_type(s: &str) -> String {
     }
 }
 
+/// Explicit schema string types use "str" (not "string") so Rust does not re-infer from data (#1603).
+fn mark_explicit_schema_string_type(typ: String) -> String {
+    if typ.eq_ignore_ascii_case("string") {
+        "str".to_string()
+    } else {
+        typ
+    }
+}
+
 /// Parse DDL schema string (e.g. "name: string, age: int" or "a string, b int") into (name, type) pairs.
 fn parse_ddl_schema_string(ddl: &str) -> Vec<(String, String)> {
     fn split_top_level_commas(s: &str) -> Vec<String> {
@@ -1886,7 +1895,10 @@ fn parse_ddl_schema_string(ddl: &str) -> Vec<(String, String)> {
             }
         };
         if !name.is_empty() {
-            pairs.push((name, simple_string_to_type(&typ)));
+            pairs.push((
+                name,
+                mark_explicit_schema_string_type(simple_string_to_type(&typ)),
+            ));
         }
     }
     pairs
@@ -1973,7 +1985,10 @@ fn parse_schema_from_py(
             }
             let name = pair.get_item(0)?.extract::<String>()?;
             let typ = pair.get_item(1)?.extract::<String>()?;
-            pairs.push((name, simple_string_to_type(&typ)));
+            pairs.push((
+                name,
+                mark_explicit_schema_string_type(simple_string_to_type(&typ)),
+            ));
         }
         return Ok(Some(pairs));
     }


### PR DESCRIPTION
## Summary
- Revert the Rust `schema_was_inferred` guard from #1603 (it broke `test_create_dataframe_from_rows_all_string_schema_infers_types`)
- Fix #1603 at the Python layer instead: explicit DDL and `(name, type)` schemas map `string` → `str`, matching StructType behavior, so all-null columns with explicit types are accepted without re-inference

## Test plan
- [x] `pytest tests/dataframe/test_issue_1603_ddl_schema_null_values.py`
- [x] `pytest tests/parity/functions/test_aggregate_cast_parity.py`
- [x] `cargo test --workspace --features sql`