### PR TITLE
Fix SQL built-in functions not recognized in spark.sql() (#1638)

### DIFF
--- a/crates/robin-sparkless-polars/src/functions/rest.rs
+++ b/crates/robin-sparkless-polars/src/functions/rest.rs
@@ -2561,8 +2561,11 @@ pub fn coalesce(columns: &[&Column]) -> Result<Column, PolarsError> {
 /// Alias for coalesce(col, value). PySpark nvl / ifnull.
 pub fn nvl(column: &Column, value: &Column) -> Column {
     use polars::prelude::*;
-    let exprs = vec![column.expr().clone(), value.expr().clone()];
-    crate::column::Column::from_expr(coalesce(&exprs), None)
+    let cond = column.expr().clone().is_null();
+    let expr = when(cond)
+        .then(value.expr().clone())
+        .otherwise(column.expr().clone());
+    crate::column::Column::from_expr(expr, None)
 }
 
 /// Alias for nvl. PySpark ifnull.

--- a/crates/robin-sparkless-polars/src/sql/mod.rs
+++ b/crates/robin-sparkless-polars/src/sql/mod.rs
@@ -513,6 +513,97 @@ mod tests {
         );
     }
 
+    /// Issue #1638: standard Spark SQL scalar built-ins in spark.sql().
+    #[test]
+    fn test_sql_builtin_scalar_functions_issue_1638() {
+        use serde_json::json;
+        let spark = SparkSession::builder().app_name("test").get_or_create();
+        let schema = vec![
+            ("col1".to_string(), "bigint".to_string()),
+            ("col2".to_string(), "double".to_string()),
+            ("col3".to_string(), "string".to_string()),
+        ];
+        let rows = vec![
+            vec![json!(1), json!(10.0), json!("abc-123")],
+            vec![json!(2), json!(100.0), json!("xy")],
+            vec![json!(3), json!(null), json!("z")],
+        ];
+        let df = spark
+            .create_dataframe_from_rows(rows, schema, false, false)
+            .unwrap();
+        spark.create_or_replace_temp_view("tbl", df);
+
+        let coalesce = spark
+            .sql("SELECT coalesce(col2, 0) AS c FROM tbl WHERE col1 = 2")
+            .unwrap();
+        let rows = coalesce.collect_as_json_rows().unwrap();
+        assert_eq!(rows[0].get("c").and_then(|v| v.as_f64()), Some(100.0));
+
+        let nvl = spark
+            .sql("SELECT nvl(col2, 0) AS n FROM tbl WHERE col1 = 3")
+            .unwrap();
+        let rows = nvl.collect_as_json_rows().unwrap();
+        assert_eq!(rows.len(), 1, "expected one row for col1=3, got {:?}", rows);
+        let n_val = rows[0].get("n");
+        assert!(
+            n_val.and_then(|v| v.as_i64()) == Some(0)
+                || n_val.and_then(|v| v.as_f64()) == Some(0.0),
+            "nvl(col2, 0) expected 0, got {:?}",
+            n_val
+        );
+
+        let log10 = spark
+            .sql("SELECT log10(col2) AS l FROM tbl WHERE col1 = 2")
+            .unwrap();
+        let rows = log10.collect_as_json_rows().unwrap();
+        assert!((rows[0].get("l").and_then(|v| v.as_f64()).unwrap() - 2.0).abs() < 1e-9);
+
+        let log_nat = spark
+            .sql("SELECT log(col2) AS l FROM tbl WHERE col1 = 2")
+            .unwrap();
+        let rows = log_nat.collect_as_json_rows().unwrap();
+        assert!(
+            (rows[0].get("l").and_then(|v| v.as_f64()).unwrap() - 100.0_f64.ln()).abs() < 1e-9
+        );
+
+        let log_base = spark
+            .sql("SELECT log(10, col2) AS l FROM tbl WHERE col1 = 2")
+            .unwrap();
+        let rows = log_base.collect_as_json_rows().unwrap();
+        assert!((rows[0].get("l").and_then(|v| v.as_f64()).unwrap() - 2.0).abs() < 1e-9);
+
+        let log2 = spark
+            .sql("SELECT log2(col2) AS l FROM tbl WHERE col1 = 2")
+            .unwrap();
+        let rows = log2.collect_as_json_rows().unwrap();
+        let expected_log2 = 100.0_f64.log2();
+        assert!((rows[0].get("l").and_then(|v| v.as_f64()).unwrap() - expected_log2).abs() < 1e-9);
+
+        let pow = spark
+            .sql("SELECT pow(col2, 2) AS p FROM tbl WHERE col1 = 1")
+            .unwrap();
+        let rows = pow.collect_as_json_rows().unwrap();
+        assert!((rows[0].get("p").and_then(|v| v.as_f64()).unwrap() - 100.0).abs() < 1e-9);
+
+        let mod_ = spark
+            .sql("SELECT mod(col1, 3) AS m FROM tbl WHERE col1 = 1")
+            .unwrap();
+        let rows = mod_.collect_as_json_rows().unwrap();
+        assert!((rows[0].get("m").and_then(|v| v.as_f64()).unwrap() - 1.0).abs() < 1e-9);
+
+        let regexp = spark
+            .sql(r#"SELECT regexp_extract(col3, '([0-9]+)', 1) AS r FROM tbl WHERE col1 = 1"#)
+            .unwrap();
+        let rows = regexp.collect_as_json_rows().unwrap();
+        assert_eq!(rows[0].get("r").and_then(|v| v.as_str()), Some("123"));
+
+        let len = spark
+            .sql("SELECT len(col3) AS l FROM tbl WHERE col1 = 1")
+            .unwrap();
+        let rows = len.collect_as_json_rows().unwrap();
+        assert_eq!(rows[0].get("l").and_then(|v| v.as_i64()), Some(7));
+    }
+
     /// Issue #1562: double-quoted format literal in spark.sql to_date().
     #[test]
     fn test_sql_to_date_double_quoted_format() {

--- a/crates/robin-sparkless-polars/src/sql/translator.rs
+++ b/crates/robin-sparkless-polars/src/sql/translator.rs
@@ -1420,6 +1420,84 @@ fn sql_expr_to_polars(
     }
 }
 
+/// Resolve SQL scalar built-ins to Polars Expr. Returns None if not a known built-in.
+fn sql_scalar_builtin_to_expr(
+    func_name: &str,
+    func: &Function,
+    args: &[Column],
+) -> Result<Option<Expr>, PolarsError> {
+    let name = func_name.to_uppercase();
+    let arg_exprs = function_args_slice(&func.args);
+
+    let expr = match name.as_str() {
+        "COALESCE" if !args.is_empty() => {
+            let refs: Vec<&Column> = args.iter().collect();
+            functions::coalesce(&refs)?.expr().clone()
+        }
+        "NVL" | "IFNULL" if args.len() == 2 => {
+            functions::nvl(&args[0], &args[1]).expr().clone()
+        }
+        "LOG10" if args.len() == 1 => functions::log10(&args[0]).expr().clone(),
+        "LOG2" if args.len() == 1 => functions::log2(&args[0]).expr().clone(),
+        "LOG" | "LN" if args.len() == 1 => functions::log(&args[0]).expr().clone(),
+        "LOG" if args.len() == 2 => {
+            // Spark SQL / PySpark: log(base, expr)
+            let base = sql_parse_f64_literal(sql_function_unnamed_expr(arg_exprs, 0)?)?;
+            functions::log_with_base(&args[1], base).expr().clone()
+        }
+        "POW" | "POWER" if args.len() == 2 => {
+            if let Ok(exp) = sql_parse_i64_literal(sql_function_unnamed_expr(arg_exprs, 1)?) {
+                functions::pow(&args[0], exp).expr().clone()
+            } else {
+                args[0].pow_with(&args[1]).expr().clone()
+            }
+        }
+        "MOD" if args.len() == 2 => args[0].mod_pyspark(&args[1]).expr().clone(),
+        "REGEXP_EXTRACT" if args.len() >= 2 => {
+            let pattern = sql_expr_to_string_literal(sql_function_unnamed_expr(arg_exprs, 1)?)?;
+            let idx = if args.len() >= 3 {
+                sql_parse_i64_literal(sql_function_unnamed_expr(arg_exprs, 2)?)? as usize
+            } else {
+                1
+            };
+            functions::regexp_extract(&args[0], &pattern, idx).expr().clone()
+        }
+        "LENGTH" | "LEN" | "CHAR_LENGTH" if args.len() == 1 => {
+            functions::length(&args[0]).expr().clone()
+        }
+        "UPPER" | "UCASE" if args.len() == 1 => functions::upper(&args[0]).expr().clone(),
+        "LOWER" | "LCASE" if args.len() == 1 => functions::lower(&args[0]).expr().clone(),
+        "TRIM" if args.len() == 1 => functions::trim(&args[0]).expr().clone(),
+        "LTRIM" if args.len() == 1 => functions::ltrim(&args[0]).expr().clone(),
+        "RTRIM" if args.len() == 1 => functions::rtrim(&args[0]).expr().clone(),
+        "SUBSTRING" | "SUBSTR" if args.len() >= 2 => {
+            let col = &args[0];
+            let start = sql_parse_i64_literal(sql_function_unnamed_expr(arg_exprs, 1)?)?;
+            let len = if args.len() >= 3 {
+                Some(sql_parse_i64_literal(sql_function_unnamed_expr(arg_exprs, 2)?)?)
+            } else {
+                None
+            };
+            functions::substring(col, start, len).expr().clone()
+        }
+        "REGEXP_REPLACE" if args.len() == 3 => {
+            use polars::prelude::DataType;
+            args[0]
+                .expr()
+                .clone()
+                .cast(DataType::String)
+                .str()
+                .replace_all(
+                    args[1].expr().clone().cast(DataType::String),
+                    args[2].expr().clone().cast(DataType::String),
+                    false,
+                )
+        }
+        _ => return Ok(None),
+    };
+    Ok(Some(expr))
+}
+
 /// Convert SQL function call to Polars Expr. Supports built-ins (UPPER, LOWER, etc.) and UDFs.
 /// For Python UDF in WHERE/HAVING we cannot return a lazy Expr; returns error (Python UDF in
 /// predicates requires eager materialization - deferred).
@@ -1482,39 +1560,8 @@ fn sql_function_to_expr(
             .clone());
     }
 
-    // Built-in scalar functions (single-column arg)
-    if let Some(col) = args.first() {
-        let builtin_expr = match func_name.to_uppercase().as_str() {
-            "UPPER" | "UCASE" if args.len() == 1 => Some(functions::upper(col).expr().clone()),
-            "LOWER" | "LCASE" if args.len() == 1 => Some(functions::lower(col).expr().clone()),
-            "TRIM" if args.len() == 1 => Some(functions::trim(col).expr().clone()),
-            "LTRIM" if args.len() == 1 => Some(functions::ltrim(col).expr().clone()),
-            "RTRIM" if args.len() == 1 => Some(functions::rtrim(col).expr().clone()),
-            "SUBSTRING" | "SUBSTR" if args.len() >= 2 => {
-                let arg_exprs = function_args_slice(&func.args);
-                let start = sql_parse_i64_literal(sql_function_unnamed_expr(arg_exprs, 1)?)?;
-                let len = if args.len() >= 3 {
-                    Some(sql_parse_i64_literal(sql_function_unnamed_expr(
-                        arg_exprs, 2,
-                    )?)?)
-                } else {
-                    None
-                };
-                Some(functions::substring(col, start, len).expr().clone())
-            }
-            "REGEXP_REPLACE" if args.len() == 3 => {
-                use polars::prelude::DataType;
-                Some(col.expr().clone().cast(DataType::String).str().replace_all(
-                    args[1].expr().clone().cast(DataType::String),
-                    args[2].expr().clone().cast(DataType::String),
-                    false,
-                ))
-            }
-            _ => None,
-        };
-        if let Some(e) = builtin_expr {
-            return Ok(e);
-        }
+    if let Some(e) = sql_scalar_builtin_to_expr(func_name, func, &args)? {
+        return Ok(e);
     }
 
     // UDF lookup
@@ -1529,7 +1576,11 @@ fn sql_function_to_expr(
     }
 
     Err(PolarsError::InvalidOperation(
-        format!("SQL: unknown function '{}'. Register with spark.udf.register() or use built-ins: UPPER, LOWER.", func_name).into(),
+        format!(
+            "SQL: unknown function '{}'. Register with spark.udf.register() or use a built-in scalar function.",
+            func_name
+        )
+        .into(),
     ))
 }
 
@@ -2111,23 +2162,8 @@ fn projection_function_to_item(
 
     let args = sql_function_args_to_columns(func, session, df)?;
 
-    // Built-ins (mirror sql_function_to_expr WHERE/HAVING support)
-    if let Some(col) = args.first() {
-        let builtin = match func_name.to_uppercase().as_str() {
-            "UPPER" | "UCASE" if args.len() == 1 => {
-                Some(functions::upper(col).expr().clone().alias(&alias))
-            }
-            "LOWER" | "LCASE" if args.len() == 1 => {
-                Some(functions::lower(col).expr().clone().alias(&alias))
-            }
-            "TRIM" if args.len() == 1 => Some(functions::trim(col).expr().clone().alias(&alias)),
-            "LTRIM" if args.len() == 1 => Some(functions::ltrim(col).expr().clone().alias(&alias)),
-            "RTRIM" if args.len() == 1 => Some(functions::rtrim(col).expr().clone().alias(&alias)),
-            _ => None,
-        };
-        if let Some(e) = builtin {
-            return Ok(ProjItem::Expr(e, alias));
-        }
+    if let Some(e) = sql_scalar_builtin_to_expr(func_name, func, &args)? {
+        return Ok(ProjItem::Expr(e.alias(&alias), alias));
     }
 
     // UDF lookup
@@ -2141,7 +2177,7 @@ fn projection_function_to_item(
 
     Err(PolarsError::InvalidOperation(
         format!(
-            "SQL: unknown function '{}'. Register with spark.udf.register() or use built-ins: UPPER, LOWER.",
+            "SQL: unknown function '{}'. Register with spark.udf.register() or use a built-in scalar function.",
             func_name
         )
         .into(),

--- a/tests/sql/test_issue_1638_sql_builtin_functions.py
+++ b/tests/sql/test_issue_1638_sql_builtin_functions.py
@@ -1,0 +1,49 @@
+"""Issue #1638: Spark SQL built-in functions in spark.sql()."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+
+@pytest.fixture
+def tbl(spark):
+    df = spark.createDataFrame(
+        [(1, 10.0, "abc-123"), (2, 100.0, "xy"), (3, None, "z")],
+        ["col1", "col2", "col3"],
+    )
+    df.createOrReplaceTempView("tbl")
+    return df
+
+
+@pytest.mark.parametrize(
+    "sql,expected",
+    [
+        ("SELECT coalesce(col2, 0) AS c FROM tbl WHERE col1 = 2", {"c": 100.0}),
+        ("SELECT coalesce(col2, 0) AS c FROM tbl WHERE col1 = 3", {"c": 0.0}),
+        ("SELECT nvl(col2, 0) AS n FROM tbl WHERE col1 = 3", {"n": 0.0}),
+        ("SELECT log10(col2) AS l FROM tbl WHERE col1 = 2", {"l": 2.0}),
+        ("SELECT log(col2) AS l FROM tbl WHERE col1 = 2", {"l": math.log(100.0)}),
+        ("SELECT log(10, col2) AS l FROM tbl WHERE col1 = 2", {"l": 2.0}),
+        ("SELECT log2(col2) AS l FROM tbl WHERE col1 = 2", {"l": math.log2(100.0)}),
+        ("SELECT pow(col2, 2) AS p FROM tbl WHERE col1 = 1", {"p": 100.0}),
+        ("SELECT mod(col1, 3) AS m FROM tbl WHERE col1 = 1", {"m": 1.0}),
+        (
+            r"SELECT regexp_extract(col3, '([0-9]+)', 1) AS r FROM tbl WHERE col1 = 1",
+            {"r": "123"},
+        ),
+        ("SELECT len(col3) AS l FROM tbl WHERE col1 = 1", {"l": 7}),
+    ],
+)
+def test_sql_builtin_functions_issue_1638(spark, tbl, sql, expected):
+    del tbl
+    rows = spark.sql(sql).collect()
+    assert len(rows) == 1
+    row = rows[0].asDict()
+    for key, val in expected.items():
+        actual = row[key]
+        if isinstance(val, float):
+            assert actual == pytest.approx(val)
+        else:
+            assert actual == val


### PR DESCRIPTION
## Summary

Fixes [#1638](https://github.com/eddiethedean/robin-sparkless/issues/1638) by registering standard Spark SQL scalar built-ins in the SQL translator.

- Add `sql_scalar_builtin_to_expr` helper used by both SELECT projections and WHERE/HAVING predicates
- Supported functions: `coalesce`, `nvl`/`ifnull`, `log`/`ln`, `log10`, `log2`, `pow`/`power`, `mod`, `regexp_extract`, `length`/`len`/`char_length` (plus existing string built-ins consolidated into the same helper)
- Fix `nvl` to use `when/then/otherwise` so mixed-type null replacement (e.g. `nvl(double_col, 0)`) matches PySpark

## Test plan

- [x] `cargo test -p robin-sparkless-polars --features sql test_sql_builtin_scalar_functions_issue_1638`
- [x] `cargo clippy -p robin-sparkless-polars --features sql -- -D warnings`
- [x] `pytest tests/sql/test_issue_1638_sql_builtin_functions.py -v` (11 cases covering all functions from the issue)