### PR TITLE
Implement SparkContext.setLogLevel stub (#1645)

### DIFF
--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1507,6 +1507,10 @@ impl PySparkContext {
     fn version(&self) -> String {
         env!("CARGO_PKG_VERSION").to_string()
     }
+
+    /// PySpark parity: set JVM/log4j log level. No-op in sparkless (no JVM).
+    #[pyo3(name = "setLogLevel")]
+    fn set_log_level(&self, _log_level: &str) {}
 }
 
 #[pyclass]

--- a/tests/dataframe/test_issue_1645_spark_context_set_log_level.py
+++ b/tests/dataframe/test_issue_1645_spark_context_set_log_level.py
@@ -1,0 +1,16 @@
+"""Regression test for issue #1645: SparkContext.setLogLevel stub."""
+
+from __future__ import annotations
+
+
+class TestIssue1645SparkContextSetLogLevel:
+    """PySpark accepts spark.sparkContext.setLogLevel(level) with no return value."""
+
+    def test_set_log_level_warn(self, spark) -> None:
+        """Exact scenario from issue #1645."""
+        result = spark.sparkContext.setLogLevel("WARN")
+        assert result is None
+
+    def test_set_log_level_common_levels(self, spark) -> None:
+        for level in ("ALL", "DEBUG", "ERROR", "FATAL", "INFO", "OFF", "TRACE", "WARN"):
+            assert spark.sparkContext.setLogLevel(level) is None


### PR DESCRIPTION
## Summary

- Add `spark.sparkContext.setLogLevel(level)` to the `PySparkContext` stub so PySpark-style startup code runs without `AttributeError`.
- No-op implementation: sparkless has no JVM/log4j backend, so valid levels are accepted silently (matching PySpark’s void return).
- Regression tests cover the issue example (`"WARN"`) and all standard Spark log levels.

Fixes #1645.

## Test plan

- [x] `pytest tests/dataframe/test_issue_1645_spark_context_set_log_level.py tests/dataframe/test_issue_387_spark_context.py -v` (4 passed)
- [ ] CI