### PR TITLE
Fix SQL JOIN ON with multiple AND equality conditions (#1639)

### DIFF
--- a/crates/robin-sparkless-polars/src/sql/mod.rs
+++ b/crates/robin-sparkless-polars/src/sql/mod.rs
@@ -1001,6 +1001,47 @@ mod tests {
         assert_eq!(rows[0].get("tag").and_then(|v| v.as_str()), Some("x"));
     }
 
+    /// Issue #1639: JOIN ON with multiple AND equality conditions.
+    #[test]
+    fn test_sql_join_on_multiple_conditions_issue_1639() {
+        use serde_json::json;
+        let spark = SparkSession::builder().app_name("test").get_or_create();
+        let schema_a = vec![
+            ("col1".to_string(), "string".to_string()),
+            ("col2".to_string(), "bigint".to_string()),
+        ];
+        let rows_a = vec![
+            vec![json!("A"), json!(1)],
+            vec![json!("B"), json!(2)],
+        ];
+        let df_a = spark
+            .create_dataframe_from_rows(rows_a, schema_a, false, false)
+            .unwrap();
+        let schema_b = vec![
+            ("col1".to_string(), "string".to_string()),
+            ("col2".to_string(), "bigint".to_string()),
+            ("col3".to_string(), "string".to_string()),
+        ];
+        let rows_b = vec![
+            vec![json!("A"), json!(1), json!("X")],
+            vec![json!("B"), json!(3), json!("Y")],
+        ];
+        let df_b = spark
+            .create_dataframe_from_rows(rows_b, schema_b, false, false)
+            .unwrap();
+        spark.create_or_replace_temp_view("tbl_a", df_a);
+        spark.create_or_replace_temp_view("tbl_b", df_b);
+        let result = spark
+            .sql(
+                "SELECT a.col1, b.col3 FROM tbl_a a JOIN tbl_b b ON a.col1 = b.col1 AND a.col2 = b.col2",
+            )
+            .unwrap();
+        assert_eq!(result.count().unwrap(), 1);
+        let rows = result.collect_as_json_rows().unwrap();
+        assert_eq!(rows[0].get("a_col1").and_then(|v| v.as_str()), Some("A"));
+        assert_eq!(rows[0].get("b_col3").and_then(|v| v.as_str()), Some("X"));
+    }
+
     /// Batch 4 / #708: LEFT JOIN supported; returns all left rows with nulls for non-matching right.
     #[test]
     fn test_sql_left_join_supported() {

--- a/crates/robin-sparkless-polars/src/sql/translator.rs
+++ b/crates/robin-sparkless-polars/src/sql/translator.rs
@@ -1077,6 +1077,44 @@ fn resolve_table_factor(
     }
 }
 
+/// Extract (left_col, right_col) pairs from JOIN ON. Supports `a.x = b.x AND a.y = b.y` (#1639).
+fn join_on_equality_pairs(
+    expr: &SqlExpr,
+    left_alias: Option<&str>,
+    right_alias: Option<&str>,
+) -> Result<Vec<(String, String)>, PolarsError> {
+    match expr {
+        SqlExpr::BinaryOp {
+            left,
+            op: BinaryOperator::Eq,
+            right,
+        } => {
+            let l = sql_expr_to_qualified_col_name(left.as_ref(), left_alias)?;
+            let r = sql_expr_to_qualified_col_name(right.as_ref(), right_alias)?;
+            Ok(vec![(l, r)])
+        }
+        SqlExpr::BinaryOp {
+            left,
+            op: BinaryOperator::And,
+            right,
+        } => {
+            let mut pairs = join_on_equality_pairs(left.as_ref(), left_alias, right_alias)?;
+            pairs.extend(join_on_equality_pairs(
+                right.as_ref(),
+                left_alias,
+                right_alias,
+            )?);
+            Ok(pairs)
+        }
+        SqlExpr::Nested(inner) => {
+            join_on_equality_pairs(inner.as_ref(), left_alias, right_alias)
+        }
+        _ => Err(PolarsError::InvalidOperation(
+            "SQL: JOIN ON must be equality conditions combined with AND.".into(),
+        )),
+    }
+}
+
 /// Returns (left_column_names, right_column_names) for JOIN ON. When table aliases are used, names are prefixed (e.g. e_dept_id, d_id) (#152).
 fn join_condition_to_on_columns(
     join_op: &JoinOperator,
@@ -1107,20 +1145,16 @@ fn join_condition_to_on_columns(
         }
     };
     match constraint {
-        JoinConstraint::On(expr) => match expr {
-            SqlExpr::BinaryOp {
-                left,
-                op: BinaryOperator::Eq,
-                right,
-            } => {
-                let l = sql_expr_to_qualified_col_name(left.as_ref(), left_alias)?;
-                let r = sql_expr_to_qualified_col_name(right.as_ref(), right_alias)?;
-                Ok((vec![l], vec![r]))
+        JoinConstraint::On(expr) => {
+            let pairs = join_on_equality_pairs(expr, left_alias, right_alias)?;
+            if pairs.is_empty() {
+                return Err(PolarsError::InvalidOperation(
+                    "SQL: JOIN ON requires at least one equality condition.".into(),
+                ));
             }
-            _ => Err(PolarsError::InvalidOperation(
-                "SQL: JOIN ON must be a single equality (col = col).".into(),
-            )),
-        },
+            let (left_on, right_on): (Vec<_>, Vec<_>) = pairs.into_iter().unzip();
+            Ok((left_on, right_on))
+        }
         _ => Err(PolarsError::InvalidOperation(
             "SQL: JOIN must use ON (equality); NATURAL/USING not supported.".into(),
         )),

--- a/tests/sql/test_issue_1639_sql_join_multi_on.py
+++ b/tests/sql/test_issue_1639_sql_join_multi_on.py
@@ -1,0 +1,24 @@
+"""Issue #1639: SQL JOIN ON with multiple AND conditions."""
+
+from __future__ import annotations
+
+
+def test_sql_join_on_multiple_conditions_issue_1639(spark):
+    df_a = spark.createDataFrame([("A", 1), ("B", 2)], ["col1", "col2"])
+    df_b = spark.createDataFrame([("A", 1, "X"), ("B", 3, "Y")], ["col1", "col2", "col3"])
+    df_a.createOrReplaceTempView("tbl_a")
+    df_b.createOrReplaceTempView("tbl_b")
+
+    rows = spark.sql(
+        """
+        SELECT a.col1, b.col3
+        FROM tbl_a a
+        JOIN tbl_b b ON a.col1 = b.col1 AND a.col2 = b.col2
+        """
+    ).collect()
+
+    assert len(rows) == 1
+    row = rows[0].asDict()
+    # Qualified SELECT output uses prefixed names (a_col1, b_col3) after aliased JOIN.
+    assert (row.get("col1") or row.get("a_col1")) == "A"
+    assert (row.get("col3") or row.get("b_col3")) == "X"


### PR DESCRIPTION
## Summary

Fixes [#1639](https://github.com/eddiethedean/robin-sparkless/issues/1639) by supporting compound JOIN ON clauses with multiple equality conditions joined by `AND`.

- Add `join_on_equality_pairs` to recursively parse `a.x = b.x AND a.y = b.y` (and parenthesized forms) into multi-key join columns
- Pass all key pairs to the existing multi-key `join()` path

Example now works:

```sql
SELECT a.col1, b.col3
FROM tbl_a a
JOIN tbl_b b ON a.col1 = b.col1 AND a.col2 = b.col2
```

## Test plan

- [x] `cargo test -p robin-sparkless-polars --features sql test_sql_join_on`
- [x] `cargo clippy -p robin-sparkless-polars --features sql -- -D warnings`
- [x] `pytest tests/sql/test_issue_1639_sql_join_multi_on.py -v`