### PR TITLE
Fix SQL CAST expressions in WHERE clause (#1640)

### DIFF
--- a/crates/robin-sparkless-polars/src/sql/mod.rs
+++ b/crates/robin-sparkless-polars/src/sql/mod.rs
@@ -462,6 +462,25 @@ mod tests {
         assert_eq!(in_result.count().unwrap(), 2);
     }
 
+    /// Issue #1640: CAST expressions in WHERE clause.
+    #[test]
+    fn test_sql_where_cast_issue_1640() {
+        let spark = SparkSession::builder().app_name("test").get_or_create();
+        let df = spark
+            .create_dataframe(
+                vec![(0, 0, "2025".to_string()), (0, 0, "2026".to_string())],
+                vec!["dummy", "v", "col1"],
+            )
+            .unwrap();
+        spark.create_or_replace_temp_view("tbl", df);
+        let result = spark
+            .sql("SELECT col1 FROM tbl WHERE cast(col1 as int) > 2025")
+            .unwrap();
+        assert_eq!(result.count().unwrap(), 1);
+        let rows = result.collect_as_json_rows().unwrap();
+        assert_eq!(rows[0].get("col1").and_then(|v| v.as_str()), Some("2026"));
+    }
+
     #[test]
     fn test_sql_table_not_found() {
         let spark = SparkSession::builder().app_name("test").get_or_create();

--- a/crates/robin-sparkless-polars/src/sql/translator.rs
+++ b/crates/robin-sparkless-polars/src/sql/translator.rs
@@ -12,10 +12,10 @@ use polars::prelude::{AnyValue, DataFrame as PlDataFrame, Expr, PolarsError, col
 use polars_plan::dsl::functions::nth;
 use serde_json::Value as JsonValue;
 use spark_sql_parser::ast::{
-    BinaryOperator, Expr as SqlExpr, FromTable, Function, FunctionArg, FunctionArgExpr,
-    FunctionArguments, GroupByExpr, JoinConstraint, JoinOperator, LimitClause, ObjectType,
-    OrderByKind, Query, Select, SelectItem, SetExpr, SetOperator, Statement, TableAlias,
-    TableFactor, TableObject, Value, ValueWithSpan,
+    BinaryOperator, CastKind, Expr as SqlExpr, FromTable, Function, FunctionArg,
+    FunctionArgExpr, FunctionArguments, GroupByExpr, JoinConstraint, JoinOperator, LimitClause,
+    ObjectType, OrderByKind, Query, Select, SelectItem, SetExpr, SetOperator, Statement,
+    TableAlias, TableFactor, TableObject, Value, ValueWithSpan,
 };
 
 /// Parsed SQL number literal: integer or float.
@@ -44,6 +44,29 @@ fn parse_sql_number_expr(s: &str) -> Result<Expr, PolarsError> {
     match parse_sql_number_val(s, "literal")? {
         SqlNumberVal::Int(i) => Ok(lit(i)),
         SqlNumberVal::Float(f) => Ok(lit(f)),
+    }
+}
+
+/// Map SQL AST data types to PySpark-style cast type names.
+fn sql_ast_data_type_to_cast_name(dt: &spark_sql_parser::ast::DataType) -> String {
+    let s = dt.to_string().to_lowercase();
+    if s.starts_with("int") || s.starts_with("integer") || s == "int4" {
+        "int".to_string()
+    } else if s.starts_with("bigint") || s == "int8" || s == "long" {
+        "long".to_string()
+    } else if s.starts_with("double") {
+        "double".to_string()
+    } else if s.starts_with("float") {
+        "float".to_string()
+    } else if s.starts_with("bool") {
+        "boolean".to_string()
+    } else if s.starts_with("date") {
+        "date".to_string()
+    } else if s.starts_with("timestamp") {
+        "timestamp".to_string()
+    } else {
+        // STRING, VARCHAR, CHAR, etc.
+        "string".to_string()
     }
 }
 
@@ -145,32 +168,15 @@ pub fn translate(
                 ));
             }
 
-            fn dtype_to_schema_str(dt: &spark_sql_parser::ast::DataType) -> String {
-                let s = dt.to_string().to_lowercase();
-                if s.starts_with("int") || s.starts_with("integer") || s == "int4" {
-                    "int".to_string()
-                } else if s.starts_with("bigint") || s == "int8" || s == "long" {
-                    "long".to_string()
-                } else if s.starts_with("double") {
-                    "double".to_string()
-                } else if s.starts_with("float") {
-                    "float".to_string()
-                } else if s.starts_with("bool") {
-                    "boolean".to_string()
-                } else if s.starts_with("date") {
-                    "date".to_string()
-                } else if s.starts_with("timestamp") {
-                    "timestamp".to_string()
-                } else {
-                    // STRING, VARCHAR, CHAR, etc.
-                    "string".to_string()
-                }
-            }
-
             let schema: Vec<(String, String)> = create_table
                 .columns
                 .iter()
-                .map(|c| (c.name.value.clone(), dtype_to_schema_str(&c.data_type)))
+                .map(|c| {
+                    (
+                        c.name.value.clone(),
+                        sql_ast_data_type_to_cast_name(&c.data_type),
+                    )
+                })
                 .collect();
             let df = session.create_dataframe_from_rows(
                 Vec::<Vec<JsonValue>>::new(),
@@ -1447,6 +1453,23 @@ fn sql_expr_to_polars(
                 .transpose()?;
             let c = Column::from_expr(col_expr, None);
             Ok(functions::substring(&c, start, len).expr().clone())
+        }
+        SqlExpr::Cast {
+            kind,
+            expr: inner,
+            data_type,
+            ..
+        } => {
+            let inner_expr =
+                sql_expr_to_polars(inner, session, df, having_agg_map, having_agg_list)?;
+            let col = Column::from_expr(inner_expr, None);
+            let type_name = sql_ast_data_type_to_cast_name(data_type);
+            let result = match kind {
+                CastKind::TryCast | CastKind::SafeCast => functions::try_cast(&col, &type_name),
+                _ => functions::cast(&col, &type_name),
+            }
+            .map_err(|s| PolarsError::InvalidOperation(s.into()))?;
+            Ok(result.expr().clone())
         }
         _ => Err(PolarsError::InvalidOperation(
             format!("SQL: unsupported expression in WHERE: {:?}. Use column, literal, =, <, >, AND, OR, IS NULL, LIKE, IN.", expr).into(),

--- a/tests/sql/test_issue_1640_sql_cast_in_where.py
+++ b/tests/sql/test_issue_1640_sql_cast_in_where.py
@@ -1,0 +1,13 @@
+"""Issue #1640: CAST expressions in SQL WHERE clause."""
+
+from __future__ import annotations
+
+
+def test_sql_cast_in_where_issue_1640(spark):
+    df = spark.createDataFrame([("2025",), ("2026",)], ["col1"])
+    df.createOrReplaceTempView("tbl")
+
+    rows = spark.sql("SELECT col1 FROM tbl WHERE cast(col1 as int) > 2025").collect()
+
+    assert len(rows) == 1
+    assert rows[0].asDict()["col1"] == "2026"


### PR DESCRIPTION
## Summary

Fixes [#1640](https://github.com/eddiethedean/robin-sparkless/issues/1640) by handling `SqlExpr::Cast` in the SQL expression translator.

- Extract shared `sql_ast_data_type_to_cast_name` helper (also used by CREATE TABLE schema mapping)
- Translate `CAST(expr AS type)` and `TRY_CAST` / `SAFE_CAST` via existing `functions::cast` / `try_cast`

Example now works:

```sql
SELECT col1 FROM tbl WHERE cast(col1 as int) > 2025
```

## Test plan

- [x] `cargo test -p robin-sparkless-polars --features sql test_sql_where_cast_issue_1640`
- [x] `cargo clippy -p robin-sparkless-polars --features sql -- -D warnings`
- [x] `pytest tests/sql/test_issue_1640_sql_cast_in_where.py -v`