### PR TITLE
Expose F.array_compact for PySpark parity (#1648)

### DIFF
--- a/python/sparkless/sparkless/__init__.py
+++ b/python/sparkless/sparkless/__init__.py
@@ -62,6 +62,7 @@ _mod = __import__(
         "greatest",
         "least",
         "array_distinct",
+        "array_compact",
         "posexplode",
         "to_timestamp",
         "to_date",
@@ -164,6 +165,7 @@ printf = format_string  # PySpark alias
 greatest = _mod.greatest
 least = _mod.least
 array_distinct = _mod.array_distinct
+array_compact = _mod.array_compact
 
 
 class _PosexplodeResult(tuple):

--- a/python/sparkless/sparkless/sql/functions.py
+++ b/python/sparkless/sparkless/sql/functions.py
@@ -19,6 +19,7 @@ from sparkless import (
     greatest as _greatest,
     least as _least,
     array_distinct as _array_distinct,
+    array_compact as _array_compact,
     posexplode as _posexplode,
     posexplode_outer as _posexplode_outer,
     upper,
@@ -458,6 +459,16 @@ def array_distinct(col_or_name: ColumnOrName) -> _ColumnType:
     out = _native_fn("array_distinct")(col_obj)
     if base_name is not None:
         return out.alias(f"array_distinct({base_name})")
+    return out
+
+
+def array_compact(col_or_name: ColumnOrName) -> _ColumnType:
+    """Remove null elements from array (PySpark array_compact). Output column name matches PySpark: array_compact(col)."""
+    col_obj = _as_col(col_or_name)
+    base_name = getattr(col_obj, "name", None)
+    out = _native_fn("array_compact")(col_obj)
+    if base_name is not None:
+        return out.alias(f"array_compact({base_name})")
     return out
 
 
@@ -1053,6 +1064,7 @@ __all__ = [
     "greatest",
     "least",
     "array_distinct",
+    "array_compact",
     "posexplode",
     "approx_count_distinct",
     "date_trunc",

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -7333,6 +7333,13 @@ impl PyColumn {
         }
     }
 
+    /// Remove null elements from list (PySpark array_compact).
+    fn array_compact(&self) -> PyColumn {
+        PyColumn {
+            inner: functions::array_compact(&self.inner),
+        }
+    }
+
     fn posexplode(&self) -> (PyColumn, PyColumn) {
         let (pos, val) = functions::posexplode(&self.inner);
         (PyColumn { inner: pos }, PyColumn { inner: val })
@@ -9499,6 +9506,13 @@ fn array_distinct(column: &PyColumn) -> PyColumn {
 }
 
 #[pyfunction]
+fn array_compact(column: &PyColumn) -> PyColumn {
+    PyColumn {
+        inner: functions::array_compact(&column.inner),
+    }
+}
+
+#[pyfunction]
 fn posexplode(column: &PyColumn) -> (PyColumn, PyColumn) {
     let (pos, val) = functions::posexplode(&column.inner);
     (PyColumn { inner: pos }, PyColumn { inner: val })
@@ -10768,6 +10782,7 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(greatest, m)?)?;
     m.add_function(wrap_pyfunction!(least, m)?)?;
     m.add_function(wrap_pyfunction!(array_distinct, m)?)?;
+    m.add_function(wrap_pyfunction!(array_compact, m)?)?;
     m.add_function(wrap_pyfunction!(posexplode, m)?)?;
     m.add_function(wrap_pyfunction!(posexplode_outer, m)?)?;
     m.add_function(wrap_pyfunction!(to_timestamp, m)?)?;

--- a/tests/dataframe/test_issue_1648_array_compact.py
+++ b/tests/dataframe/test_issue_1648_array_compact.py
@@ -1,0 +1,42 @@
+"""Regression test for issue #1648: F.array_compact()."""
+
+from __future__ import annotations
+
+from sparkless.testing import get_imports
+
+F = get_imports().F
+ArrayType = get_imports().ArrayType
+StringType = get_imports().StringType
+StructField = get_imports().StructField
+StructType = get_imports().StructType
+
+
+def _row_val(row, key):
+    if hasattr(row, "asDict"):
+        return row.asDict().get(key)
+    return row[key]
+
+
+class TestIssue1648ArrayCompact:
+    """PySpark array_compact removes null elements from arrays."""
+
+    def test_array_compact_issue_example(self, spark) -> None:
+        """Exact scenario from issue #1648."""
+        schema = StructType([StructField("col1", ArrayType(StringType()))])
+        df = spark.createDataFrame([([" A", None, "B"],)], schema)
+        result = df.withColumn("col2", F.array_compact("col1"))
+        row = result.collect()[0]
+        assert _row_val(row, "col1") == [" A", None, "B"]
+        assert _row_val(row, "col2") == [" A", "B"]
+
+    def test_array_compact_all_nulls(self, spark) -> None:
+        schema = StructType([StructField("col1", ArrayType(StringType()))])
+        df = spark.createDataFrame([( [None, None], )], schema)
+        row = df.withColumn("col2", F.array_compact("col1")).collect()[0]
+        assert _row_val(row, "col2") == []
+
+    def test_array_compact_no_nulls_unchanged(self, spark) -> None:
+        schema = StructType([StructField("col1", ArrayType(StringType()))])
+        df = spark.createDataFrame([( ["x", "y"], )], schema)
+        row = df.withColumn("col2", F.array_compact("col1")).collect()[0]
+        assert _row_val(row, "col2") == ["x", "y"]


### PR DESCRIPTION
## Summary

- Expose `array_compact` in PyO3 (`sparkless._native`) and register it on the native module.
- Add `F.array_compact(col)` to `sparkless.sql.functions` (same pattern as `array_distinct`).
- Add `Column.array_compact()` for parity with other array helpers.
- Regression tests cover the issue example and edge cases (all nulls, no nulls).

Fixes #1648.

## Test plan

- [x] `pytest tests/dataframe/test_issue_1648_array_compact.py -v` (3 passed)
- [ ] CI