### PR TITLE
Fix date_format time patterns on DateType columns (#1641)

### DIFF
--- a/crates/robin-sparkless-polars/src/functions/rest.rs
+++ b/crates/robin-sparkless-polars/src/functions/rest.rs
@@ -1981,12 +1981,15 @@ pub fn to_date(column: &Column, format: Option<&str>) -> Result<Column, String> 
 pub fn date_format(column: &Column, format: &str) -> Column {
     use polars::prelude::*;
     let out_name = format!("date_format({}, {format})", column.name());
-    let chrono_fmt = crate::udfs::pyspark_format_to_chrono(format);
-    let parsed = column.expr().clone().map(
-        |s| crate::column::expect_col(crate::udfs::apply_string_to_date_format(s, None, false)),
-        |_schema, field| Ok(Field::new(field.name().clone(), DataType::Date)),
-    );
-    let expr = parsed.dt().strftime(&chrono_fmt).alias(&out_name);
+    let fmt = format.to_string();
+    let expr = column
+        .expr()
+        .clone()
+        .map(
+            move |s| crate::column::expect_col(crate::udfs::apply_date_format(s, &fmt)),
+            |_schema, field| Ok(Field::new(field.name().clone(), DataType::String)),
+        )
+        .alias(&out_name);
     crate::column::Column::from_expr(expr, Some(out_name))
 }
 

--- a/crates/robin-sparkless-polars/src/udfs/rest.rs
+++ b/crates/robin-sparkless-polars/src/udfs/rest.rs
@@ -4149,6 +4149,81 @@ pub fn apply_from_unixtime(column: Column, format: Option<&str>) -> PolarsResult
     Ok(Some(Column::new(name, out.into_series())))
 }
 
+/// Format date/datetime as string (PySpark date_format). Date columns use midnight for time tokens (#1641).
+pub fn apply_date_format(column: Column, format: &str) -> PolarsResult<Option<Column>> {
+    use chrono::NaiveDateTime;
+    let chrono_fmt = pyspark_format_to_chrono(format);
+    let name = column.field().into_owned().name;
+    let series = column.take_materialized_series();
+
+    let format_ndt = |ndt: NaiveDateTime| ndt.format(&chrono_fmt).to_string();
+
+    let out = match series.dtype() {
+        DataType::Date => {
+            let ca = date_series_to_days(&series)?;
+            StringChunked::from_iter_options(
+                name.as_str().into(),
+                ca.into_iter().map(|opt_days| {
+                    opt_days.and_then(|days| {
+                        let d = days_to_naive_date(days)?;
+                        let ndt = d.and_hms_opt(0, 0, 0)?;
+                        Some(format_ndt(ndt))
+                    })
+                }),
+            )
+        }
+        DataType::Datetime(_, _) => {
+            let casted = series
+                .cast(&DataType::Int64)
+                .map_err(|e| compute_err("date_format datetime cast", e))?;
+            let ca = casted
+                .i64()
+                .map_err(|e| compute_err("date_format datetime", e))?;
+            StringChunked::from_iter_options(
+                name.as_str().into(),
+                ca.into_iter().map(|opt_micros| {
+                    opt_micros.and_then(|micros| {
+                        chrono::DateTime::from_timestamp_micros(micros)
+                            .map(|dt| format_ndt(dt.naive_utc()))
+                    })
+                }),
+            )
+        }
+        DataType::String => {
+            let ca = series.str().map_err(|e| compute_err("date_format string", e))?;
+            StringChunked::from_iter_options(
+                name.as_str().into(),
+                ca.into_iter().map(|opt_s| {
+                    opt_s.and_then(|s| {
+                        parse_str_to_datetime_micros(s)
+                            .and_then(chrono::DateTime::from_timestamp_micros)
+                            .map(|dt| format_ndt(dt.naive_utc()))
+                            .or_else(|| {
+                                parse_str_to_date(s)
+                                    .and_then(|d| d.and_hms_opt(0, 0, 0))
+                                    .map(format_ndt)
+                            })
+                    })
+                }),
+            )
+        }
+        DataType::Null => StringChunked::from_iter_options(
+            name.as_str().into(),
+            (0..series.len()).map(|_| None::<String>),
+        ),
+        _ => {
+            return Err(PolarsError::ComputeError(
+                format!(
+                    "date_format: expected Date, Datetime, or String input, got `{}`",
+                    series.dtype()
+                )
+                .into(),
+            ))
+        }
+    };
+    Ok(Some(Column::new(name, out.into_series())))
+}
+
 /// make_timestamp(year, month, day, hour, min, sec, timezone?) - six columns to timestamp (micros).
 /// When timezone is Some(tz_str), components are interpreted as local time in that zone, then converted to UTC.
 pub fn apply_make_timestamp(

--- a/tests/dataframe/test_issue_1641_date_format_time_on_date.py
+++ b/tests/dataframe/test_issue_1641_date_format_time_on_date.py
@@ -1,0 +1,33 @@
+"""Issue #1641: date_format with time pattern on DateType returns midnight time."""
+
+from __future__ import annotations
+
+from datetime import date
+
+from sparkless.testing import get_imports
+
+_imports = get_imports()
+F = _imports.F
+DateType = _imports.DateType
+StructField = _imports.StructField
+StructType = _imports.StructType
+
+
+def test_date_format_time_pattern_on_date_type_issue_1641(spark):
+    schema = StructType([StructField("col1", DateType())])
+    df = spark.createDataFrame([(date(2025, 6, 15),)], schema)
+    rows = df.withColumn("col2", F.date_format(F.col("col1"), "HH:mm:ss")).collect()
+
+    assert len(rows) == 1
+    row = rows[0].asDict()
+    assert row["col1"] == date(2025, 6, 15)
+    assert row["col2"] == "00:00:00"
+
+
+def test_date_format_date_pattern_on_date_type_still_works(spark):
+    schema = StructType([StructField("col1", DateType())])
+    df = spark.createDataFrame([(date(2025, 6, 15),)], schema)
+    rows = df.withColumn("col2", F.date_format(F.col("col1"), "yyyy-MM-dd")).collect()
+
+    assert len(rows) == 1
+    assert rows[0].asDict()["col2"] == "2025-06-15"


### PR DESCRIPTION
## Summary

Fixes [#1641](https://github.com/eddiethedean/robin-sparkless/issues/1641) by formatting Date columns at midnight when time tokens are present in the pattern.

- Add `apply_date_format` UDF for Date, Datetime, and String inputs
- Route `functions::date_format` through the UDF instead of Polars `dt().strftime()` on Date (which errors on `%H:%M:%S`)

Example now works:

```python
df.withColumn("col2", F.date_format(F.col("col1"), "HH:mm:ss"))
# Date(2025-06-15) -> "00:00:00"
```

## Test plan

- [x] `cargo clippy -p robin-sparkless-polars -- -D warnings`
- [x] `pytest tests/dataframe/test_issue_1641_date_format_time_on_date.py -v`
- [x] `pytest tests/parity/functions/test_datetime.py::TestDatetimeFunctionsParity::test_date_format -v`