### PR TITLE
Implement RDD isEmpty() and distinct() (#1646)

### DIFF
--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -4225,6 +4225,42 @@ impl PyRDD {
         }
         Ok(acc)
     }
+
+    /// PySpark parity: True when the RDD has no elements.
+    #[pyo3(name = "isEmpty")]
+    fn is_empty_rdd(&self, py: Python<'_>) -> PyResult<bool> {
+        if let Some(ref elements) = self.elements {
+            return Ok(elements.is_empty());
+        }
+        if let Some(ref inner) = self.inner {
+            return Ok(inner.is_empty());
+        }
+        Ok(self.collect_elements(py)?.is_empty())
+    }
+
+    /// PySpark parity: return an RDD with duplicate elements removed (first occurrence kept).
+    fn distinct(slf: PyRef<Self>, py: Python<'_>) -> PyResult<PyRDD> {
+        let elements = slf.collect_elements(py)?;
+        let mut out: Vec<PyObject> = Vec::new();
+        for item in elements {
+            let item_bound = item.bind(py);
+            let mut duplicate = false;
+            for prev in &out {
+                if item_bound.eq(prev.bind(py))? {
+                    duplicate = true;
+                    break;
+                }
+            }
+            if !duplicate {
+                out.push(item);
+            }
+        }
+        Ok(PyRDD {
+            source_df: None,
+            inner: None,
+            elements: Some(out),
+        })
+    }
 }
 
 #[pyclass]

--- a/tests/dataframe/test_issue_1646_rdd_isempty_distinct.py
+++ b/tests/dataframe/test_issue_1646_rdd_isempty_distinct.py
@@ -1,0 +1,29 @@
+"""Regression test for issue #1646: RDD isEmpty() and distinct()."""
+
+from __future__ import annotations
+
+from sparkless.testing import get_imports
+
+StructField = get_imports().StructField
+StructType = get_imports().StructType
+StringType = get_imports().StringType
+
+
+class TestIssue1646RddIsEmptyDistinct:
+    """PySpark supports rdd.isEmpty() and rdd.distinct()."""
+
+    def test_rdd_isempty_and_distinct_count(self, spark) -> None:
+        """Exact scenario from issue #1646."""
+        df = spark.createDataFrame([("A",), ("A",), ("B",)], ["col1"])
+        assert df.rdd.isEmpty() is False
+        assert df.rdd.distinct().count() == 2
+
+    def test_rdd_isempty_true_on_empty_dataframe(self, spark) -> None:
+        schema = StructType([StructField("col1", StringType())])
+        df = spark.createDataFrame([], schema)
+        assert df.rdd.isEmpty() is True
+
+    def test_rdd_distinct_on_materialized_rdd(self, spark) -> None:
+        df = spark.createDataFrame([(1,), (1,), (2,), (3,), (2,)], ["x"])
+        rdd = df.rdd.flatMap(lambda row: (row["x"], row["x"] + 10))
+        assert sorted(rdd.distinct().collect()) == sorted([1, 2, 3, 11, 12, 13])


### PR DESCRIPTION
## Summary

- Add `rdd.isEmpty()` to `PyRDD` (uses DataFrame row count when backed by `df.rdd`, otherwise checks materialized elements).
- Add `rdd.distinct()` to deduplicate RDD elements using Python equality, keeping first occurrence order.
- Regression tests cover the issue example (`False`, count `2`) plus empty DataFrame and materialized-RDD cases.

Fixes #1646.

## Test plan

- [x] `pytest tests/dataframe/test_issue_1646_rdd_isempty_distinct.py tests/dataframe/test_issue_408_rdd_flatmap.py -v` (15 passed)
- [ ] CI