### PR TITLE
Accept fullouter as full outer join alias (#1644)

### DIFF
--- a/crates/robin-sparkless-polars/src/dataframe/aggregations.rs
+++ b/crates/robin-sparkless-polars/src/dataframe/aggregations.rs
@@ -891,7 +891,8 @@ fn parse_pivot_agg_spec(expr: &Expr) -> Option<PivotAggParsed> {
             value_col,
         });
     }
-    parse_pivot_literal_expr(expr).map(|(alias, literal)| PivotAggParsed::Literal { alias, literal })
+    parse_pivot_literal_expr(expr)
+        .map(|(alias, literal)| PivotAggParsed::Literal { alias, literal })
 }
 
 /// Alias(Literal) or Literal -> (alias, literal expr).
@@ -1227,7 +1228,6 @@ impl PivotedGroupedData {
 
     /// Internal: pivot then first (not in PySpark pivot API).
     pub fn _first(&self, value_col: &str) -> Result<DataFrame, PolarsError> {
-        use polars::prelude::*;
         self.pivot_agg(value_col, |e| e.first_non_null())
     }
 
@@ -1362,9 +1362,7 @@ impl PivotedGroupedData {
                     } => {
                         let value_resolved = self.resolve_column(value_col)?;
                         let then_expr = col(value_resolved.as_str());
-                        let expr = when(pred.clone())
-                            .then(then_expr)
-                            .otherwise(lit(NULL));
+                        let expr = when(pred.clone()).then(then_expr).otherwise(lit(NULL));
                         let has_any = expr
                             .clone()
                             .is_not_null()

--- a/crates/robin-sparkless-polars/src/plan/mod.rs
+++ b/crates/robin-sparkless-polars/src/plan/mod.rs
@@ -698,7 +698,7 @@ fn handle_join_op(
     let join_type = match how {
         "left" => JoinType::Left,
         "right" => JoinType::Right,
-        "outer" => JoinType::Outer,
+        "outer" | "full" | "full_outer" | "fullouter" => JoinType::Outer,
         "left_semi" | "leftsemi" | "semi" => JoinType::LeftSemi,
         "left_anti" | "leftanti" | "anti" => JoinType::LeftAnti,
         "inner" => JoinType::Inner,

--- a/crates/robin-sparkless-polars/src/sql/mod.rs
+++ b/crates/robin-sparkless-polars/src/sql/mod.rs
@@ -581,9 +581,7 @@ mod tests {
             .sql("SELECT log(col2) AS l FROM tbl WHERE col1 = 2")
             .unwrap();
         let rows = log_nat.collect_as_json_rows().unwrap();
-        assert!(
-            (rows[0].get("l").and_then(|v| v.as_f64()).unwrap() - 100.0_f64.ln()).abs() < 1e-9
-        );
+        assert!((rows[0].get("l").and_then(|v| v.as_f64()).unwrap() - 100.0_f64.ln()).abs() < 1e-9);
 
         let log_base = spark
             .sql("SELECT log(10, col2) AS l FROM tbl WHERE col1 = 2")
@@ -1029,10 +1027,7 @@ mod tests {
             ("col1".to_string(), "string".to_string()),
             ("col2".to_string(), "bigint".to_string()),
         ];
-        let rows_a = vec![
-            vec![json!("A"), json!(1)],
-            vec![json!("B"), json!(2)],
-        ];
+        let rows_a = vec![vec![json!("A"), json!(1)], vec![json!("B"), json!(2)]];
         let df_a = spark
             .create_dataframe_from_rows(rows_a, schema_a, false, false)
             .unwrap();

--- a/crates/robin-sparkless-polars/src/sql/translator.rs
+++ b/crates/robin-sparkless-polars/src/sql/translator.rs
@@ -12,10 +12,10 @@ use polars::prelude::{AnyValue, DataFrame as PlDataFrame, Expr, PolarsError, col
 use polars_plan::dsl::functions::nth;
 use serde_json::Value as JsonValue;
 use spark_sql_parser::ast::{
-    BinaryOperator, CastKind, Expr as SqlExpr, FromTable, Function, FunctionArg,
-    FunctionArgExpr, FunctionArguments, GroupByExpr, JoinConstraint, JoinOperator, LimitClause,
-    ObjectType, OrderByKind, Query, Select, SelectItem, SetExpr, SetOperator, Statement,
-    TableAlias, TableFactor, TableObject, Value, ValueWithSpan,
+    BinaryOperator, CastKind, Expr as SqlExpr, FromTable, Function, FunctionArg, FunctionArgExpr,
+    FunctionArguments, GroupByExpr, JoinConstraint, JoinOperator, LimitClause, ObjectType,
+    OrderByKind, Query, Select, SelectItem, SetExpr, SetOperator, Statement, TableAlias,
+    TableFactor, TableObject, Value, ValueWithSpan,
 };
 
 /// Parsed SQL number literal: integer or float.
@@ -1112,9 +1112,7 @@ fn join_on_equality_pairs(
             )?);
             Ok(pairs)
         }
-        SqlExpr::Nested(inner) => {
-            join_on_equality_pairs(inner.as_ref(), left_alias, right_alias)
-        }
+        SqlExpr::Nested(inner) => join_on_equality_pairs(inner.as_ref(), left_alias, right_alias),
         _ => Err(PolarsError::InvalidOperation(
             "SQL: JOIN ON must be equality conditions combined with AND.".into(),
         )),
@@ -1491,9 +1489,7 @@ fn sql_scalar_builtin_to_expr(
             let refs: Vec<&Column> = args.iter().collect();
             functions::coalesce(&refs)?.expr().clone()
         }
-        "NVL" | "IFNULL" if args.len() == 2 => {
-            functions::nvl(&args[0], &args[1]).expr().clone()
-        }
+        "NVL" | "IFNULL" if args.len() == 2 => functions::nvl(&args[0], &args[1]).expr().clone(),
         "LOG10" if args.len() == 1 => functions::log10(&args[0]).expr().clone(),
         "LOG2" if args.len() == 1 => functions::log2(&args[0]).expr().clone(),
         "LOG" | "LN" if args.len() == 1 => functions::log(&args[0]).expr().clone(),
@@ -1517,7 +1513,9 @@ fn sql_scalar_builtin_to_expr(
             } else {
                 1
             };
-            functions::regexp_extract(&args[0], &pattern, idx).expr().clone()
+            functions::regexp_extract(&args[0], &pattern, idx)
+                .expr()
+                .clone()
         }
         "LENGTH" | "LEN" | "CHAR_LENGTH" if args.len() == 1 => {
             functions::length(&args[0]).expr().clone()
@@ -1531,7 +1529,9 @@ fn sql_scalar_builtin_to_expr(
             let col = &args[0];
             let start = sql_parse_i64_literal(sql_function_unnamed_expr(arg_exprs, 1)?)?;
             let len = if args.len() >= 3 {
-                Some(sql_parse_i64_literal(sql_function_unnamed_expr(arg_exprs, 2)?)?)
+                Some(sql_parse_i64_literal(sql_function_unnamed_expr(
+                    arg_exprs, 2,
+                )?)?)
             } else {
                 None
             };

--- a/crates/robin-sparkless-polars/src/udfs/rest.rs
+++ b/crates/robin-sparkless-polars/src/udfs/rest.rs
@@ -4190,7 +4190,9 @@ pub fn apply_date_format(column: Column, format: &str) -> PolarsResult<Option<Co
             )
         }
         DataType::String => {
-            let ca = series.str().map_err(|e| compute_err("date_format string", e))?;
+            let ca = series
+                .str()
+                .map_err(|e| compute_err("date_format string", e))?;
             StringChunked::from_iter_options(
                 name.as_str().into(),
                 ca.into_iter().map(|opt_s| {
@@ -4218,7 +4220,7 @@ pub fn apply_date_format(column: Column, format: &str) -> PolarsResult<Option<Co
                     series.dtype()
                 )
                 .into(),
-            ))
+            ));
         }
     };
     Ok(Some(Column::new(name, out.into_series())))

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -5588,7 +5588,7 @@ impl PyDataFrame {
             "inner" => JoinType::Inner,
             "left" | "left_outer" => JoinType::Left,
             "right" | "right_outer" => JoinType::Right,
-            "outer" | "full" | "full_outer" => JoinType::Outer,
+            "outer" | "full" | "full_outer" | "fullouter" => JoinType::Outer,
             "semi" | "left_semi" | "leftsemi" => JoinType::LeftSemi,
             "anti" | "left_anti" | "leftanti" => JoinType::LeftAnti,
             other => {

--- a/tests/dataframe/test_issue_1642_create_dataframe_extra_fields.py
+++ b/tests/dataframe/test_issue_1642_create_dataframe_extra_fields.py
@@ -32,6 +32,7 @@ def test_create_dataframe_structtype_still_rejects_extra_fields(spark):
 
     with pytest.raises(Exception) as exc_info:
         spark.createDataFrame([("A", "B", "C", "D")], schema=schema)
-    assert "LENGTH_SHOULD_BE_THE_SAME" in str(exc_info.value) or "length" in str(
-        exc_info.value
-    ).lower()
+    assert (
+        "LENGTH_SHOULD_BE_THE_SAME" in str(exc_info.value)
+        or "length" in str(exc_info.value).lower()
+    )

--- a/tests/dataframe/test_issue_1643_pivot_agg_lit_first.py
+++ b/tests/dataframe/test_issue_1643_pivot_agg_lit_first.py
@@ -29,9 +29,13 @@ def test_pivot_agg_lit_issue_1643(spark) -> None:
 
 def test_pivot_agg_multiple_first_issue_1643(spark) -> None:
     df = _issue_1643_df(spark)
-    result = df.groupBy("col1").pivot("col2").agg(
-        F.first(F.col("col3")).alias("col3"),
-        F.first(F.col("col4")).alias("col4"),
+    result = (
+        df.groupBy("col1")
+        .pivot("col2")
+        .agg(
+            F.first(F.col("col3")).alias("col3"),
+            F.first(F.col("col4")).alias("col4"),
+        )
     )
     rows = {r["col1"]: r.asDict() for r in result.collect()}
 

--- a/tests/dataframe/test_issue_1644_fullouter_join_alias.py
+++ b/tests/dataframe/test_issue_1644_fullouter_join_alias.py
@@ -16,7 +16,7 @@ class TestIssue1644FullouterJoinAlias:
         df_b = spark.createDataFrame([("A", 100), ("C", 300)], ["col1", "col3"])
 
         result = df_a.join(df_b, "col1", "fullouter")
-        rows = { _row_val(r, "col1"): r for r in result.collect() }
+        rows = {_row_val(r, "col1"): r for r in result.collect()}
 
         assert set(rows) == {"A", "B", "C"}
         assert _row_val(rows["A"], "col2") == 1

--- a/tests/dataframe/test_issue_1644_fullouter_join_alias.py
+++ b/tests/dataframe/test_issue_1644_fullouter_join_alias.py
@@ -1,0 +1,54 @@
+"""Regression test for issue #1644: accept 'fullouter' as a full outer join alias."""
+
+
+def _row_val(row, key):
+    if hasattr(row, "asDict"):
+        return row.asDict().get(key)
+    return row[key]
+
+
+class TestIssue1644FullouterJoinAlias:
+    """PySpark accepts fullouter, full_outer, and outer for full outer joins."""
+
+    def test_join_fullouter_string_key(self, spark):
+        """Exact scenario from issue #1644."""
+        df_a = spark.createDataFrame([("A", 1), ("B", 2)], ["col1", "col2"])
+        df_b = spark.createDataFrame([("A", 100), ("C", 300)], ["col1", "col3"])
+
+        result = df_a.join(df_b, "col1", "fullouter")
+        rows = { _row_val(r, "col1"): r for r in result.collect() }
+
+        assert set(rows) == {"A", "B", "C"}
+        assert _row_val(rows["A"], "col2") == 1
+        assert _row_val(rows["A"], "col3") == 100
+        assert _row_val(rows["B"], "col2") == 2
+        assert _row_val(rows["B"], "col3") is None
+        assert _row_val(rows["C"], "col2") is None
+        assert _row_val(rows["C"], "col3") == 300
+
+    def test_join_fullouter_equals_outer(self, spark):
+        """fullouter should match outer on the same data."""
+        df_a = spark.createDataFrame([("A", 1), ("B", 2)], ["col1", "col2"])
+        df_b = spark.createDataFrame([("A", 100), ("C", 300)], ["col1", "col3"])
+
+        fullouter_rows = sorted(
+            df_a.join(df_b, "col1", "fullouter").collect(),
+            key=lambda r: (_row_val(r, "col1") or "",),
+        )
+        outer_rows = sorted(
+            df_a.join(df_b, "col1", "outer").collect(),
+            key=lambda r: (_row_val(r, "col1") or "",),
+        )
+        assert len(fullouter_rows) == len(outer_rows) == 3
+        for a, b in zip(fullouter_rows, outer_rows):
+            assert _row_val(a, "col1") == _row_val(b, "col1")
+            assert _row_val(a, "col2") == _row_val(b, "col2")
+            assert _row_val(a, "col3") == _row_val(b, "col3")
+
+    def test_join_full_outer_still_accepted(self, spark):
+        """Existing full_outer alias remains supported."""
+        df_a = spark.createDataFrame([("A", 1)], ["col1", "col2"])
+        df_b = spark.createDataFrame([("A", 100)], ["col1", "col3"])
+        row = df_a.join(df_b, "col1", "full_outer").collect()[0]
+        assert _row_val(row, "col2") == 1
+        assert _row_val(row, "col3") == 100

--- a/tests/security/test_delta_uri_confinement.py
+++ b/tests/security/test_delta_uri_confinement.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import tempfile
 import uuid
 from pathlib import Path
 

--- a/tests/security/test_files_base_sandbox.py
+++ b/tests/security/test_files_base_sandbox.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import os
-from pathlib import Path
 
 import pytest
 

--- a/tests/security/test_jdbc_sql_gate.py
+++ b/tests/security/test_jdbc_sql_gate.py
@@ -23,7 +23,9 @@ def test_jdbc_query_blocked_when_gate_disabled(monkeypatch) -> None:
     monkeypatch.setenv("SPARKLESS_JDBC_ALLOW_ARBITRARY_SQL", "false")
     spark = SparkSession.builder.appName("jdbc-gate").getOrCreate()
     try:
-        with pytest.raises(Exception, match="query/sessionInitStatement/prepareQuery disabled"):
+        with pytest.raises(
+            Exception, match="query/sessionInitStatement/prepareQuery disabled"
+        ):
             spark.read.format("jdbc").option(
                 "url", "jdbc:postgresql://localhost:5432/test"
             ).option("query", "SELECT 1").load(".")

--- a/tests/security/test_warehouse_path_traversal.py
+++ b/tests/security/test_warehouse_path_traversal.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import os
-from pathlib import Path
 
 import pytest
 
@@ -20,7 +18,7 @@ def test_table_rejects_path_traversal_outside_warehouse(tmp_path) -> None:
     outside.mkdir()
     secret = outside / "secret_table"
     secret.mkdir()
-  # empty dir mimics saveAsTable layout
+    # empty dir mimics saveAsTable layout
 
     spark = (
         SparkSession.builder.app_name("path-security")

--- a/tests/sql/test_issue_1639_sql_join_multi_on.py
+++ b/tests/sql/test_issue_1639_sql_join_multi_on.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 
 def test_sql_join_on_multiple_conditions_issue_1639(spark):
     df_a = spark.createDataFrame([("A", 1), ("B", 2)], ["col1", "col2"])
-    df_b = spark.createDataFrame([("A", 1, "X"), ("B", 3, "Y")], ["col1", "col2", "col3"])
+    df_b = spark.createDataFrame(
+        [("A", 1, "X"), ("B", 3, "Y")], ["col1", "col2", "col3"]
+    )
     df_a.createOrReplaceTempView("tbl_a")
     df_b.createOrReplaceTempView("tbl_b")
 

--- a/tests/unit/test_ansi_divide_parallel.py
+++ b/tests/unit/test_ansi_divide_parallel.py
@@ -24,5 +24,7 @@ def ansi_spark(monkeypatch):
 
 def test_divide_by_zero_errors_under_parallel_polars(ansi_spark) -> None:
     df = ansi_spark.createDataFrame([(1, 0), (2, 1)], ["num", "den"])
-    with pytest.raises(Exception, match="DIVIDE_BY_ZERO|divide by zero|division by zero"):
+    with pytest.raises(
+        Exception, match="DIVIDE_BY_ZERO|divide by zero|division by zero"
+    ):
         df.select((F.col("num") / F.col("den")).alias("ratio")).collect()


### PR DESCRIPTION
## Summary

- Accept `"fullouter"` as a valid alias for full outer joins in `DataFrame.join()`, matching PySpark alongside existing `"outer"`, `"full"`, and `"full_outer"` support.
- Apply the same alias in plan execution (`robin-sparkless-polars`) for consistency.
- Add regression tests for the exact scenario from [#1644](https://github.com/eddiethedean/robin-sparkless/issues/1644).

Fixes #1644.

## Test plan

- [x] `pytest tests/dataframe/test_issue_1644_fullouter_join_alias.py -v` (3 passed)
- [ ] CI