### PR TITLE
Expose Column.endswith() for PySpark parity (#1647)

### DIFF
--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -7475,6 +7475,13 @@ impl PyColumn {
         }
     }
 
+    /// True if string ends with suffix (PySpark endswith).
+    fn endswith(&self, suffix: &str) -> PyColumn {
+        PyColumn {
+            inner: self.inner.endswith(suffix),
+        }
+    }
+
     /// Extract first match of regex pattern. PySpark regexp_extract. idx=0 is full match.
     #[pyo3(signature = (pattern, idx=0))]
     fn regexp_extract(&self, pattern: &str, idx: usize) -> PyColumn {

--- a/tests/dataframe/test_issue_1647_column_endswith.py
+++ b/tests/dataframe/test_issue_1647_column_endswith.py
@@ -1,0 +1,38 @@
+"""Regression test for issue #1647: Column.endswith()."""
+
+from __future__ import annotations
+
+from sparkless.testing import get_imports
+
+F = get_imports().F
+
+
+def _row_val(row, key):
+    if hasattr(row, "asDict"):
+        return row.asDict().get(key)
+    return row[key]
+
+
+class TestIssue1647ColumnEndswith:
+    """PySpark Column.endswith() filters rows by string suffix."""
+
+    def test_filter_col_endswith_issue_example(self, spark) -> None:
+        """Exact scenario from issue #1647."""
+        df = spark.createDataFrame([("hello_world",), ("test_case",)], ["col1"])
+        result = df.filter(F.col("col1").endswith("world"))
+        rows = result.collect()
+        assert len(rows) == 1
+        assert _row_val(rows[0], "col1") == "hello_world"
+
+    def test_endswith_no_match(self, spark) -> None:
+        df = spark.createDataFrame([("abc",), ("xyz",)], ["col1"])
+        assert df.filter(F.col("col1").endswith("world")).count() == 0
+
+    def test_endswith_and_startswith_together(self, spark) -> None:
+        df = spark.createDataFrame([("hello_world",), ("hello_test",)], ["col1"])
+        result = df.filter(
+            F.col("col1").startswith("hello") & F.col("col1").endswith("world")
+        )
+        rows = result.collect()
+        assert len(rows) == 1
+        assert _row_val(rows[0], "col1") == "hello_world"


### PR DESCRIPTION
## Summary

- Add `Column.endswith(suffix)` to `PyColumn`, delegating to the existing Rust `Column::endswith` implementation (same pattern as `startswith`).
- Regression tests cover the issue example and combined `startswith`/`endswith` filters.

Fixes #1647.

## Test plan

- [x] `pytest tests/dataframe/test_issue_1647_column_endswith.py -v` (3 passed)
- [ ] CI